### PR TITLE
Release 134

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tokens-studio-for-figma",
   "version": "1.0.0",
-  "plugin_version": "133",
+  "plugin_version": "134",
   "description": "Tokens Studio for Figma",
   "license": "MIT",
   "scripts": {

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,4 +1,4 @@
-VERSION=figma-tokens@133
+VERSION=figma-tokens@134
 sentry-cli releases -p figma-tokens files "$VERSION" upload-sourcemaps --ext ts --ext tsx --ext map --ext js --ignore-file .sentryignore .
 sentry-cli releases set-commits "$VERSION" --auto
 sentry-cli releases finalize "$VERSION"

--- a/src/app/components/InspectorTokenSingle.tsx
+++ b/src/app/components/InspectorTokenSingle.tsx
@@ -94,12 +94,12 @@ export default function InspectorTokenSingle({
           onCheckedChange={onCheckedChanged}
         />
         {
-          token.value === 'none' && <ValueNoneIcon />
+           (token.value === 'none' || mappedToken?.value === 'none') && <ValueNoneIcon />
         }
         {
           isBrokenLink && token.value !== 'none' && <IconBrokenLink />
         }
-        {(!!mappedToken) && (
+        {(!!mappedToken && token.value !== 'none' && mappedToken?.value !== 'none') && (
           <InspectorResolvedToken token={mappedToken} />
         )}
         <Box

--- a/src/app/store/useTokens.test.tsx
+++ b/src/app/store/useTokens.test.tsx
@@ -328,6 +328,7 @@ describe('useToken test', () => {
       type: AsyncMessageTypes.BULK_REMAP_TOKENS,
       oldName: 'old.',
       newName: 'new.',
+      updateMode: UpdateMode.SELECTION,
     });
   });
 
@@ -467,6 +468,7 @@ describe('useToken test', () => {
         type: AsyncMessageTypes.BULK_REMAP_TOKENS,
         oldName: 'oldName',
         newName: 'newName',
+        updateMode: UpdateMode.SELECTION,
       });
     });
 

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -136,12 +136,13 @@ export default function useTokens() {
     });
   }, [confirm]);
 
-  const handleBulkRemap = useCallback(async (newName: string, oldName: string) => {
+  const handleBulkRemap = useCallback(async (newName: string, oldName: string, updateMode = UpdateMode.SELECTION) => {
     track('bulkRemapToken', { fromInspect: true });
     AsyncMessageChannel.ReactInstance.message({
       type: AsyncMessageTypes.BULK_REMAP_TOKENS,
       oldName,
       newName,
+      updateMode,
     });
   }, []);
 
@@ -174,7 +175,7 @@ export default function useTokens() {
       ],
     });
     if (shouldRemap) {
-      await handleBulkRemap(newGroupName, oldGroupName);
+      await handleBulkRemap(newGroupName, oldGroupName, shouldRemap.data[0]);
       dispatch.settings.setUpdateMode(shouldRemap.data[0] as UpdateMode);
     }
   }, [settings.updateMode, confirm, handleBulkRemap, dispatch.settings]);

