### PR TITLE
GitLab sync: Include inherited members when checking for write permissions

### DIFF
--- a/src/storage/GitlabTokenStorage.ts
+++ b/src/storage/GitlabTokenStorage.ts
@@ -90,11 +90,15 @@ export class GitlabTokenStorage extends GitTokenStorage {
     try {
       if (!currentUser || currentUser.state !== 'active') return false;
 
-      const groupPermission = await this.gitlabClient.GroupMembers.show(this.groupId, currentUser.id);
+      const groupPermission = await this.gitlabClient.GroupMembers.show(this.groupId, currentUser.id, {
+        includeInherited: true,
+      });
       return groupPermission.access_level >= GitLabAccessLevel.Developer;
     } catch (e) {
       try {
-        const projectPermission = await this.gitlabClient.ProjectMembers.show(this.projectId, currentUser.id);
+        const projectPermission = await this.gitlabClient.ProjectMembers.show(this.projectId, currentUser.id, {
+          includeInherited: true,
+        });
         return projectPermission.access_level >= GitLabAccessLevel.Developer;
       } catch (e) {
         console.error(e);

--- a/src/storage/__tests__/GitlabTokenStorage.test.ts
+++ b/src/storage/__tests__/GitlabTokenStorage.test.ts
@@ -178,7 +178,7 @@ describe('GitlabTokenStorage', () => {
       })
     ));
     expect(await storageProvider.canWrite()).toBe(true);
-    expect(mockGetGroupMembers).toBeCalledWith(51634506, 11289475);
+    expect(mockGetGroupMembers).toBeCalledWith(51634506, 11289475, { includeInherited: true });
   });
 
   it('canWrite should return true if user is a collaborator by projectMember', async () => {
@@ -197,7 +197,7 @@ describe('GitlabTokenStorage', () => {
       })
     ));
     expect(await storageProvider.canWrite()).toBe(true);
-    expect(mockGetProjectMembers).toBeCalledWith(35102363, 11289475);
+    expect(mockGetProjectMembers).toBeCalledWith(35102363, 11289475, { includeInherited: true });
   });
 
   it('canWrite should return false if user is not a collaborator', async () => {


### PR DESCRIPTION
We're currently blocked from using the plugin because after connecting to our private GitLab server the plugin refuses to let us write any changes (even though it was able to create a commit with the new json file).

After some debugging we found that the GitLab API was returning a 404 error when trying to fetch the member data for the project. This is because our GitLab repository inherits the members from another group and it doesn't have any direct members itself. To get all the members including the inherited ones you need to fetch another endpoint.

By including the `includeInherited` option in the calls to `GroupMembers` and `ProjectMembers` from the `@gitbeaker/browser` package this issue will be resolved for us as it will hit the correct endpoint. According to GitLab's own documentation this should include all members at all times https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-and-invited-members, so it should not have any impact on existing use cases.