### PR TITLE
WIP: feat/allow json indent config

### DIFF
--- a/src/app/components/Checkbox.tsx
+++ b/src/app/components/Checkbox.tsx
@@ -16,6 +16,7 @@ const StyledCheckbox = styled(CheckboxPrimitive.Root, {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+  flexShrink: 0,
   width: 12,
   height: 12,
   '&:focus': { boxShadow: '$focus' },

--- a/src/app/components/ExportProvider/MultiFilesExport.tsx
+++ b/src/app/components/ExportProvider/MultiFilesExport.tsx
@@ -24,13 +24,13 @@ export default function MultiFilesExport({ onClose }: Props) {
   const filesChangeset = React.useMemo(() => {
     const changeObj: Record<string, string> = {};
     Object.entries(convertTokensToObject(tokens)).forEach(([key, value]) => {
-      changeObj[`${key}.json`] = JSON.stringify(value, null, 2);
+      changeObj[`${key}.json`] = JSON.stringify(value, null, '\t');
     });
-    changeObj[`${SystemFilenames.THEMES}.json`] = JSON.stringify(themes, null, 2);
+    changeObj[`${SystemFilenames.THEMES}.json`] = JSON.stringify(themes, null, '\t');
     const metadata = {
       tokenSetOrder: Object.keys(tokens),
     };
-    changeObj[`${SystemFilenames.METADATA}.json`] = JSON.stringify(metadata, null, 2);
+    changeObj[`${SystemFilenames.METADATA}.json`] = JSON.stringify(metadata, null, '\t');
     return changeObj;
   }, [tokens, themes]);
 

--- a/src/app/components/ExportProvider/SingleFileExport.tsx
+++ b/src/app/components/ExportProvider/SingleFileExport.tsx
@@ -72,7 +72,7 @@ export default function SingleFileExport({ onClose }: Props) {
         tokenSetOrder: Object.keys(tokens),
       });
     }
-    return JSON.stringify(returnValue, null, 2);
+    return JSON.stringify(returnValue, null, '\t');
   }, [formattedTokens, tokens, themes, includeAllTokens]);
 
   return (

--- a/src/app/components/Settings/Settings.tsx
+++ b/src/app/components/Settings/Settings.tsx
@@ -10,7 +10,7 @@ import Heading from '../Heading';
 import { Dispatch } from '../../store';
 import Label from '../Label';
 import {
-  ignoreFirstPartForStylesSelector, prefixStylesWithThemeNameSelector, uiStateSelector,
+  ignoreFirstPartForStylesSelector, prefixStylesWithThemeNameSelector, jsonIndentationSelector, uiStateSelector,
 } from '@/selectors';
 import Stack from '../Stack';
 import Box from '../Box';
@@ -18,6 +18,9 @@ import AddLicenseKey from '../AddLicenseKey/AddLicenseKey';
 import { Divider } from '../Divider';
 import OnboardingExplainer from '../OnboardingExplainer';
 import RemConfiguration from '../RemConfiguration';
+import Text from '../Text';
+import Select from '../Select';
+import { JSONIndentationSettings } from '@/types';
 
 function Settings() {
   const onboardingData = {
@@ -28,6 +31,7 @@ function Settings() {
 
   const ignoreFirstPartForStyles = useSelector(ignoreFirstPartForStylesSelector);
   const prefixStylesWithThemeName = useSelector(prefixStylesWithThemeNameSelector);
+  const jsonIndentation = useSelector(jsonIndentationSelector);
   const uiState = useSelector(uiStateSelector);
   const dispatch = useDispatch<Dispatch>();
 
@@ -44,6 +48,14 @@ function Settings() {
       track('setPrefixStylesWithThemeName', { value: state });
 
       dispatch.settings.setPrefixStylesWithThemeName(!!state);
+    },
+    [dispatch.settings],
+  );
+
+  const handleJsonIndentationChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      track('setJsonIndentation', { value: e.target.value });
+      dispatch.settings.setJSONIndentation(e.target.value as JSONIndentationSettings);
     },
     [dispatch.settings],
   );
@@ -71,31 +83,59 @@ function Settings() {
         )}
         <SyncSettings />
         <Divider />