--- a/src/plugin/NodeManager.ts
+++ b/src/plugin/NodeManager.ts
@@ -100,30 +100,7 @@ export class NodeManager {
 
     const currentPluginVersion = parseInt(pkg.plugin_version, 10);
     const version = parseIntOrDefault(await VersionProperty.read(node), 0);
-    const migrationFlags = {
-      v72: version && version >= currentPluginVersion,
-    };
     let tokens: NodeTokenRefMap | null = null;
-
-    // only perform this action if the node has not been migrated yet
-    if (!migrationFlags.v72) {
-      // @deprecated - moved to separated token values
-      const deprecatedValuesProp = node.getPluginData('values');
-      // There was a bug in the previous version that would save the values as an 'none' string. Once we get rid of the migration this is fine.'
-      if (deprecatedValuesProp && deprecatedValuesProp !== 'none') {
-        tokens = JSON.parse(deprecatedValuesProp) as NodeTokenRefMap;
-        // migrate values to new format
-        // there's no need to keep supporting deprecated data structures
-        // this will take more time on startup but only once
-        await Promise.all(
-          Object.keys(tokens).map(async (property) => {
-            const token = tokens?.[(property as Properties)];
-            tokensSharedDataHandler.set(node, property, token ?? '');
-          }),
-        );
-        node.setPluginData('values', '');
-      }
-    }
 
     if (!tokens) {
       // also consider the non-shared keys if the v72 migration has not been executed
@@ -139,30 +116,10 @@ export class NodeManager {
       const availableSharedKeys = tokensSharedDataHandler.keys(node).filter((key) => (
         !excludedKeys.includes(key)
       ));
-      const deprecatedAvailableKeys = (!migrationFlags.v72 ? node.getPluginDataKeys() : []).filter((key) => (
-        !excludedKeys.includes(key)
-      ));
 
       tokens = Object.fromEntries(
         compact(
           await Promise.all([
-            ...deprecatedAvailableKeys.map((property) => {
-              const value = node.getPluginData(property);
-              if (value) {
-                // migrate from private to shared data if the data is coming from private
-                node.setPluginData(property, '');
-                tokensSharedDataHandler.set(node, property, value);
-                try {
-                  // make sure we catch JSON parse errors in case invalid property keys are set and found
-                  // we're storing `none` as a string without quotes
-                  const parsedValue = value === 'none' ? 'none' : JSON.parse(value);
-                  return [property, parsedValue] as [Properties, NodeTokenRefValue];
-                } catch (err) {
-                  console.warn(err);
-                }
-              }
-              return null;
-            }),
             ...availableSharedKeys.map((property) => {
               const value = tokensSharedDataHandler.get(node, property);
               if (value) {

--- a/src/plugin/SharedDataHandler.test.ts
+++ b/src/plugin/SharedDataHandler.test.ts
@@ -1,0 +1,22 @@
+import { tokensSharedDataHandler } from './SharedDataHandler';
+
+describe('SharedDataHandler', () => {
+  const mockSetSharedPluginData = jest.fn();
+  const mockGetSharedPluginDataKeys = jest.fn();
+
+  const node = {
+    name: 'Rectangle 1',
+    setSharedPluginData: mockSetSharedPluginData,
+    getSharedPluginDataKeys: mockGetSharedPluginDataKeys,
+  } as unknown as BaseNode;
+
+  it('should call setSharedPluginData', () => {
+    tokensSharedDataHandler.set(node, 'key', 'value');
+    expect(mockSetSharedPluginData).toBeCalledWith('tokens', 'key', 'value');
+  });
+
+  it('should return getSharedPluginDataKeys', () => {
+    tokensSharedDataHandler.keys(node);
+    expect(mockGetSharedPluginDataKeys).toBeCalledWith('tokens');
+  });
+});

--- a/src/plugin/SharedDataHandler.ts
+++ b/src/plugin/SharedDataHandler.ts
@@ -13,7 +13,10 @@ class SharedDataHandler {
 
   get<Result = string>(node: BaseNode, key: string, transformer?: (value: string) => Result) {
     const value = node.getSharedPluginData(this.namespace, key);
-    return (transformer ? transformer(value) : value) as Result;
+    if (value) {
+      return (transformer ? transformer(value) : value) as Result;
+    }
+    return value;
   }
 
   set(node: BaseNode, key: string, value: string) {

--- a/src/plugin/__tests__/setValuesOnNode.test.ts
+++ b/src/plugin/__tests__/setValuesOnNode.test.ts
@@ -707,4 +707,21 @@ describe('Can set values on node', () => {
     expect(solidNodeMock.strokeWeight).toEqual(12);
     expect(solidNodeMock.dashPattern).toEqual([0, 0]);
   });
+
+  it('apply token with none value', async () => {
+    await setValuesOnNode(
+      solidNodeMock,
+      {
+        borderColor: 'none',
+        borderRadius: 'none',
+      },
+      {
+        borderColor: 'border-color.none',
+        borderRadius: 'border-radius.none',
+      },
+      emptyStylesMap,
+      emptyThemeInfo,
+    );
+    expect(solidNodeMock).toEqual({ ...solidNodeMock, strokes: [], cornerRadius: 0 });
+  });
 });

--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -1,5 +1,4 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
-import { UpdateMode } from '@/constants/UpdateMode';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { defaultNodeManager, NodeManagerNode } from '../NodeManager';
 import { updatePluginData } from '../pluginData';
@@ -8,7 +7,7 @@ import { sendSelectionChange } from '../sendSelectionChange';
 export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK_REMAP_TOKENS] = async (msg) => {
   try {
     const { oldName, newName } = msg;
-    const allWithData = await defaultNodeManager.findNodesWithData({ updateMode: UpdateMode.SELECTION });
+    const allWithData = await defaultNodeManager.findNodesWithData({ updateMode: msg.updateMode });
     const updatedNodes: NodeManagerNode[] = [];
 
     allWithData.forEach((node) => {

--- a/src/plugin/figmaUtils/styleUtils.ts
+++ b/src/plugin/figmaUtils/styleUtils.ts
@@ -24,7 +24,17 @@ function getStyleId(node: BaseNode, key: StyleTypeName) {
 }
 
 function getStyleIdFromBackup(node: BaseNode, backupKey: string) {
-  return tokensSharedDataHandler.get(node, backupKey, (val) => (val ? (JSON.parse(val) as string) : val));
+  return tokensSharedDataHandler.get(node, backupKey, (val) => {
+    if (val) {
+      try {
+        const parsedValue = JSON.parse(val) as string;
+        return parsedValue;
+      } catch (e) {
+        return val;
+      }
+    }
+    return val;
+  });
 }
 
 export function getNonLocalStyle<T extends StyleTypeName>(

--- a/src/plugin/pluginData.test.tsx
+++ b/src/plugin/pluginData.test.tsx
@@ -1,5 +1,5 @@
 import { defaultNodeManager, NodeManagerNode } from './NodeManager';
-import { updatePluginData } from './pluginData';
+import { transformPluginDataToSelectionValues, updatePluginData } from './pluginData';
 
 describe('pluginData', () => {
   const mockSetPluginData = jest.fn();
@@ -51,5 +51,52 @@ describe('pluginData', () => {
       borderRadius: 'none',
       fill: 'none',
     });
+  });
+
+  it('transformPluginDataToSelectionValues', () => {
+    const pluginData = [{
+      id: '5989:3',
+      node: {
+        name: 'Rectangle 1',
+        type: 'RECTANGLE',
+      } as unknown as BaseNode,
+      tokens: {
+        borderRadius: 'border-radius.8',
+        fill: 'color.red.700',
+        opacity: 'opacity.60',
+      },
+    } as NodeManagerNode];
+    const selectionValues = transformPluginDataToSelectionValues(pluginData);
+
+    expect(selectionValues).toEqual([
+      {
+        category: 'borderRadius',
+        nodes: [{
+          id: '5989:3',
+          name: 'Rectangle 1',
+          type: 'RECTANGLE',
+        }],
+        type: 'borderRadius',
+        value: 'border-radius.8',
+      }, {
+        category: 'fill',
+        nodes: [{
+          id: '5989:3',
+          name: 'Rectangle 1',
+          type: 'RECTANGLE',
+        }],
+        type: 'fill',
+        value: 'color.red.700',
+      }, {
+        category: 'opacity',
+        nodes: [{
+          id: '5989:3',
+          name: 'Rectangle 1',
+          type: 'RECTANGLE',
+        }],
+        type: 'opacity',
+        value: 'opacity.60',
+      },
+    ]);
   });
 });

--- a/src/plugin/pluginData.ts
+++ b/src/plugin/pluginData.ts
@@ -92,25 +92,14 @@ export async function removePluginData({ nodes, key, shouldRemoveValues = true }
   }));
 }
 
-export async function setNonePluginData({ nodes, key }: { nodes: readonly (BaseNode | SceneNode)[], key?: Properties }) {
+export async function setNonePluginData({ nodes, key }: { nodes: readonly (BaseNode | SceneNode)[], key: Properties }) {
   return Promise.all(nodes.map(async (node) => {
-    if (key) {
-      node.setPluginData(key, 'none');
-      tokensSharedDataHandler.set(node, key, 'none');
-      await defaultNodeManager.updateNode(node, (tokens) => (
-        omit(tokens, key)
-      ));
-      removeValuesFromNode(node, key);
-    } else {
-      await defaultNodeManager.updateNode(node, (tokens) => (
-        omit(tokens, Object.values(Properties))
-      ));
-      Object.values(Properties).forEach((prop) => {
-        node.setPluginData(prop, 'none');
-        tokensSharedDataHandler.set(node, prop, 'none');
-        removeValuesFromNode(node, prop);
-      });
-    }
+    node.setPluginData(key, 'none');
+    tokensSharedDataHandler.set(node, key, 'none');
+    await defaultNodeManager.updateNode(node, (tokens) => (
+      omit(tokens, key)
+    ));
+    removeValuesFromNode(node, key);
     store.successfulNodes.add(node);
   }));
 }
@@ -135,7 +124,7 @@ export async function updatePluginData({
     promises.add(defaultWorker.schedule(async () => {
       const currentValuesOnNode = tokens ?? {};
       let newValuesOnNode: NodeTokenRefMap = {};
-      if (values.composition === 'delete' || values.composition === 'none') newValuesOnNode = { ...values, ...currentValuesOnNode, composition: values.composition };
+      if (values.composition === 'delete') newValuesOnNode = { ...values, ...currentValuesOnNode, composition: values.composition };
       else newValuesOnNode = { ...currentValuesOnNode, ...values };
       if (currentValuesOnNode.composition && values.composition) {
         // when select another composition token, reset applied properties by current composition token

--- a/src/plugin/removeValuesFromNode.test.ts
+++ b/src/plugin/removeValuesFromNode.test.ts
@@ -188,4 +188,9 @@ describe('removeTokensByValue', () => {
     removeValuesFromNode(mockNode, Properties.asset);
     expect(mockNode.fills).toEqual([]);
   });
+
+  it('should set cornerRadius as 0', () => {
+    removeValuesFromNode(mockNode, Properties.borderColor);
+    expect(mockNode.strokes).toEqual([]);
+  });
 });

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -23,6 +23,8 @@ import setBackgroundBlurOnTarget from './setBackgroundBlurOnTarget';
 import setImageValuesOnTarget from './setImageValuesOnTarget';
 import { isCompositeBorderValue } from '@/utils/is/isCompositeBorderValue';
 import { setBorderColorValuesOnTarget } from './setBorderColorValuesOnTarget';
+import removeValuesFromNode from './removeValuesFromNode';
+import { Properties } from '@/constants/Properties';
 
 // @README values typing is wrong
 
@@ -49,6 +51,12 @@ export default async function setValuesOnNode(
       && node.type !== 'STICKY'
       && node.type !== 'CODE_BLOCK'
     ) {
+      Object.entries(values).forEach(([key, value]) => {
+        if (value === 'none') {
+          removeValuesFromNode(node, key as Properties);
+          delete values[key];
+        }
+      });
       // set border token
       if (values.border && isCompositeBorderValue(values.border)) {
         setBorderValuesOnTarget(node, { value: values.border });

--- a/src/storage/GitlabTokenStorage.ts
+++ b/src/storage/GitlabTokenStorage.ts
@@ -90,11 +90,15 @@ export class GitlabTokenStorage extends GitTokenStorage {
     try {
       if (!currentUser || currentUser.state !== 'active') return false;
 
-      const groupPermission = await this.gitlabClient.GroupMembers.show(this.groupId, currentUser.id);
+      const groupPermission = await this.gitlabClient.GroupMembers.show(this.groupId, currentUser.id, {
+        includeInherited: true,
+      });
       return groupPermission.access_level >= GitLabAccessLevel.Developer;
     } catch (e) {
       try {
-        const projectPermission = await this.gitlabClient.ProjectMembers.show(this.projectId, currentUser.id);
+        const projectPermission = await this.gitlabClient.ProjectMembers.show(this.projectId, currentUser.id, {
+          includeInherited: true,
+        });
         return projectPermission.access_level >= GitLabAccessLevel.Developer;
       } catch (e) {
         console.error(e);

--- a/src/storage/__tests__/GitlabTokenStorage.test.ts
+++ b/src/storage/__tests__/GitlabTokenStorage.test.ts
@@ -178,7 +178,7 @@ describe('GitlabTokenStorage', () => {
       })
     ));
     expect(await storageProvider.canWrite()).toBe(true);
-    expect(mockGetGroupMembers).toBeCalledWith(51634506, 11289475);
+    expect(mockGetGroupMembers).toBeCalledWith(51634506, 11289475, { includeInherited: true });
   });
 
   it('canWrite should return true if user is a collaborator by projectMember', async () => {
@@ -197,7 +197,7 @@ describe('GitlabTokenStorage', () => {
       })
     ));
     expect(await storageProvider.canWrite()).toBe(true);
-    expect(mockGetProjectMembers).toBeCalledWith(35102363, 11289475);
+    expect(mockGetProjectMembers).toBeCalledWith(35102363, 11289475, { includeInherited: true });
   });
 
   it('canWrite should return false if user is not a collaborator', async () => {

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -104,6 +104,7 @@ export type RemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.REMAP
 export type BulkRemapTokensAsyncMessage = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS, {
   oldName: string;
   newName: string;
+  updateMode: UpdateMode;
 }>;
 export type BulkRemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS>;
 


### PR DESCRIPTION
- Fixes an issue with GitLab group credentials not being inherited. Thanks @robin-ambachtsheer
- Fixes an issue with renaming token groups where user choice was sometimes ignored and only applied on selection
- Fixes an issue with `none` value tokens sometimes causing tokens not being applied
- Adds support for the `none` keyword in token values
- Removed an older migration that should speed up performance by a bit