### PR TITLE
feat: connect created styles to local variables

### DIFF
--- a/src/utils/isPaintEqual.ts
+++ b/src/utils/isPaintEqual.ts
@@ -16,6 +16,7 @@ export function isPaintEqual(paint1?: Paint, paint2?: Paint) {
 
           // Compare using hex instead for now:
           && convertFigmaPaintToHex(paint1) === convertFigmaPaintToHex(paint2)
+          && paint1.boundVariables?.color?.id === paint2.boundVariables?.color?.id
         );
       }
 


### PR DESCRIPTION
In relation to this question: https://tokens-studio.slack.com/archives/C03C60J1XUP/p1687428596648179?thread_ts=1687367476.523889&cid=C03C60J1XUP

This is probably a very simplified implementation, as it should probably consider some other settings as well, like whether the first part of token path is removed from style names or not. But seemed to work okay for my test, I now have styles connected to vars! 

Feel free to iterate on, orpoint out what I should do additionally to get this merged, or close at some point :)