### PR TITLE
Add header for JSONBin to enable bin versioning

### DIFF
--- a/src/storage/JSONBinTokenStorage.ts
+++ b/src/storage/JSONBinTokenStorage.ts
@@ -67,6 +67,7 @@ export class JSONBinTokenStorage extends RemoteTokenStorage<JsonBinMetadata> {
     this.defaultHeaders = new Headers();
     this.defaultHeaders.append('Content-Type', 'application/json');
     this.defaultHeaders.append('X-Master-Key', this.secret);
+    this.defaultHeaders.append('X-Bin-Versioning', 'true');
   }
 
   private convertJsonBinDataToFiles(data: JsonbinData): RemoteTokenStorageFile<JsonBinMetadata>[] {


### PR DESCRIPTION
By default, private bins in JSONBin have versioning turned off. This is not ideal for keeping backups of previous files published. This MR enables JSONBin versioning. 

To enable versioning, extra header needs to be added as described in: https://jsonbin.io/api-reference/bins/update 

Todo:
- [x] Versioning in JSONBin is available only for paid users, how can we address this within Figma Tokens plugin? (add toggle? / Check if user is free or paid via rest call ? )
