### PR TITLE
fix: push dialog for Supernova onConfirm should be called

### DIFF
--- a/src/app/components/PushDialog.test.tsx
+++ b/src/app/components/PushDialog.test.tsx
@@ -5,7 +5,6 @@ import {
   act, render, resetStore, createMockStore, fireEvent,
 } from '../../../tests/config/setupTest';
 import PushDialog from './PushDialog';
-import { store } from '../store';
 
 describe('PushDialog', () => {
   beforeEach(() => {
@@ -67,7 +66,7 @@ describe('PushDialog', () => {
       },
     });
 
-    expect(store.getState().uiState.showPushDialog).toBe(false);
+    expect(mockStore.getState().uiState.showPushDialog).toBe('initial');
 
     const result = render(
       <Provider store={mockStore}>
@@ -75,7 +74,7 @@ describe('PushDialog', () => {
       </Provider>,
     );
 
-    expect(store.getState().uiState.showPushDialog).toBe(false);
+    expect(mockStore.getState().uiState.showPushDialog).toBe('initial');
 
     const commitMessageInput = result.getByTestId('push-dialog-commit-message');
     fireEvent.change(commitMessageInput, {
@@ -90,7 +89,7 @@ describe('PushDialog', () => {
       });
     });
 
-    expect(store.getState().uiState.showPushDialog).toBe(false);
+    expect(mockStore.getState().uiState.showPushDialog).toBe('loading');
 
     result.unmount();
   });
@@ -111,11 +110,13 @@ describe('PushDialog', () => {
       </Provider>,
     );
 
+    expect(mockStore.getState().uiState.showPushDialog).toBe('initial');
+
     act(() => {
       fireEvent.click(result.getByTestId('push-dialog-button-push-changes'));
     });
 
-    expect(store.getState().uiState.showPushDialog).toBe(false);
+    expect(mockStore.getState().uiState.showPushDialog).toBe('loading');
 
     result.unmount();
   });

--- a/src/app/components/PushDialog.test.tsx
+++ b/src/app/components/PushDialog.test.tsx
@@ -67,11 +67,15 @@ describe('PushDialog', () => {
       },
     });
 
+    expect(store.getState().uiState.showPushDialog).toBe(false);
+
     const result = render(
       <Provider store={mockStore}>
         <PushDialog />
       </Provider>,
     );
+
+    expect(store.getState().uiState.showPushDialog).toBe(false);
 
     const commitMessageInput = result.getByTestId('push-dialog-commit-message');
     fireEvent.change(commitMessageInput, {
@@ -84,6 +88,31 @@ describe('PushDialog', () => {
         code: 'Enter',
         ctrlKey: true,
       });
+    });
+
+    expect(store.getState().uiState.showPushDialog).toBe(false);
+
+    result.unmount();
+  });
+
+  it('should be able to push to Supernova by pressing ctrl/cmd + Enter', () => {
+    const mockStore = createMockStore({
+      uiState: {
+        showPushDialog: 'initial',
+        localApiState: {
+          provider: StorageProviderType.SUPERNOVA,
+        },
+      },
+    });
+
+    const result = render(
+      <Provider store={mockStore}>
+        <PushDialog />
+      </Provider>,
+    );
+
+    act(() => {
+      fireEvent.click(result.getByTestId('push-dialog-button-push-changes'));
     });
 
     expect(store.getState().uiState.showPushDialog).toBe(false);

--- a/src/app/components/PushDialog.test.tsx
+++ b/src/app/components/PushDialog.test.tsx
@@ -94,7 +94,7 @@ describe('PushDialog', () => {
     result.unmount();
   });
 
-  it('should be able to push to Supernova by pressing ctrl/cmd + Enter', () => {
+  it('should be able to push to Supernova by pressing ctrl/cmd + Enter', async () => {
     const mockStore = createMockStore({
       uiState: {
         showPushDialog: 'initial',
@@ -112,10 +112,11 @@ describe('PushDialog', () => {
 
     expect(mockStore.getState().uiState.showPushDialog).toBe('initial');
 
-    act(() => {
-      fireEvent.click(result.getByTestId('push-dialog-button-push-changes'));
+    await act(async () => {
+      await fireEvent.click(result.getByTestId('push-dialog-button-push-changes'));
     });
 
+    expect(result.getByText('Pushing to Supernova.io')).toBeInTheDocument();
     expect(mockStore.getState().uiState.showPushDialog).toBe('loading');
 
     result.unmount();

--- a/src/app/components/PushDialog.tsx
+++ b/src/app/components/PushDialog.tsx
@@ -108,10 +108,10 @@ function PushDialog() {
   }, [showPushDialog, localApiState]);
 
   const handlePushChanges = React.useCallback(() => {
-    if (commitMessage && branch) {
+    if (localApiState.provider === StorageProviderType.SUPERNOVA || (commitMessage && branch)) {
       onConfirm(commitMessage, branch);
     }
-  }, [branch, commitMessage, onConfirm]);
+  }, [branch, commitMessage, onConfirm, localApiState]);
 
   const handleSaveShortcut = React.useCallback((event: KeyboardEvent) => {
     if (showPushDialog === 'initial' && (event.metaKey || event.ctrlKey)) {


### PR DESCRIPTION
Fixes calling `onConfirm` inside `PushDialog` for Supernova integration, which has no `commitMessage` or `branch`. This was lost after last changes to `PushDialog`.