-        <Stack direction="column" gap={3} css={{ padding: '0 $4' }}>
-          <Heading size="small">Settings</Heading>
-          <Stack direction="row" gap={2} align="center">
-            <Checkbox
-              id="ignoreFirstPartForStyles"
-              checked={!!ignoreFirstPartForStyles}
-              defaultChecked={ignoreFirstPartForStyles}
-              onCheckedChange={handleIgnoreChange}
-            />
-            <Label htmlFor="ignoreFirstPartForStyles">Ignore first part of token name for styles</Label>
+        <Stack direction="column" gap={5} css={{ padding: '0 $4' }}>
+          <Stack direction="column" gap={4}>
+            <Heading size="medium">Styles</Heading>
+            <Stack direction="row" gap={3}>
+              <Checkbox
+                id="ignoreFirstPartForStyles"
+                checked={!!ignoreFirstPartForStyles}
+                defaultChecked={ignoreFirstPartForStyles}
+                onCheckedChange={handleIgnoreChange}
+              />
+              <Label htmlFor="ignoreFirstPartForStyles" css={{ display: 'flex', flexDirection: 'column', gap: '$2' }}>
+                <Text bold size="small">Ignore first part of token name for styles</Text>
+                <Text muted size="small">This will ignore the first part of the token name when generating styles, e.g. the `colors` in a token called `colors.blue.500`.</Text>
+              </Label>
+            </Stack>
+            <Stack direction="row" gap={3}>
+              <Checkbox
+                id="prefixStylesWithThemeName"
+                checked={!!prefixStylesWithThemeName}
+                defaultChecked={prefixStylesWithThemeName}
+                onCheckedChange={handlePrefixWithThemeNameChange}
+              />
+              <Label htmlFor="prefixStylesWithThemeName" css={{ display: 'flex', flexDirection: 'column', gap: '$2' }}>
+                <Text bold size="small">Prefix styles with active theme name</Text>
+                <Text muted size="small">This will prefix all styles with the active theme name.</Text>
+              </Label>
+            </Stack>
           </Stack>
-          <Stack direction="row" gap={2} align="center">
-            <Checkbox
-              id="prefixStylesWithThemeName"
-              checked={!!prefixStylesWithThemeName}
-              defaultChecked={prefixStylesWithThemeName}
-              onCheckedChange={handlePrefixWithThemeNameChange}
-            />
-            <Label htmlFor="prefixStylesWithThemeName">Prefix styles with active theme name</Label>
+          <Stack direction="column" gap={2}>
+            <Heading size="medium">Base font size token (rem)</Heading>
+            <Text muted size="small">This is the base font size used to calculate rem values. You can change this to a token to enable dynamic theming, or keep to a value (default 16px)</Text>
+            <RemConfiguration />
           </Stack>
-          <Heading size="small">Base font size token</Heading>
-          <RemConfiguration />
-          <Box>
-            <Button variant="secondary" size="small" id="reset-onboarding" onClick={handleResetButton}>Reset onboarding</Button>
-          </Box>
+          <Stack direction="column" gap={2}>
+            <Heading size="medium">JSON indendation</Heading>
+            <Text muted size="small">This is the number of spaces used to indent the JSON output. Or tabs if you prefer that.</Text>
+            <Select
+              id="jsonIndentation"
+              value={jsonIndentation}
+              onChange={handleJsonIndentationChange}
+            >
+              <option value={JSONIndentationSettings.TwoSpaces}>2 spaces</option>
+              <option value={JSONIndentationSettings.FourSpaces}>4 spaces</option>
+              <option value={JSONIndentationSettings.Tab}>Tab</option>
+            </Select>
+          </Stack>
+          <Stack direction="column" gap={3}>
+            <Heading size="medium">Onboarding</Heading>
+            <Text muted size="small">Need to run through the onboarding hints again?</Text>
+            <Box>
+              <Button variant="secondary" size="small" id="reset-onboarding" onClick={handleResetButton}>Reset onboarding</Button>
+            </Box>
+          </Stack>
         </Stack>
       </Stack>
     </Box>

