### PR TITLE
Fix theme groups not being loaded (#1981)

### DIFF
--- a/src/storage/__tests__/FileTokenStorage.test.ts
+++ b/src/storage/__tests__/FileTokenStorage.test.ts
@@ -15,6 +15,7 @@ const json = JSON.stringify({
     {
       id: '8722635276827d42671ab23df835867c9e0024dd',
       name: 'Light',
+      group: 'Color',
       selectedTokenSets: {
         global: 'enabled',
       },
@@ -38,16 +39,23 @@ describe('FileTokenStorage', () => {
     } as unknown as FileList;
     const mockFileTokenStorage = new FileTokenStorage(mockFileList);
 
-    expect(await mockFileTokenStorage.read()).toEqual([{
-      data: [{
-        $figmaStyleReferences: {}, id: '8722635276827d42671ab23df835867c9e0024dd', name: 'Light', selectedTokenSets: { global: 'enabled' },
-      }],
-      path: 'core.json',
-      type: 'themes',
-    },
-    { data: { tokenSetOrder: ['global'] }, path: 'core.json', type: 'metadata' },
-    {
-      data: { primary: { type: 'sizing', value: '1.5' }, secondary: { type: 'sizing', value: '4' } }, name: 'global', path: 'core.json', type: 'tokenSet',
-    }]);
+    expect(await mockFileTokenStorage.read()).toEqual([
+      {
+        data: [
+          {
+            $figmaStyleReferences: {},
+            id: '8722635276827d42671ab23df835867c9e0024dd',
+            name: 'Light',
+            group: 'Color',
+            selectedTokenSets: { global: 'enabled' },
+          },
+        ],
+        path: 'core.json',
+        type: 'themes',
+      },
+      { data: { tokenSetOrder: ['global'] }, path: 'core.json', type: 'metadata' },
+      {
+        data: { primary: { type: 'sizing', value: '1.5' }, secondary: { type: 'sizing', value: '4' } }, name: 'global', path: 'core.json', type: 'tokenSet',
+      }]);
   });
 });

--- a/src/storage/schemas/themeObjectSchema.ts
+++ b/src/storage/schemas/themeObjectSchema.ts
@@ -4,6 +4,7 @@ import { TokenSetStatus } from '@/constants/TokenSetStatus';
 export const themeObjectSchema = z.object({
   id: z.string(),
   name: z.string(),
+  group: z.string().optional(),
   selectedTokenSets: z.record(z.enum([
     TokenSetStatus.ENABLED,
     TokenSetStatus.DISABLED,


### PR DESCRIPTION
This should fix the issue identified in #1981 where theme group metadata is ignored when loading tokens from storage.