### PR TITLE
Ensure no additional telemetry could be used to associate user sessions

### DIFF
--- a/src/utils/validateLicense.ts
+++ b/src/utils/validateLicense.ts
@@ -14,13 +14,6 @@ export default async function validateLicense(
     );
 
     if (res.status === 200) {
-      // set as user id in Sentry
-      Sentry.setUser({
-        licenseKey,
-        id: userId || '<UNKNOWN>',
-        username: userName || '<UNKNOWN>',
-      });
-
       return await res.json();
     }
 


### PR DESCRIPTION
The prior usage of Sentry setUser could result in non anonymized sessions that could be associated with user details like names. This should be removed