### PR TITLE
fix: Set all header values to be sensitive by default and allow toggling to expose

### DIFF
--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -166,16 +166,16 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
 }, ref) => {
   // if isMasked is true, then we need to handle toggle visibility
   const [show, setShow] = React.useState(false);
+  const htmlInputRef = React.useRef<HTMLInputElement>(null);
+  const reifiedRef = inputRef || htmlInputRef;
 
   const handleVisibility = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setShow(!show);
-    if (inputRef?.current?.type) {
-      inputRef.current.type = inputRef?.current?.type === 'password' ? 'text' : 'password';
+    if (reifiedRef?.current?.type) {
+      reifiedRef.current.type = reifiedRef?.current?.type === 'password' ? 'text' : 'password';
     }
-  }, [show, inputRef]);
-
-  const htmlInputRef = React.useRef<HTMLInputElement>(null);
+  }, [show, reifiedRef]);
 
   React.useEffect(() => {
     if (autofocus && htmlInputRef && htmlInputRef.current) {

--- a/src/app/components/StorageItemForm/GenericVersioned.tsx
+++ b/src/app/components/StorageItemForm/GenericVersioned.tsx
@@ -177,8 +177,9 @@ export default function GenericVersionedForm({
                 label="Value"
                 value={x.value}
                 disabled={!x.name}
+                isMasked
                 onChange={onHeaderChange}
-                type="text"
+                type="password"
                 name="value"
                 data-index={i}
               />


### PR DESCRIPTION
This resolves https://github.com/tokens-studio/figma-plugin/issues/1504 . It also fixes a minor "bug" if an input ref was not provided but needed for masking