### PR TITLE
Fix/edit token no update

### DIFF
--- a/.changeset/kind-lizards-occur.md
+++ b/.changeset/kind-lizards-occur.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Changed behavior of editing, duplicating or creating tokens to no longer automatically apply changes. You now need to run `Apply to..` if you want tokens to be updated.

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -557,10 +557,10 @@ export const tokenState = createModel<RootModel>()({
       dispatch.tokenState.updateDocument({ updateRemote: false });
     },
     duplicateToken() {
-      dispatch.tokenState.updateDocument();
+      dispatch.tokenState.updateDocument({ shouldUpdateNodes: false });
     },
     createToken() {
-      dispatch.tokenState.updateDocument();
+      dispatch.tokenState.updateDocument({ shouldUpdateNodes: false });
     },
     renameTokenGroup(data: RenameTokenGroupPayload, rootState) {
       const {

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -515,7 +515,7 @@ export const tokenState = createModel<RootModel>()({
       }
 
       if (payload.shouldUpdate && rootState.settings.updateOnChange) {
-        dispatch.tokenState.updateDocument();
+        dispatch.tokenState.updateDocument({ shouldUpdateNodes: false });
       }
     },
     deleteToken() {


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2136

fixes behavior where we'd call apply to.. on every token creation, duplication and edit

This change updates the `updateDocument()` function in the `tokenState` model to prevent node updates by default and adds this parameter to the `createToken()` and `duplicateToken()` functions.

* `src/app/store/models/tokenState.tsx`: Updated `updateDocument()` function to include `shouldUpdateNodes` parameter with default value of `false` to prevent node updates by default, and updated `createToken()` and `duplicateToken()` functions to pass this parameter. (F7f22e68L515R515, F7f22e68L557R557) 