### PR TITLE
fix sync tabs

### DIFF
--- a/.changeset/proud-cheetahs-float.md
+++ b/.changeset/proud-cheetahs-float.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fix: Fixes sync tabs being displayed malformed

--- a/src/app/components/PushDialog.tsx
+++ b/src/app/components/PushDialog.tsx
@@ -139,11 +139,11 @@ function PushDialog() {
           close={onCancel}
         >
           <Stack direction="column" gap={4}>
-            <div>
+            <Stack direction="row">
               <TabButton<string> name="commit" activeTab={activeTab} label={t('commit')} onSwitch={handleSwitch} />
               <TabButton<string> name="diff" activeTab={activeTab} label={t('diff')} onSwitch={handleSwitch} />
               <TabButton<string> name="json" activeTab={activeTab} label="JSON" onSwitch={handleSwitch} />
-            </div>
+            </Stack>
             {
               activeTab !== 'commit' && localApiState.provider === StorageProviderType.SUPERNOVA && (
                 <Stack direction="row" gap={2} align="center" css={{ display: 'inline', padding: '0 $4' }}>


### PR DESCRIPTION
Fixes a bug that was introduced with i18n

Before:

<img width="453" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/6e38a299-3cea-44c6-b606-80980a66a6e8">

After:

<img width="456" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/378a2bce-1466-4f78-948e-a3b1258e116e">
