### PR TITLE
Perf fixes

### DIFF
--- a/.changeset/breezy-trainers-hug.md
+++ b/.changeset/breezy-trainers-hug.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixed a major performance issue that appeared after 1.37. Times to apply and update nodes should now be down to 10% of what it was before for some files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokens-studio/figma-plugin",
-  "version": "1.37.3",
+  "version": "1.37.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokens-studio/figma-plugin",
-      "version": "1.37.3",
+      "version": "1.37.6",
       "license": "MIT",
       "dependencies": {
         "@figma-plugin/helpers": "^0.15.2",
@@ -109,7 +109,7 @@
         "@babel/preset-react": "^7.12.13",
         "@babel/preset-typescript": "^7.12.16",
         "@changesets/cli": "^2.26.2",
-        "@figma/plugin-typings": "github:figma/plugin-typings#vars",
+        "@figma/plugin-typings": "^1.71.1",
         "@sentry/webpack-plugin": "^2.2.0",
         "@storybook/addon-actions": "^6.5.8",
         "@storybook/addon-docs": "^6.5.8",
@@ -5522,10 +5522,10 @@
       }
     },
     "node_modules/@figma/plugin-typings": {
-      "version": "1.65.0",
-      "resolved": "git+ssh://git@github.com/figma/plugin-typings.git#934f4415656089aa1c3d14ba0eb83b8ae912562c",
-      "dev": true,
-      "license": "MIT License"
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.71.1.tgz",
+      "integrity": "sha512-Ej8lieEvCSrSbpFcpBrBKZtjzdqj26QvRPi/yQiy8ENLcNzbSqD0fhegiXOkQjaLmkN4sIQlpY7xcds8HbgD1g==",
+      "dev": true
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -57731,9 +57731,10 @@
       }
     },
     "@figma/plugin-typings": {
-      "version": "git+ssh://git@github.com/figma/plugin-typings.git#934f4415656089aa1c3d14ba0eb83b8ae912562c",
-      "dev": true,
-      "from": "@figma/plugin-typings@github:figma/plugin-typings#vars"
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.71.1.tgz",
+      "integrity": "sha512-Ej8lieEvCSrSbpFcpBrBKZtjzdqj26QvRPi/yQiy8ENLcNzbSqD0fhegiXOkQjaLmkN4sIQlpY7xcds8HbgD1g==",
+      "dev": true
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.16",
     "@changesets/cli": "^2.26.2",
-    "@figma/plugin-typings": "github:figma/plugin-typings#vars",
+    "@figma/plugin-typings": "^1.71.1",
     "@sentry/webpack-plugin": "^2.2.0",
     "@storybook/addon-actions": "^6.5.8",
     "@storybook/addon-docs": "^6.5.8",

--- a/src/plugin/NodeManager.ts
+++ b/src/plugin/NodeManager.ts
@@ -49,31 +49,31 @@ export class NodeManager {
   constructor() {
     this.updating = new Promise(async (resolve) => {
       if (typeof figma.root !== 'undefined') {
-        // const parsedCache = await PersistentNodesCacheProperty.read(figma.root);
-        // if (parsedCache) {
-        //   // this.persistentNodesCache = new Map(parsedCache);
-        // }
+        const parsedCache = await PersistentNodesCacheProperty.read(figma.root);
+        if (parsedCache) {
+          this.persistentNodesCache = new Map(parsedCache);
+        }
 
-        // // Compare nodes in the document to what we have in the cache
-        // const allNodes = figma.root.findAll();
-        // if (allNodes.length > 0) {
-        //   const nodeIds = new Set(allNodes.map((node) => node.id));
-        //   let hasDeletedNodes = false;
+        // Compare nodes in the document to what we have in the cache
+        const allNodes = figma.root.findAllWithCriteria({ sharedPluginData: { namespace: 'tokens' } });
+        if (allNodes.length > 0) {
+          const nodeIds = new Set(allNodes.map((node) => node.id));
+          let hasDeletedNodes = false;
 
-        //   // Remove any nodes from the cache that no longer exist
-        //   for (const [id] of this.persistentNodesCache) {
-        //     if (!nodeIds.has(id)) {
-        //       this.persistentNodesCache.delete(id);
-        //       hasDeletedNodes = true;
-        //     }
-        //   }
+          // Remove any nodes from the cache that no longer exist
+          for (const [id] of this.persistentNodesCache) {
+            if (!nodeIds.has(id)) {
+              this.persistentNodesCache.delete(id);
+              hasDeletedNodes = true;
+            }
+          }
 
-        //   // Cache update if we removed any nodes
-        //   if (hasDeletedNodes) {
-        //     const remainingEntries = Array.from(this.persistentNodesCache.entries());
-        //     await PersistentNodesCacheProperty.write(remainingEntries);
-        //   }
-        // }
+          // Cache update if we removed any nodes
+          if (hasDeletedNodes) {
+            const remainingEntries = Array.from(this.persistentNodesCache.entries());
+            await PersistentNodesCacheProperty.write(remainingEntries);
+          }
+        }
 
         this.emitter.on('cache-update', debounce(async () => {
           const entries = Array.from(this.persistentNodesCache.entries());

--- a/src/plugin/NodeManager.ts
+++ b/src/plugin/NodeManager.ts
@@ -49,31 +49,31 @@ export class NodeManager {
   constructor() {
     this.updating = new Promise(async (resolve) => {
       if (typeof figma.root !== 'undefined') {
-        const parsedCache = await PersistentNodesCacheProperty.read(figma.root);
-        if (parsedCache) {
-          this.persistentNodesCache = new Map(parsedCache);
-        }
+        // const parsedCache = await PersistentNodesCacheProperty.read(figma.root);
+        // if (parsedCache) {
+        //   // this.persistentNodesCache = new Map(parsedCache);
+        // }
 
-        // Compare nodes in the document to what we have in the cache
-        const allNodes = figma.root.findAll();
-        if (allNodes.length > 0) {
-          const nodeIds = new Set(allNodes.map((node) => node.id));
-          let hasDeletedNodes = false;
+        // // Compare nodes in the document to what we have in the cache
+        // const allNodes = figma.root.findAll();
+        // if (allNodes.length > 0) {
+        //   const nodeIds = new Set(allNodes.map((node) => node.id));
+        //   let hasDeletedNodes = false;
 
-          // Remove any nodes from the cache that no longer exist
-          for (const [id] of this.persistentNodesCache) {
-            if (!nodeIds.has(id)) {
-              this.persistentNodesCache.delete(id);
-              hasDeletedNodes = true;
-            }
-          }
+        //   // Remove any nodes from the cache that no longer exist
+        //   for (const [id] of this.persistentNodesCache) {
+        //     if (!nodeIds.has(id)) {
+        //       this.persistentNodesCache.delete(id);
+        //       hasDeletedNodes = true;
+        //     }
+        //   }
 
-          // Cache update if we removed any nodes
-          if (hasDeletedNodes) {
-            const remainingEntries = Array.from(this.persistentNodesCache.entries());
-            await PersistentNodesCacheProperty.write(remainingEntries);
-          }
-        }
+        //   // Cache update if we removed any nodes
+        //   if (hasDeletedNodes) {
+        //     const remainingEntries = Array.from(this.persistentNodesCache.entries());
+        //     await PersistentNodesCacheProperty.write(remainingEntries);
+        //   }
+        // }
 
         this.emitter.on('cache-update', debounce(async () => {
           const entries = Array.from(this.persistentNodesCache.entries());

--- a/src/plugin/__tests__/setValuesOnNode.test.ts
+++ b/src/plugin/__tests__/setValuesOnNode.test.ts
@@ -1,23 +1,16 @@
 import setValuesOnNode from '../setValuesOnNode';
-import { ThemeObjectsList } from '@/types';
 import * as setTextValuesOnTarget from '../setTextValuesOnTarget';
 import * as setEffectValuesOnTarget from '../setEffectValuesOnTarget';
 import * as setColorValuesOnTarget from '../setColorValuesOnTarget';
 import { BoxShadowTypes } from '@/constants/BoxShadowTypes';
 import { mockFetch } from '../../../tests/__mocks__/fetchMock';
 import { mockCreateImage } from '../../../tests/__mocks__/figmaMock';
-import { INTERNAL_THEMES_NO_GROUP } from '@/constants/InternalTokenGroup';
 
 describe('Can set values on node', () => {
   const emptyStylesMap = {
     effectStyles: new Map(),
     paintStyles: new Map(),
     textStyles: new Map(),
-  };
-
-  const emptyThemeInfo = {
-    activeTheme: {},
-    themes: [] as ThemeObjectsList,
   };
 
   const setTextValuesOnTargetSpy = jest.spyOn(setTextValuesOnTarget, 'default');
@@ -101,7 +94,7 @@ describe('Can set values on node', () => {
       borderRadiusBottomLeft: 'border-radius-10',
     };
 
-    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap);
 
     expect(solidNodeMock.cornerRadius).toEqual(10);
     expect(solidNodeMock.topLeftRadius).toEqual(10);
@@ -140,7 +133,6 @@ describe('Can set values on node', () => {
       },
       { sizing: 'size.10' },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(mockResize).toBeCalledWith(100, 100);
   });
@@ -159,7 +151,6 @@ describe('Can set values on node', () => {
       },
       { width: 'size.100' },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(mockResize).toBeCalledWith(100, 50);
   });
@@ -178,7 +169,6 @@ describe('Can set values on node', () => {
       },
       { height: 'size.100' },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(mockResize).toBeCalledWith(50, 100);
   });
@@ -195,7 +185,6 @@ describe('Can set values on node', () => {
         boxShadow: 'shadows.default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(setTextValuesOnTargetSpy).toHaveBeenCalled();
   });
@@ -212,7 +201,6 @@ describe('Can set values on node', () => {
         boxShadow: 'shadows.default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
   });
@@ -232,7 +220,6 @@ describe('Can set values on node', () => {
         boxShadow: 'shadows.default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(setTextValuesOnTargetSpy).toHaveBeenCalled();
   });
@@ -255,7 +242,6 @@ describe('Can set values on node', () => {
         ...emptyStylesMap,
         textStyles: new Map([['type/heading/h1', { name: 'type/heading/h1', id: '123' } as TextStyle]]),
       },
-      emptyThemeInfo,
     );
     expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
     expect(textNodeMock).toEqual({ ...textNodeMock, textStyleId: '123' });
@@ -279,7 +265,10 @@ describe('Can set values on node', () => {
         ...emptyStylesMap,
         textStyles: new Map([['heading/h1', { name: 'heading/h1', id: '456' } as TextStyle]]),
       },
-      emptyThemeInfo,
+      {},
+      {},
+      {},
+      null,
       true,
     );
     expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
@@ -307,7 +296,6 @@ describe('Can set values on node', () => {
         ...emptyStylesMap,
         effectStyles: new Map([['shadows/default', { name: 'shadows/default', id: '123' } as EffectStyle]]),
       },
-      emptyThemeInfo,
     );
     expect(setEffectValuesOnTargetSpy).not.toHaveBeenCalled();
     expect(solidNodeMock).toEqual({ ...solidNodeMock, effectStyleId: '123' });
@@ -334,7 +322,6 @@ describe('Can set values on node', () => {
         ...emptyStylesMap,
         effectStyles: new Map([['shadows/other', { name: 'shadows/other', id: '123' } as EffectStyle]]),
       },
-      emptyThemeInfo,
     );
     expect(setEffectValuesOnTargetSpy).toHaveBeenCalled();
   });
@@ -360,14 +347,11 @@ describe('Can set values on node', () => {
         ...emptyStylesMap,
         effectStyles: new Map([['light/shadows/default', { name: 'light/shadows/default', id: '123' } as EffectStyle]]),
       },
-      {
-        activeTheme: {
-          [INTERNAL_THEMES_NO_GROUP]: 'light',
-        },
-        themes: [{ id: 'light', name: 'light', selectedTokenSets: {} }],
-      },
+      {},
+      {},
+      {},
+      'light',
       false,
-      true,
     );
     expect(setEffectValuesOnTargetSpy).not.toHaveBeenCalled();
     expect(solidNodeMock).toEqual({ ...solidNodeMock, effectStyleId: '123' });
@@ -386,7 +370,6 @@ describe('Can set values on node', () => {
         ...emptyStylesMap,
         paintStyles: new Map([['colors/red', { name: 'colors/red', id: '123' } as PaintStyle]]),
       },
-      emptyThemeInfo,
     );
     expect(setColorValuesOnTargetSpy).not.toHaveBeenCalled();
     expect(solidNodeMock).toEqual({ ...solidNodeMock, fillStyleId: '123' });
@@ -402,7 +385,6 @@ describe('Can set values on node', () => {
         fill: 'colors.red',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(setColorValuesOnTargetSpy).toHaveBeenCalledWith(solidNodeMock, { value: '#ff0000' }, 'fills');
   });
@@ -420,7 +402,6 @@ describe('Can set values on node', () => {
         ...emptyStylesMap,
         paintStyles: new Map([['colors/red', { name: 'colors/red', id: '123' } as PaintStyle]]),
       },
-      emptyThemeInfo,
     );
     expect(setColorValuesOnTargetSpy).not.toHaveBeenCalled();
     expect(solidNodeMock).toEqual({ ...solidNodeMock, strokeStyleId: '123' });
@@ -436,7 +417,6 @@ describe('Can set values on node', () => {
         borderColor: 'colors.red',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(setColorValuesOnTargetSpy).toHaveBeenCalledWith(solidNodeMock, { value: '#ff0000' }, 'strokes');
   });
@@ -451,7 +431,6 @@ describe('Can set values on node', () => {
         spacing: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.paddingLeft).toBe(20);
     expect(frameNodeMock.paddingRight).toBe(20);
@@ -469,7 +448,6 @@ describe('Can set values on node', () => {
         horizontalPadding: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.paddingLeft).toBe(20);
     expect(frameNodeMock.paddingRight).toBe(20);
@@ -485,7 +463,6 @@ describe('Can set values on node', () => {
         verticalPadding: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.paddingTop).toBe(20);
     expect(frameNodeMock.paddingBottom).toBe(20);
@@ -501,7 +478,6 @@ describe('Can set values on node', () => {
         itemSpacing: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.itemSpacing).toBe(20);
   });
@@ -516,7 +492,6 @@ describe('Can set values on node', () => {
         paddingTop: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.paddingTop).toBe(20);
   });
@@ -531,7 +506,6 @@ describe('Can set values on node', () => {
         paddingRight: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.paddingRight).toBe(20);
   });
@@ -546,7 +520,6 @@ describe('Can set values on node', () => {
         paddingBottom: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.paddingBottom).toBe(20);
   });
@@ -561,7 +534,6 @@ describe('Can set values on node', () => {
         paddingLeft: 'spacing.lg',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(frameNodeMock.paddingLeft).toBe(20);
   });
@@ -576,7 +548,6 @@ describe('Can set values on node', () => {
         fill: 'fg.default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(textNodeMock.fills).toEqual([
       {
@@ -601,7 +572,6 @@ describe('Can set values on node', () => {
         fill: 'default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(textNodeMock.characters).toEqual('My new content');
   });
@@ -616,7 +586,6 @@ describe('Can set values on node', () => {
         fill: 'fg.default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(textNodeMock.characters).toEqual('foobar');
   });
@@ -632,7 +601,6 @@ describe('Can set values on node', () => {
         boxShadow: 'shadows.default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(figma.loadFontAsync).toHaveBeenCalled();
     expect(textNodeMock.characters).toEqual('0');
@@ -647,7 +615,6 @@ describe('Can set values on node', () => {
         boxShadow: 'shadows.default',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(figma.loadFontAsync).not.toHaveBeenCalled();
     expect(textNodeMock.characters).toEqual('foobar');
@@ -665,7 +632,7 @@ describe('Can set values on node', () => {
     mockCreateImage.mockImplementation(() => ({
       hash: '1234',
     }));
-    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap);
     expect(solidNodeMock.fills).toEqual([
       {
         type: 'IMAGE',
@@ -684,7 +651,7 @@ describe('Can set values on node', () => {
       dimension: '12px',
     };
     const data = { dimension: 'dimension.regular' };
-    await setValuesOnNode(mockNode, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(mockNode, values, data, emptyStylesMap);
     expect(mockResize).toBeCalledWith(12, 12);
   });
 
@@ -699,7 +666,7 @@ describe('Can set values on node', () => {
       dimension: '12px',
     };
     const data = { dimension: 'dimension.regular' };
-    await setValuesOnNode(mockNode, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(mockNode, values, data, emptyStylesMap);
     expect(mockResize).toBeCalledTimes(0);
     expect(mockNode.itemSpacing).toEqual(12);
   });
@@ -712,7 +679,7 @@ describe('Can set values on node', () => {
       },
     };
     const data = { border: 'border.regular' };
-    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap);
     expect(solidNodeMock.strokeWeight).toEqual(12);
     expect(solidNodeMock.dashPattern).toEqual([0, 0]);
   });
@@ -729,7 +696,6 @@ describe('Can set values on node', () => {
         borderRadius: 'border-radius.none',
       },
       emptyStylesMap,
-      emptyThemeInfo,
     );
     expect(solidNodeMock).toEqual({ ...solidNodeMock, strokes: [], cornerRadius: 0 });
   });
@@ -739,7 +705,7 @@ describe('Can set values on node', () => {
       visibility: 'false',
     };
     const data = { visibility: 'boolean-false' };
-    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap);
     expect(solidNodeMock.visible).toEqual(false);
   });
 
@@ -752,7 +718,7 @@ describe('Can set values on node', () => {
       number: '12px',
     };
     const data = { number: 'number.regular' };
-    await setValuesOnNode(mockNode, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(mockNode, values, data, emptyStylesMap);
     expect(mockResize).toBeCalledWith(12, 12);
   });
 
@@ -767,7 +733,7 @@ describe('Can set values on node', () => {
       number: '12px',
     };
     const data = { number: 'number.regular' };
-    await setValuesOnNode(mockNode, values, data, emptyStylesMap, emptyThemeInfo);
+    await setValuesOnNode(mockNode, values, data, emptyStylesMap);
     expect(mockResize).toBeCalledTimes(0);
     expect(mockNode.itemSpacing).toEqual(12);
   });

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -78,6 +78,9 @@ figma.on('selectionchange', () => {
 });
 
 figma.on('documentchange', (event: DocumentChangeEvent) => {
+  if (event.documentChanges.length === 1 && event.documentChanges[0].type === 'PROPERTY_CHANGE' && event.documentChanges[0].id === '0:0') {
+    return;
+  }
   sendDocumentChange(event);
 });
 

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -78,9 +78,6 @@ figma.on('selectionchange', () => {
 });
 
 figma.on('documentchange', (event: DocumentChangeEvent) => {
-  if (event.documentChanges.length === 1 && event.documentChanges[0].type === 'PROPERTY_CHANGE' && event.documentChanges[0].id === '0:0') {
-    return;
-  }
   sendDocumentChange(event);
 });
 

--- a/src/plugin/getAppliedVariablesFromNode.ts
+++ b/src/plugin/getAppliedVariablesFromNode.ts
@@ -42,7 +42,7 @@ export default function getAppliedVariablesFromNode(node: BaseNode): SelectionVa
       }
       if (!Array.isArray(value) && key in node) {
         const variableId = value.id;
-        if (variableId) {
+        if (variableId && typeof variableId === 'string') {
           const variable = figma.variables.getVariableById(variableId);
           if (variable) {
             localVariables.push({

--- a/src/plugin/node.ts
+++ b/src/plugin/node.ts
@@ -262,11 +262,14 @@ export async function updateNodes(
     });
   });
 
+  // TODO: Instead of passing in figmaStyleReferences as a whole, can we just pass in the matching variable / style instead of having to do the heavy lifting inside setNodeValue?
+
   entries.forEach((entry) => {
     promises.add(
       defaultWorker.schedule(async () => {
         try {
           if (entry.tokens) {
+            // TODO: This is probably something we can optimize
             const mappedTokens = destructureTokenForAlias(tokens, entry.tokens);
             let mappedValues = mapValuesToTokens(tokens, entry.tokens);
             mappedValues = destructureToken(mappedValues);

--- a/src/plugin/node.ts
+++ b/src/plugin/node.ts
@@ -262,6 +262,8 @@ export async function updateNodes(
     });
   });
 
+  const stylePathPrefix = prefixStylesWithThemeName && activeThemes.length > 0 ? activeThemes[0].name : null;
+
   // TODO: Instead of passing in figmaStyleReferences as a whole, can we just pass in the matching variable / style instead of having to do the heavy lifting inside setNodeValue?
 
   entries.forEach((entry) => {
@@ -281,9 +283,8 @@ export async function updateNodes(
               figmaStyleReferences,
               figmaVariableMaps,
               figmaVariableReferences,
-              activeThemes,
+              stylePathPrefix,
               ignoreFirstPartForStyles,
-              prefixStylesWithThemeName,
               baseFontSize,
             );
             store.successfulNodes.add(entry.node);

--- a/src/plugin/sendDocumentChange.ts
+++ b/src/plugin/sendDocumentChange.ts
@@ -3,6 +3,9 @@ import { defaultNodeManager } from './NodeManager';
 import { sendSelectionChange } from './sendSelectionChange';
 
 export async function sendDocumentChange(event: DocumentChangeEvent) {
+  if (event.documentChanges.length === 1 && event.documentChanges[0].type === 'PROPERTY_CHANGE' && event.documentChanges[0].id === '0:0') {
+    return;
+  }
   const changeNodeIds = event.documentChanges.filter((change) => change.origin === 'REMOTE' && change.type === 'PROPERTY_CHANGE').map((change) => change.id);
   if (!changeNodeIds.length) {
     return;

--- a/src/plugin/sendDocumentChange.ts
+++ b/src/plugin/sendDocumentChange.ts
@@ -3,7 +3,10 @@ import { defaultNodeManager } from './NodeManager';
 import { sendSelectionChange } from './sendSelectionChange';
 
 export async function sendDocumentChange(event: DocumentChangeEvent) {
-  const changeNodeIds = event.documentChanges.filter((change) => change.type === 'PROPERTY_CHANGE').map((change) => change.id);
+  const changeNodeIds = event.documentChanges.filter((change) => change.origin === 'REMOTE' && change.type === 'PROPERTY_CHANGE').map((change) => change.id);
+  if (!changeNodeIds.length) {
+    return;
+  }
   const nodeManagers = await Promise.all(changeNodeIds.map((nodeId) => defaultNodeManager.getNode(nodeId)));
   const nodes = compact(nodeManagers).map((nodeManager) => nodeManager?.node);
   await defaultNodeManager.update(nodes);

--- a/src/plugin/setValuesOnNode.test.ts
+++ b/src/plugin/setValuesOnNode.test.ts
@@ -1,4 +1,3 @@
-import { GetThemeInfoMessageResult } from '@/types/AsyncMessages';
 import { getAllFigmaStyleMaps } from '@/utils/getAllFigmaStyleMaps';
 import setValuesOnNode from './setValuesOnNode';
 
@@ -25,13 +24,12 @@ describe('setValuesOnNode', () => {
     spacing: 'spacing.10',
   };
   const figmaStyleMaps = {} as ReturnType<typeof getAllFigmaStyleMaps>;
-  const themeInfo = {} as Omit<GetThemeInfoMessageResult, 'type'>;
 
   it('should apply all border when borderRadius token has one value', async () => {
     const borderRadiusTokenWithOneValue = {
       borderRadius: '10px',
     };
-    await setValuesOnNode(textNodeMock, borderRadiusTokenWithOneValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(textNodeMock, borderRadiusTokenWithOneValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
       cornerRadius: 10,
       bottomLeftRadius: 3,
@@ -45,7 +43,7 @@ describe('setValuesOnNode', () => {
     const borderRadiusTokenWithTwoValue = {
       borderRadius: '10px 20px',
     };
-    await setValuesOnNode(textNodeMock, borderRadiusTokenWithTwoValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(textNodeMock, borderRadiusTokenWithTwoValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
       cornerRadius: 3,
       bottomLeftRadius: 20,
@@ -59,7 +57,7 @@ describe('setValuesOnNode', () => {
     const borderRadiusTokenWithThreeValue = {
       borderRadius: '10px 20px 30px',
     };
-    await setValuesOnNode(textNodeMock, borderRadiusTokenWithThreeValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(textNodeMock, borderRadiusTokenWithThreeValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
       cornerRadius: 3,
       bottomLeftRadius: 20,
@@ -73,7 +71,7 @@ describe('setValuesOnNode', () => {
     const borderRadiusTokenWithFourValue = {
       borderRadius: '10px 20px 30px 40px',
     };
-    await setValuesOnNode(textNodeMock, borderRadiusTokenWithFourValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(textNodeMock, borderRadiusTokenWithFourValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
       cornerRadius: 3,
       bottomLeftRadius: 40,
@@ -87,7 +85,7 @@ describe('setValuesOnNode', () => {
     const borderRadiusTokenWithFiveValue = {
       borderRadius: '10px 20px 30px 40px 50px',
     };
-    await setValuesOnNode(textNodeMock, borderRadiusTokenWithFiveValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(textNodeMock, borderRadiusTokenWithFiveValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
       cornerRadius: 3,
       bottomLeftRadius: 3,
@@ -101,7 +99,7 @@ describe('setValuesOnNode', () => {
     const spacingTokenWithOneValue = {
       spacing: '10px',
     };
-    await setValuesOnNode(frameNodeMock, spacingTokenWithOneValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(frameNodeMock, spacingTokenWithOneValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
       paddingBottom: 10,
       paddingLeft: 10,
@@ -114,7 +112,7 @@ describe('setValuesOnNode', () => {
     const spacingTokenWithTwoValue = {
       spacing: '10px 20px',
     };
-    await setValuesOnNode(frameNodeMock, spacingTokenWithTwoValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(frameNodeMock, spacingTokenWithTwoValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
       paddingBottom: 10,
       paddingLeft: 20,
@@ -127,7 +125,7 @@ describe('setValuesOnNode', () => {
     const spacingTokenWithThreeValue = {
       spacing: '10px 20px 30px',
     };
-    await setValuesOnNode(frameNodeMock, spacingTokenWithThreeValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(frameNodeMock, spacingTokenWithThreeValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
       paddingBottom: 30,
       paddingLeft: 20,
@@ -140,7 +138,7 @@ describe('setValuesOnNode', () => {
     const spacingTokenWithFourValue = {
       spacing: '10px 20px 30px 40px',
     };
-    await setValuesOnNode(frameNodeMock, spacingTokenWithFourValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(frameNodeMock, spacingTokenWithFourValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
       paddingBottom: 30,
       paddingLeft: 40,
@@ -153,7 +151,7 @@ describe('setValuesOnNode', () => {
     const spacingTokenWithFiveValue = {
       spacing: '10px 20px 30px 40px 50px',
     };
-    await setValuesOnNode(frameNodeMock, spacingTokenWithFiveValue, data, figmaStyleMaps, themeInfo);
+    await setValuesOnNode(frameNodeMock, spacingTokenWithFiveValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
       paddingBottom: 3,
       paddingLeft: 3,

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -44,7 +44,6 @@ export default async function setValuesOnNode(
   prefixStylesWithThemeName = false,
   baseFontSize = defaultBaseFontSize,
 ) {
-  // Filter activeThemes e.g light, desktop
   const stylePathSlice = ignoreFirstPartForStyles ? 1 : 0;
   const stylePathPrefix = prefixStylesWithThemeName && activeThemes.length > 0 ? activeThemes[0].name : null;
 

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -1,5 +1,4 @@
-import { MapValuesToTokensResult } from '@/types';
-import { GetThemeInfoMessageResult } from '@/types/AsyncMessages';
+import { MapValuesToTokensResult, ThemeObjectsList } from '@/types';
 import { NodeTokenRefMap } from '@/types/NodeTokenRefMap';
 import { convertTokenNameToPath } from '@/utils/convertTokenNameToPath';
 import { getAllFigmaStyleMaps } from '@/utils/getAllFigmaStyleMaps';
@@ -37,32 +36,17 @@ export default async function setValuesOnNode(
   values: MapValuesToTokensResult,
   data: NodeTokenRefMap,
   figmaStyleMaps: ReturnType<typeof getAllFigmaStyleMaps>,
-  themeInfo: Omit<GetThemeInfoMessageResult, 'type'>,
+  figmaStyleReferences: Record<string, string>,
+  figmaVariableMaps: ReturnType<typeof getVariablesMap>,
+  figmaVariableReferences: Record<string, string>,
+  activeThemes: ThemeObjectsList,
   ignoreFirstPartForStyles = false,
   prefixStylesWithThemeName = false,
   baseFontSize = defaultBaseFontSize,
 ) {
   // Filter activeThemes e.g light, desktop
-  const activeThemes = themeInfo.themes?.filter((theme) => Object.values(themeInfo.activeTheme).some((v) => v === theme.id));
   const stylePathSlice = ignoreFirstPartForStyles ? 1 : 0;
   const stylePathPrefix = prefixStylesWithThemeName && activeThemes.length > 0 ? activeThemes[0].name : null;
-  const figmaVariableMaps = getVariablesMap();
-
-  // Store all figmaStyleReferences through all activeThemes (e.g {color.red: ['s.1234'], color.blue ['s.2345', 's.3456']})
-  const figmaStyleReferences: Record<string, string> = {};
-  const figmaVariableReferences: Record<string, string> = {};
-  activeThemes?.forEach((theme) => {
-    Object.entries(theme.$figmaVariableReferences ?? {}).forEach(([token, variableId]) => {
-      if (!figmaVariableReferences[token]) {
-        figmaVariableReferences[token] = variableId;
-      }
-    });
-    Object.entries(theme.$figmaStyleReferences ?? {}).forEach(([token, styleId]) => {
-      if (!figmaStyleReferences[token]) {
-        figmaStyleReferences[token] = styleId;
-      }
-    });
-  });
 
   try {
     // BORDER RADIUS

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -1,4 +1,4 @@
-import { MapValuesToTokensResult, ThemeObjectsList } from '@/types';
+import { MapValuesToTokensResult } from '@/types';
 import { NodeTokenRefMap } from '@/types/NodeTokenRefMap';
 import { convertTokenNameToPath } from '@/utils/convertTokenNameToPath';
 import { getAllFigmaStyleMaps } from '@/utils/getAllFigmaStyleMaps';
@@ -36,16 +36,14 @@ export default async function setValuesOnNode(
   values: MapValuesToTokensResult,
   data: NodeTokenRefMap,
   figmaStyleMaps: ReturnType<typeof getAllFigmaStyleMaps>,
-  figmaStyleReferences: Record<string, string>,
-  figmaVariableMaps: ReturnType<typeof getVariablesMap>,
-  figmaVariableReferences: Record<string, string>,
-  activeThemes: ThemeObjectsList,
+  figmaStyleReferences: Record<string, string> = {},
+  figmaVariableMaps: ReturnType<typeof getVariablesMap> = {},
+  figmaVariableReferences: Record<string, string> = {},
+  stylePathPrefix: string | null = null,
   ignoreFirstPartForStyles = false,
-  prefixStylesWithThemeName = false,
   baseFontSize = defaultBaseFontSize,
 ) {
   const stylePathSlice = ignoreFirstPartForStyles ? 1 : 0;
-  const stylePathPrefix = prefixStylesWithThemeName && activeThemes.length > 0 ? activeThemes[0].name : null;
 
   try {
     // BORDER RADIUS

--- a/tests/__mocks__/figmaMock.js
+++ b/tests/__mocks__/figmaMock.js
@@ -58,6 +58,7 @@ module.exports.mockUiPostMessage = jest.fn((pluginMessage) => {
 module.exports.mockRootSetSharedPluginData = jest.fn(() => {});
 module.exports.mockRootGetSharedPluginData = jest.fn(() => {});
 module.exports.mockRootFindAll = jest.fn(() => []);
+module.exports.mockRootFindAllWithCriteria = jest.fn(() => []);
 module.exports.mockParentPostMessage = jest.fn((data) => {
   figmaUiOnHandlers
     .filter(([eventName]) => eventName === 'message')
@@ -91,6 +92,7 @@ module.exports.figma = {
     setSharedPluginData: module.exports.mockRootSetSharedPluginData,
     getSharedPluginData: module.exports.mockRootGetSharedPluginData,
     findAll: module.exports.mockRootFindAll,
+    findAllWithCriteria: module.exports.mockRootFindAllWithCriteria,
   },
   variables: {
     getLocalVariables: module.exports.mockGetLocalVariables


### PR DESCRIPTION
Removed migrateTokens call. This was something we added to migrate border tokens to borderColor tokens. I's likely ok to remove this, it's been around 6 months since we introduced the border tokens or more. This was responsible for a lot of calls to Updating plugin data... which caused everything to be rather slow.

I added a few checks to document changes. This is basically responsible for checking if other users are changing something to applied tokens, and then we would invalidate and re-fetch those nodes. However, it also ran on all document changes, including internal ones and from the user. I removed this, and it should lead to less calls and faster execution time.

Also fixes a major issue that caused us to iterate over all variable references _on every node_ resulting in poor performance.