### PR TITLE
fix: SupernovaTokenStorage should persist $metadata

### DIFF
--- a/.changeset/breezy-spiders-cross.md
+++ b/.changeset/breezy-spiders-cross.md
@@ -2,4 +2,4 @@
 '@tokens-studio/figma-plugin': patch
 ---
 
-Fixes order sync when push, then pull from Supernova.
+Fixes a bug that caused token set order to be ignored when syncing with Supernova

--- a/.changeset/breezy-spiders-cross.md
+++ b/.changeset/breezy-spiders-cross.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixes order sync when push, then pull from Supernova.

--- a/src/storage/SupernovaTokenStorage.ts
+++ b/src/storage/SupernovaTokenStorage.ts
@@ -100,6 +100,11 @@ export class SupernovaTokenStorage extends RemoteTokenStorage<SupernovaStorageSa
         dataObject.$themes = [...(dataObject.$themes ?? []), ...file.data];
       } else if (file.type === 'tokenSet') {
         dataObject[file.name] = file.data;
+      } else if (file.type === 'metadata') {
+        dataObject.$metadata = {
+          ...(dataObject.$metadata ?? []),
+          ...file.data,
+        };
       }
     });
 


### PR DESCRIPTION
## Changes
 - Fixes order sync when push, then pull from Supernova.

## Before

https://github.com/tokens-studio/figma-plugin/assets/729374/15317825-7225-4a84-98e4-76143851135e

## After

https://github.com/tokens-studio/figma-plugin/assets/729374/eebb1318-0329-4466-8993-940a2e10e73b