--- a/src/app/components/Text.tsx
+++ b/src/app/components/Text.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { styled } from '@/stitches.config';
 
 const StyledText = styled('div', {
-  lineHeight: '$default',
+  lineHeight: '130%',
   variants: {
     bold: {
       true: {

--- a/src/app/store/models/reducers/settingsState/index.ts
+++ b/src/app/store/models/reducers/settingsState/index.ts
@@ -1,2 +1,3 @@
 export * from './setPrefixStylesWithThemeName';
 export * from './setShouldSwapStyles';
+export * from './setJSONIndentation';

--- a/src/app/store/models/reducers/settingsState/setJSONIndentation.ts
+++ b/src/app/store/models/reducers/settingsState/setJSONIndentation.ts
@@ -1,0 +1,9 @@
+import { JSONIndentationSettings } from '@/types';
+import type { SettingsState } from '../../settings';
+
+export function setJSONIndentation(state: SettingsState, payload: JSONIndentationSettings): SettingsState {
+  return {
+    ...state,
+    jsonIndentation: payload,
+  };
+}

--- a/src/app/store/models/settings.tsx
+++ b/src/app/store/models/settings.tsx
@@ -8,6 +8,7 @@ import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import * as settingsStateReducers from './reducers/settingsState';
 import * as settingsStateEffects from './effects/settingsState';
 import { defaultBaseFontSize } from '@/constants/defaultBaseFontSize';
+import { JSONIndentationSettings } from '@/types';
 
 type WindowSettingsType = {
   width: number;
@@ -26,6 +27,7 @@ export interface SettingsState {
   tokenType?: TokenModeType;
   ignoreFirstPartForStyles?: boolean;
   prefixStylesWithThemeName?: boolean;
+  jsonIndentation?: JSONIndentationSettings
   inspectDeep: boolean;
   shouldSwapStyles: boolean;
   baseFontSize: string;
@@ -53,6 +55,7 @@ export const settings = createModel<RootModel>()({
     tokenType: 'object',
     ignoreFirstPartForStyles: false,
     prefixStylesWithThemeName: false,
+    jsonIndentation: '2',
     inspectDeep: false,
     shouldSwapStyles: false,
     baseFontSize: defaultBaseFontSize,

--- a/src/selectors/index.ts
+++ b/src/selectors/index.ts
@@ -55,3 +55,4 @@ export * from './getLastopened';
 export * from './baseFontSizeSelector';
 export * from './aliasBaseFontSizeSelector';
 export * from './figmaFontsSelector';
+export * from './jsonIndentationSelector';

--- a/src/selectors/jsonIndentationSelector.ts
+++ b/src/selectors/jsonIndentationSelector.ts
@@ -1,0 +1,7 @@
+import { createSelector } from 'reselect';
+import { settingsStateSelector } from './settingsStateSelector';
+
+export const jsonIndentationSelector = createSelector(
+  settingsStateSelector,
+  (state) => state.jsonIndentation,
+);

--- a/src/storage/GenericVersionedStorage.ts
+++ b/src/storage/GenericVersionedStorage.ts
@@ -54,7 +54,7 @@ export class GenericVersionedStorage extends RemoteTokenStorage<GenericVersioned
       values: {
         options: {},
       },
-    }, null, 2);
+    }, null, '\t');
     let method: string;
     switch (flow) {
       case GenericVersionedStorageFlow.READ_ONLY:

--- a/src/storage/GitTokenStorage.ts
+++ b/src/storage/GitTokenStorage.ts
@@ -99,15 +99,15 @@ export abstract class GitTokenStorage extends RemoteTokenStorage<GitStorageSaveO
           }
           return acc;
         }, {}),
-      }, null, 2);
+      }, null, '\t');
     } else if (this.flags.multiFileEnabled) {
       files.forEach((file) => {
         if (file.type === 'tokenSet') {
-          filesChangeset[joinPath(this.path, `${file.name}.json`)] = JSON.stringify(file.data, null, 2);
+          filesChangeset[joinPath(this.path, `${file.name}.json`)] = JSON.stringify(file.data, null, '\t');
         } else if (file.type === 'themes') {
-          filesChangeset[joinPath(this.path, `${SystemFilenames.THEMES}.json`)] = JSON.stringify(file.data, null, 2);
+          filesChangeset[joinPath(this.path, `${SystemFilenames.THEMES}.json`)] = JSON.stringify(file.data, null, '\t');
         } else if (file.type === 'metadata') {
-          filesChangeset[joinPath(this.path, `${SystemFilenames.METADATA}.json`)] = JSON.stringify(file.data, null, 2);
+          filesChangeset[joinPath(this.path, `${SystemFilenames.METADATA}.json`)] = JSON.stringify(file.data, null, '\t');
         }
       });
     } else {

--- a/src/storage/JSONBinTokenStorage.ts
+++ b/src/storage/JSONBinTokenStorage.ts
@@ -46,7 +46,7 @@ export class JSONBinTokenStorage extends RemoteTokenStorage<JsonBinMetadata> {
           version: pjs.plugin_version,
           updatedAt,
         },
-      }, null, 2),
+      }, null, '\t'),
       headers: new Headers([
         ['Content-Type', 'application/json'],
         ['X-Master-Key', secret],

--- a/src/types/JSONIndentationSettings.ts
+++ b/src/types/JSONIndentationSettings.ts
@@ -1,0 +1,5 @@
+export enum JSONIndentationSettings {
+  TwoSpaces = '2',
+  FourSpaces = '4',
+  Tab = 'tab',
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,3 +11,4 @@ export * from './ThemeObjectsList';
 export * from './DeepTokensMap';
 export * from './MapValuesToTokensResult';
 export * from './ShowFormOptions';
+export * from './JSONIndentationSettings';

--- a/src/utils/formatTokens.ts
+++ b/src/utils/formatTokens.ts
@@ -59,5 +59,5 @@ export default function formatTokens({
     });
   });
 
-  return JSON.stringify(tokenObj, null, 2);
+  return JSON.stringify(tokenObj, null, '\t');
 }

--- a/src/utils/stringifyTokens.ts
+++ b/src/utils/stringifyTokens.ts
@@ -30,5 +30,5 @@ export default function stringifyTokens(
     }
   });
 
-  return JSON.stringify(tokenObj, null, 2);
+  return JSON.stringify(tokenObj, null, '\t');
 }


### PR DESCRIPTION
this is a work in progress PR for allowing customization of the JSON indentation settings.

TODO:
- [x] Add UI to choose indentation type of `2 spaces`, `4 spaces`, `tab`
- [ ] Pick up UI setting from wherever we perform our `stringifyTokens` function
- [ ] Save UI setting in `$metadata` as `jsonIndentation` so this is the same by whoever uses the stored tokens (e.g. on GitHub)