### PR TITLE
fix: flooding errors

### DIFF
--- a/src/app/store/remoteTokens.tsx
+++ b/src/app/store/remoteTokens.tsx
@@ -450,9 +450,9 @@ export default function useRemoteTokens() {
   ]);
 
   const checkRemoteChange = useCallback(async (context: StorageTypeCredentials = api): Promise<boolean> => {
-    track('checkRemoteChange', { provider: context.provider });
+    track('checkRemoteChange', { provider: context?.provider });
     let hasChange = false;
-    switch (context.provider) {
+    switch (context?.provider) {
       case StorageProviderType.JSONBIN: {
         hasChange = false;
         break;


### PR DESCRIPTION
This https://github.com/tokens-studio/figma-plugin/blob/87d272b9bbf5b27eddaf4038ec7cc18261253c5c/src/app/store/remoteTokens.tsx#L453 is currently causing an issue.

It is possible that the context value is not provided or null from remote storage, etc.

This is currently causing unnecessary errors in Sentry despite it not causing a crash to the plugin