### PR TITLE
Add better tracking for error event

### DIFF
--- a/src/app/store/updateSources.tsx
+++ b/src/app/store/updateSources.tsx
@@ -98,7 +98,7 @@ async function updateRemoteTokens({
       break;
     }
     default:
-      throw new Error('Not implemented');
+      throw new Error(`Unimplemented storage provider for ${provider}`);
   }
 }
 


### PR DESCRIPTION
Addresses #2028 

We are currently just exposing more surface area for the unnecessary configuration of a storage provider. If a provider does  not need this hook they should be able to ignore it and rather opt in if necessary