### PR TITLE
Fix/update nodes on boot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tokens-studio-for-figma",
   "version": "1.0.0",
-  "plugin_version": "1.36.0",
+  "plugin_version": "1.36.1",
   "description": "Tokens Studio for Figma",
   "license": "MIT",
   "scripts": {

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,4 +1,4 @@
-VERSION=figma-tokens@1.36
+VERSION=figma-tokens@1.36.1
 sentry-cli releases -p figma-tokens files "$VERSION" upload-sourcemaps --ext ts --ext tsx --ext map --ext js --ignore-file .sentryignore .
 sentry-cli releases set-commits "$VERSION" --auto
 sentry-cli releases finalize "$VERSION"

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -547,9 +547,6 @@ export const tokenState = createModel<RootModel>()({
     updateCheckForChanges() {
       dispatch.tokenState.updateDocument({ shouldUpdateNodes: false, updateRemote: false });
     },
-    setCollapsedTokenSets() {
-      dispatch.tokenState.updateDocument({ updateRemote: false });
-    },
 
     updateDocument(options?: UpdateDocumentPayload, rootState?) {
       const defaults = { shouldUpdateNodes: true, updateRemote: true };


### PR DESCRIPTION
fixes a call which was updating nodes on boot or whenever you'd change token sets (collapse/expand, pull from git)