### PR TITLE
fix: respect theme groups from multi file import

### DIFF
--- a/src/storage/__tests__/UrlTokenStorage.test.ts
+++ b/src/storage/__tests__/UrlTokenStorage.test.ts
@@ -49,6 +49,7 @@ describe('Test URLTokenStorage', () => {
           $themes: [{
             id: 'light',
             name: 'Light',
+            group: 'Theme',
             selectedTokenSets: {
               global: TokenSetStatus.SOURCE,
               light: TokenSetStatus.ENABLED,
@@ -71,6 +72,7 @@ describe('Test URLTokenStorage', () => {
           {
             id: 'light',
             name: 'Light',
+            group: 'Theme',
             selectedTokenSets: {
               global: TokenSetStatus.SOURCE,
               light: TokenSetStatus.ENABLED,

--- a/src/storage/schemas/multiFileSchema.ts
+++ b/src/storage/schemas/multiFileSchema.ts
@@ -1,16 +1,7 @@
 import z from 'zod';
-import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { tokensMapSchema } from './tokensMapSchema';
+import { themeObjectSchema } from './themeObjectSchema';
 
-export const multiFileSchema = tokensMapSchema.or(z.array(z.object({
-  id: z.string(),
-  name: z.string(),
-  selectedTokenSets: z.record(z.enum([
-    TokenSetStatus.ENABLED,
-    TokenSetStatus.DISABLED,
-    TokenSetStatus.SOURCE,
-  ])),
-  $figmaStyleReferences: z.record(z.string()).optional(),
-}))).or(z.object({
+export const multiFileSchema = tokensMapSchema.or(z.array(themeObjectSchema)).or(z.object({
   tokenSetOrder: z.array(z.string()).optional(),
 }));


### PR DESCRIPTION
Likely fixes #1927. Ran into it while trying to generate multi theme variables for Figma :) I guess the zod schema validation just stripped unknown properties.

Note: Originally this PR fixed URL sync as well, but a fix for that was merged separately in #1982.