### PR TITLE
fix apply performance

### DIFF
--- a/.changeset/moody-chairs-eat.md
+++ b/.changeset/moody-chairs-eat.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Cut down speed of `Apply to..` operations to around 40% of where we were before

--- a/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
@@ -1,9 +1,9 @@
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { bulkRemapTokens } from '../bulkRemapTokens';
 import { defaultNodeManager } from '../../NodeManager';
-import { updatePluginData } from '@/plugin/pluginData';
+import { updatePluginData } from '@/plugin/updatePluginData';
 
-jest.mock('@/plugin/pluginData', (() => ({
+jest.mock('@/plugin/updatePluginData', (() => ({
   updatePluginData: jest.fn(),
 })));
 

--- a/src/plugin/asyncMessageHandlers/__tests__/remapTokens.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/remapTokens.test.ts
@@ -1,17 +1,17 @@
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { defaultNodeManager } from '../../NodeManager';
-import { updatePluginData } from '@/plugin/pluginData';
+import { updatePluginData } from '@/plugin/updatePluginData';
 import { remapTokens } from '../remapTokens';
 import { UpdateMode } from '@/constants/UpdateMode';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { AnyTokenList } from '@/types/tokens';
 import { Properties } from '@/constants/Properties';
 
-jest.mock('@/plugin/pluginData', () => ({
+jest.mock('@/plugin/updatePluginData', () => ({
   updatePluginData: jest.fn(),
 }));
 
-jest.mock('@/plugin/node', () => ({
+jest.mock('@/plugin/updateNodes', () => ({
   updateNodes: jest.fn(),
 }));
 

--- a/src/plugin/asyncMessageHandlers/__tests__/removeTokensByValue.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/removeTokensByValue.test.ts
@@ -1,11 +1,11 @@
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { defaultNodeManager, NodeManagerNode } from '../../NodeManager';
-import { updatePluginData } from '@/plugin/pluginData';
+import { updatePluginData } from '@/plugin/updatePluginData';
 import { removeTokensByValue } from '../removeTokensByValue';
 import { Properties } from '@/constants/Properties';
 import { NodeInfo } from '@/types/NodeInfo';
 
-jest.mock('@/plugin/pluginData', () => ({
+jest.mock('@/plugin/updatePluginData', () => ({
   updatePluginData: jest.fn(),
 }));
 

--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -1,7 +1,7 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { defaultNodeManager, NodeManagerNode } from '../NodeManager';
-import { updatePluginData } from '../pluginData';
+import { updatePluginData } from '../updatePluginData';
 import { sendSelectionChange } from '../sendSelectionChange';
 
 export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK_REMAP_TOKENS] = async (msg) => {

--- a/src/plugin/asyncMessageHandlers/remapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/remapTokens.ts
@@ -2,9 +2,9 @@ import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
 import { UpdateMode } from '@/constants/UpdateMode';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { tokenArrayGroupToMap } from '@/utils/tokenArrayGroupToMap';
-import { updateNodes } from '../node';
+import { updateNodes } from '../updateNodes';
 import { defaultNodeManager, NodeManagerNode } from '../NodeManager';
-import { updatePluginData } from '../pluginData';
+import { updatePluginData } from '../updatePluginData';
 import { sendSelectionChange } from '../sendSelectionChange';
 import { TokenTypes } from '@/constants/TokenTypes';
 

--- a/src/plugin/asyncMessageHandlers/removeTokensByValue.ts
+++ b/src/plugin/asyncMessageHandlers/removeTokensByValue.ts
@@ -1,7 +1,7 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { defaultNodeManager } from '../NodeManager';
-import { updatePluginData } from '../pluginData';
+import { updatePluginData } from '../updatePluginData';
 import { sendSelectionChange } from '../sendSelectionChange';
 
 export const removeTokensByValue: AsyncMessageChannelHandlers[AsyncMessageTypes.REMOVE_TOKENS_BY_VALUE] = async (msg) => {

--- a/src/plugin/asyncMessageHandlers/setNodeData.ts
+++ b/src/plugin/asyncMessageHandlers/setNodeData.ts
@@ -1,9 +1,10 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { tokenArrayGroupToMap } from '@/utils/tokenArrayGroupToMap';
-import { updateNodes } from '../node';
+import { updateNodes } from '../updateNodes';
 import { defaultNodeManager } from '../NodeManager';
-import { sendPluginValues, updatePluginData } from '../pluginData';
+import { sendPluginValues } from '../pluginData';
+import { updatePluginData } from '../updatePluginData';
 
 export const setNodeData: AsyncMessageChannelHandlers[AsyncMessageTypes.SET_NODE_DATA] = async (msg) => {
   try {

--- a/src/plugin/asyncMessageHandlers/setNoneValuesOnNode.ts
+++ b/src/plugin/asyncMessageHandlers/setNoneValuesOnNode.ts
@@ -1,9 +1,9 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { tokenArrayGroupToMap } from '@/utils/tokenArrayGroupToMap';
-import { updateNodes } from '../node';
+import { updateNodes } from '../updateNodes';
 import { defaultNodeManager } from '../NodeManager';
-import { updatePluginData } from '../pluginData';
+import { updatePluginData } from '../updatePluginData';
 import { sendSelectionChange } from '../sendSelectionChange';
 
 export const setNoneValuesOnNode: AsyncMessageChannelHandlers[AsyncMessageTypes.SET_NONE_VALUES_ON_NODE] = async (msg) => {

--- a/src/plugin/asyncMessageHandlers/update.ts
+++ b/src/plugin/asyncMessageHandlers/update.ts
@@ -2,9 +2,8 @@ import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { updateLocalTokensData } from '@/utils/figma';
 import { tokenArrayGroupToMap } from '@/utils/tokenArrayGroupToMap';
-import { updateNodes } from '../node';
+import { updateNodes } from '../updateNodes';
 import { NodeManagerNode, defaultNodeManager } from '../NodeManager';
-import { updatePluginData } from '../pluginData';
 import updateStyles from '../updateStyles';
 import { swapStyles } from './swapStyles';
 
@@ -31,7 +30,6 @@ export const update: AsyncMessageChannelHandlers[AsyncMessageTypes.UPDATE] = asy
       updateMode: msg.settings.updateMode,
     });
     await updateNodes(allWithData, tokensMap, msg.settings);
-    await updatePluginData({ entries: allWithData, values: {} });
     if (msg.activeTheme && msg.themes && msg.settings.shouldSwapStyles) {
       await swapStyles(msg.activeTheme, msg.themes, msg.settings.updateMode);
     }

--- a/src/plugin/node.test.ts
+++ b/src/plugin/node.test.ts
@@ -1,7 +1,7 @@
 import { mockRootSetSharedPluginData } from '../../tests/__mocks__/figmaMock';
 import { StorageProviderType } from '@/constants/StorageProviderType';
 import {
-  destructureToken, mapValuesToTokens, returnValueToLookFor, saveStorageType, saveOnboardingExplainerSets, saveOnboardingExplainerInspect, saveOnboardingExplainerSyncProviders, destructureTokenForAlias,
+  mapValuesToTokens, returnValueToLookFor, saveStorageType, saveOnboardingExplainerSets, saveOnboardingExplainerInspect, saveOnboardingExplainerSyncProviders, destructureTokenForAlias,
 } from './node';
 import getOnboardingExplainer from '@/utils/getOnboardingExplainer';
 import { TokenTypes } from '@/constants/TokenTypes';
@@ -157,24 +157,16 @@ const values = [
 
 const mappedTokens = [
   { fill: '#0000ff' },
+  { opacity: '40%' },
   {
-    composition: { opacity: '40%' },
+    opacity: '40%',
+    borderRadius: '24px',
   },
   {
-    composition: {
-      opacity: '40%',
-      borderRadius: '24px',
-    },
+    boxShadow: singleShadowToken.value,
   },
   {
-    composition: {
-      boxShadow: singleShadowToken.value,
-    },
-  },
-  {
-    composition: {
-      boxShadow: multipleShadowToken.value,
-    },
+    boxShadow: multipleShadowToken.value,
   },
   {
     boxShadow: singleShadowToken.value,
@@ -184,34 +176,24 @@ const mappedTokens = [
   },
   {
     border: borderToken.value,
+    borderColor: borderToken.value.color,
   },
   {
     borderTop: borderToken.value,
+    borderColor: borderToken.value.color,
   },
   {
     borderRight: borderToken.value,
+    borderColor: borderToken.value.color,
   },
   {
     borderLeft: borderToken.value,
+    borderColor: borderToken.value.color,
   },
   {
     borderBottom: borderToken.value,
+    borderColor: borderToken.value.color,
   },
-];
-
-const applyProperties = [
-  { fill: '#0000ff' },
-  { opacity: '40%' },
-  { opacity: '40%', borderRadius: '24px' },
-  { boxShadow: singleShadowToken.value },
-  { boxShadow: multipleShadowToken.value },
-  { boxShadow: singleShadowToken.value },
-  { boxShadow: multipleShadowToken.value },
-  { border: borderToken.value, borderColor: '#ff0000' },
-  { borderTop: borderToken.value, borderColor: '#ff0000' },
-  { borderRight: borderToken.value, borderColor: '#ff0000' },
-  { borderLeft: borderToken.value, borderColor: '#ff0000' },
-  { borderBottom: borderToken.value, borderColor: '#ff0000' },
 ];
 
 const applyTokens = [
@@ -289,15 +271,7 @@ describe('mapValuesToTokens', () => {
   });
 });
 
-describe('destructureToken', () => {
-  it('return properties in compositionToken', () => {
-    mappedTokens.forEach((token, index) => {
-      expect(destructureToken(token)).toEqual(applyProperties[index]);
-    });
-  });
-});
-
-describe('destructureTokenForAliasa', () => {
+describe('destructureTokenForAlias', () => {
   it('return extract border color from border token', () => {
     values.forEach((value, index) => {
       expect(destructureTokenForAlias(tokens, value)).toEqual(applyTokens[index]);

--- a/src/plugin/node.ts
+++ b/src/plugin/node.ts
@@ -31,6 +31,14 @@ export function returnValueToLookFor(key: string) {
   }
 }
 
+const borderPropertyMap = new Map<Properties, string>([
+  [Properties.border, 'border'],
+  [Properties.borderTop, 'borderTop'],
+  [Properties.borderRight, 'borderRight'],
+  [Properties.borderBottom, 'borderBottom'],
+  [Properties.borderLeft, 'borderLeft'],
+]);
+
 type MapValuesToTokensResult = Record<string, string | number | SingleToken['value'] | {
   property: string
   value?: SingleToken['value'];
@@ -53,26 +61,14 @@ export function mapValuesToTokens(tokens: Map<string, AnyTokenList[number]>, val
       } else if (key === TokenTypes.COMPOSITION) {
         Object.entries(resolvedToken.value).forEach(([property, value]) => {
           // Assign the actual value of a composition token property to the applied values
-          acc[property as CompositionTokenProperty] = value;
+          acc[property as Properties] = value;
           // If we're dealing with border tokens we want to extract the color part to be applied (we can only apply color on the whole border, not individual sides)
-          if (typeof value === 'object' && ['border', 'borderTop', 'borderRight', 'borderBottom', 'borderLeft'].includes(property) && 'color' in value && typeof value.color === 'string') {
+          if (typeof value === 'object' && borderPropertyMap.get(property as Properties) && 'color' in value && typeof value.color === 'string') {
             acc.borderColor = value.color;
           }
         });
-        // Same as above, if we're dealing with border tokens we want to extract the color part to be applied (we can only apply color on the whole border, not individual sides)
-      } else if (key === Properties.border && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
-        acc.borderColor = resolvedToken.value.color;
-        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
-      } else if (key === Properties.borderTop && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
-        acc.borderColor = resolvedToken.value.color;
-        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
-      } else if (key === Properties.borderRight && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
-        acc.borderColor = resolvedToken.value.color;
-        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
-      } else if (key === Properties.borderBottom && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
-        acc.borderColor = resolvedToken.value.color;
-        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
-      } else if (key === Properties.borderLeft && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
+      } else if (borderPropertyMap.get(key as Properties) && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
+      // Same as above, if we're dealing with border tokens we want to extract the color part to be applied (we can only apply color on the whole border, not individual sides)
         acc.borderColor = resolvedToken.value.color;
         acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
       } else {

--- a/src/plugin/node.ts
+++ b/src/plugin/node.ts
@@ -1,16 +1,6 @@
 import compact from 'just-compact';
 import { CollapsedTokenSetsProperty } from '@/figmaStorage/CollapsedTokenSetsProperty';
-import store from './store';
-import setValuesOnNode from './setValuesOnNode';
-import { Properties } from '@/constants/Properties';
 import { NodeTokenRefMap } from '@/types/NodeTokenRefMap';
-import { NodeManagerNode } from './NodeManager';
-import { postToUI } from './notifiers';
-import { MessageFromPluginTypes } from '@/types/messages';
-import { BackgroundJobs } from '@/constants/BackgroundJobs';
-import { defaultWorker } from './Worker';
-import { getAllFigmaStyleMaps } from '@/utils/getAllFigmaStyleMaps';
-import { ProgressTracker } from './ProgressTracker';
 import { AnyTokenList, SingleToken, TokenStore } from '@/types/tokens';
 import { isSingleToken } from '@/utils/is';
 import { ThemeObjectsList } from '@/types';
@@ -21,11 +11,8 @@ import { StorageType } from '@/types/StorageType';
 import {
   ActiveThemeProperty, CheckForChangesProperty, StorageTypeProperty, ThemesProperty, UpdatedAtProperty, ValuesProperty, VersionProperty, OnboardingExplainerSetsProperty, OnboardingExplainerInspectProperty, OnboardingExplainerSyncProvidersProperty,
 } from '@/figmaStorage';
-import { AsyncMessageChannel } from '@/AsyncMessageChannel';
-import { AsyncMessageTypes } from '@/types/AsyncMessages';
-import { SettingsState } from '@/app/store/models/settings';
 import { ColorModifierTypes } from '@/constants/ColorModifierTypes';
-import { getVariablesMap } from '@/utils/getVariablesMap';
+import { Properties } from '@/constants/Properties';
 
 // @TODO fix typings
 
@@ -49,22 +36,46 @@ type MapValuesToTokensResult = Record<string, string | number | SingleToken['val
   value?: SingleToken['value'];
 }[]>;
 
+// TODO: It feels unecessary to do this like that. whats up with the modify? cant we do that upfront before we send tokens to the document?
 export function mapValuesToTokens(tokens: Map<string, AnyTokenList[number]>, values: NodeTokenRefMap): MapValuesToTokensResult {
   const mappedValues = Object.entries(values).reduce<MapValuesToTokensResult>((acc, [key, tokenOnNode]) => {
     const resolvedToken = tokens.get(tokenOnNode);
+
     if (!resolvedToken) return acc;
     if (isSingleToken(resolvedToken)) {
+      // We only do this for rawValue as its a documentation and we want to show this to the user
+      // TODO: This should not happen here. We should do this when we build the token object.
       if (returnValueToLookFor(key) === 'rawValue' && resolvedToken.$extensions) {
         const modifier = resolvedToken.$extensions?.['studio.tokens']?.modify;
         if (modifier) {
           acc[key] = modifier.type === ColorModifierTypes.MIX ? `${resolvedToken.rawValue} / mix(${modifier.color}, ${modifier.value}) / ${modifier.space}` : `${resolvedToken.rawValue} / ${modifier.type}(${modifier.value}) / ${modifier.space}`;
         }
+      } else if (key === TokenTypes.COMPOSITION) {
+        Object.entries(resolvedToken.value).forEach(([property, value]) => {
+          acc[property as CompositionTokenProperty] = value;
+        });
+      } else if (key === Properties.border && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
+        acc.borderColor = resolvedToken.value.color;
+        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
+      } else if (key === Properties.borderTop && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
+        acc.borderColor = resolvedToken.value.color;
+        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
+      } else if (key === Properties.borderRight && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
+        acc.borderColor = resolvedToken.value.color;
+        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
+      } else if (key === Properties.borderBottom && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
+        acc.borderColor = resolvedToken.value.color;
+        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
+      } else if (key === Properties.borderLeft && resolvedToken.type === TokenTypes.BORDER && typeof resolvedToken.value === 'object' && 'color' in resolvedToken.value && resolvedToken.value.color) {
+        acc.borderColor = resolvedToken.value.color;
+        acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
       } else {
         acc[key] = resolvedToken[returnValueToLookFor(key)] || resolvedToken.value;
       }
     } else {
       acc[key] = resolvedToken;
     }
+
     return acc;
   }, {});
   return mappedValues;
@@ -155,36 +166,6 @@ export function selectNodes(ids: string[]) {
   figma.currentPage.selection = nodes;
 }
 
-export function destructureToken(values: MapValuesToTokensResult): MapValuesToTokensResult {
-  const tokensInCompositionToken: Partial<
-  Record<TokenTypes, SingleToken['value']>
-  & Record<Properties, SingleToken['value']>
-  > = {};
-  if (values && values.composition) {
-    Object.entries(values.composition).forEach(([property, value]) => {
-      tokensInCompositionToken[property as CompositionTokenProperty] = value;
-    });
-    const { composition, ...objExcludedCompositionToken } = values;
-    values = { ...tokensInCompositionToken, ...objExcludedCompositionToken };
-  }
-  if (values && values.border && typeof values.border === 'object' && 'color' in values.border && values.border.color) {
-    values = { ...values, ...(values.borderColor ? { } : { borderColor: values.border.color }) };
-  }
-  if (values && values.borderTop && typeof values.borderTop === 'object' && 'color' in values.borderTop && values.borderTop.color) {
-    values = { ...values, ...(values.borderColor ? { } : { borderColor: values.borderTop.color }) };
-  }
-  if (values && values.borderRight && typeof values.borderRight === 'object' && 'color' in values.borderRight && values.borderRight.color) {
-    values = { ...values, ...(values.borderColor ? { } : { borderColor: values.borderRight.color }) };
-  }
-  if (values && values.borderLeft && typeof values.borderLeft === 'object' && 'color' in values.borderLeft && values.borderLeft.color) {
-    values = { ...values, ...(values.borderColor ? { } : { borderColor: values.borderLeft.color }) };
-  }
-  if (values && values.borderBottom && typeof values.borderBottom === 'object' && 'color' in values.borderBottom && values.borderBottom.color) {
-    values = { ...values, ...(values.borderColor ? { } : { borderColor: values.borderBottom.color }) };
-  }
-  return values;
-}
-
 export function destructureTokenForAlias(tokens: Map<string, AnyTokenList[number]>, values: NodeTokenRefMap): MapValuesToTokensResult {
   if (values && values.composition) {
     const resolvedToken = tokens.get(values.composition);
@@ -216,99 +197,4 @@ export function destructureTokenForAlias(tokens: Map<string, AnyTokenList[number
     values = { ...values, ...(values.borderColor ? { } : { borderColor: values.borderBottom }) };
   }
   return values;
-}
-
-export async function updateNodes(
-  entries: readonly NodeManagerNode[],
-  tokens: Map<string, AnyTokenList[number]>,
-  settings?: SettingsState,
-) {
-  // Big O (n * m): (n = amount of nodes, m = amount of applied tokens to the node)
-  const { ignoreFirstPartForStyles, prefixStylesWithThemeName, baseFontSize } = settings ?? {};
-  const figmaStyleMaps = getAllFigmaStyleMaps();
-  const figmaVariableMaps = getVariablesMap();
-
-  const themeInfo = await AsyncMessageChannel.PluginInstance.message({
-    type: AsyncMessageTypes.GET_THEME_INFO,
-  });
-  postToUI({
-    type: MessageFromPluginTypes.START_JOB,
-    job: {
-      name: BackgroundJobs.PLUGIN_UPDATENODES,
-      timePerTask: 2,
-      completedTasks: 0,
-      totalTasks: entries.length,
-    },
-  });
-
-  const tracker = new ProgressTracker(BackgroundJobs.PLUGIN_UPDATENODES);
-  const promises: Set<Promise<void>> = new Set();
-  const returnedValues: Set<NodeTokenRefMap> = new Set();
-
-  // Store all figmaStyleReferences through all activeThemes (e.g {color.red: ['s.1234'], color.blue ['s.2345', 's.3456']})
-  const figmaStyleReferences: Record<string, string> = {};
-  const figmaVariableReferences: Record<string, string> = {};
-  const activeThemes = themeInfo.themes?.filter((theme) => Object.values(themeInfo.activeTheme).some((v) => v === theme.id));
-
-  activeThemes?.forEach((theme) => {
-    Object.entries(theme.$figmaVariableReferences ?? {}).forEach(([token, variableId]) => {
-      if (!figmaVariableReferences[token]) {
-        figmaVariableReferences[token] = variableId;
-      }
-    });
-    Object.entries(theme.$figmaStyleReferences ?? {}).forEach(([token, styleId]) => {
-      if (!figmaStyleReferences[token]) {
-        figmaStyleReferences[token] = styleId;
-      }
-    });
-  });
-
-  const stylePathPrefix = prefixStylesWithThemeName && activeThemes.length > 0 ? activeThemes[0].name : null;
-
-  // TODO: Instead of passing in figmaStyleReferences as a whole, can we just pass in the matching variable / style instead of having to do the heavy lifting inside setNodeValue?
-
-  entries.forEach((entry) => {
-    promises.add(
-      defaultWorker.schedule(async () => {
-        try {
-          if (entry.tokens) {
-            // TODO: This is probably something we can optimize
-            const mappedTokens = destructureTokenForAlias(tokens, entry.tokens);
-            let mappedValues = mapValuesToTokens(tokens, entry.tokens);
-            mappedValues = destructureToken(mappedValues);
-            setValuesOnNode(
-              entry.node,
-              mappedValues,
-              mappedTokens,
-              figmaStyleMaps,
-              figmaStyleReferences,
-              figmaVariableMaps,
-              figmaVariableReferences,
-              stylePathPrefix,
-              ignoreFirstPartForStyles,
-              baseFontSize,
-            );
-            store.successfulNodes.add(entry.node);
-            returnedValues.add(entry.tokens);
-          }
-        } catch (e) {
-          console.log('got error', e);
-        }
-
-        tracker.next();
-        tracker.reportIfNecessary();
-      }),
-    );
-  });
-  await Promise.all(promises);
-
-  postToUI({
-    type: MessageFromPluginTypes.COMPLETE_JOB,
-    name: BackgroundJobs.PLUGIN_UPDATENODES,
-  });
-  if (returnedValues.size) {
-    return returnedValues.entries().next();
-  }
-
-  return {};
 }

--- a/src/plugin/pluginData.test.tsx
+++ b/src/plugin/pluginData.test.tsx
@@ -1,6 +1,7 @@
 import { mockGetNodeById } from '../../tests/__mocks__/figmaMock';
 import { defaultNodeManager, NodeManagerNode } from './NodeManager';
-import { transformPluginDataToSelectionValues, updatePluginData } from './pluginData';
+import { transformPluginDataToSelectionValues } from './pluginData';
+import { updatePluginData } from './updatePluginData';
 
 describe('pluginData', () => {
   const mockSetPluginData = jest.fn();

--- a/src/plugin/updateNodes.ts
+++ b/src/plugin/updateNodes.ts
@@ -1,0 +1,109 @@
+import store from './store';
+import setValuesOnNode from './setValuesOnNode';
+import { NodeTokenRefMap } from '@/types/NodeTokenRefMap';
+import { NodeManagerNode } from './NodeManager';
+import { postToUI } from './notifiers';
+import { MessageFromPluginTypes } from '@/types/messages';
+import { BackgroundJobs } from '@/constants/BackgroundJobs';
+import { defaultWorker } from './Worker';
+import { getAllFigmaStyleMaps } from '@/utils/getAllFigmaStyleMaps';
+import { ProgressTracker } from './ProgressTracker';
+import { AnyTokenList } from '@/types/tokens';
+import { AsyncMessageChannel } from '@/AsyncMessageChannel';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import { SettingsState } from '@/app/store/models/settings';
+import { getVariablesMap } from '@/utils/getVariablesMap';
+import { destructureTokenForAlias, mapValuesToTokens } from './node';
+
+export async function updateNodes(
+  nodes: readonly NodeManagerNode[],
+  tokens: Map<string, AnyTokenList[number]>,
+  settings?: SettingsState,
+) {
+  // Big O (n * m): (n = amount of nodes, m = amount of applied tokens to the node)
+  const { ignoreFirstPartForStyles, prefixStylesWithThemeName, baseFontSize } = settings ?? {};
+  const figmaStyleMaps = getAllFigmaStyleMaps();
+  const figmaVariableMaps = getVariablesMap();
+
+  const themeInfo = await AsyncMessageChannel.PluginInstance.message({
+    type: AsyncMessageTypes.GET_THEME_INFO,
+  });
+  postToUI({
+    type: MessageFromPluginTypes.START_JOB,
+    job: {
+      name: BackgroundJobs.PLUGIN_UPDATENODES,
+      timePerTask: 2,
+      completedTasks: 0,
+      totalTasks: nodes.length,
+    },
+  });
+
+  const tracker = new ProgressTracker(BackgroundJobs.PLUGIN_UPDATENODES);
+  const promises: Set<Promise<void>> = new Set();
+  const returnedValues: Set<NodeTokenRefMap> = new Set();
+
+  // Store all figmaStyleReferences through all activeThemes (e.g {color.red: ['s.1234'], color.blue ['s.2345', 's.3456']})
+  const figmaStyleReferences: Record<string, string> = {};
+  const figmaVariableReferences: Record<string, string> = {};
+  const activeThemes = themeInfo.themes?.filter((theme) => Object.values(themeInfo.activeTheme).some((v) => v === theme.id));
+
+  activeThemes?.forEach((theme) => {
+    Object.entries(theme.$figmaVariableReferences ?? {}).forEach(([token, variableId]) => {
+      if (!figmaVariableReferences[token]) {
+        figmaVariableReferences[token] = variableId;
+      }
+    });
+    Object.entries(theme.$figmaStyleReferences ?? {}).forEach(([token, styleId]) => {
+      if (!figmaStyleReferences[token]) {
+        figmaStyleReferences[token] = styleId;
+      }
+    });
+  });
+
+  const stylePathPrefix = prefixStylesWithThemeName && activeThemes.length > 0 ? activeThemes[0].name : null;
+
+  nodes.forEach((entry) => {
+    promises.add(
+      defaultWorker.schedule(async () => {
+        try {
+          if (entry.tokens) {
+            const rawTokenMap = destructureTokenForAlias(tokens, entry.tokens);
+            const tokenValues = mapValuesToTokens(tokens, entry.tokens);
+            setValuesOnNode(
+              entry.node,
+              tokenValues,
+              rawTokenMap,
+              figmaStyleMaps,
+              figmaStyleReferences,
+              figmaVariableMaps,
+              figmaVariableReferences,
+              stylePathPrefix,
+              ignoreFirstPartForStyles,
+              baseFontSize,
+            );
+
+            store.successfulNodes.add(entry.node);
+            returnedValues.add(entry.tokens);
+          }
+        } catch (e) {
+          console.log('got error', e);
+        }
+
+        tracker.next();
+        tracker.reportIfNecessary();
+      }),
+    );
+  });
+  await Promise.all(promises);
+
+  postToUI({
+    type: MessageFromPluginTypes.COMPLETE_JOB,
+    name: BackgroundJobs.PLUGIN_UPDATENODES,
+  });
+
+  if (returnedValues.size) {
+    return returnedValues.entries().next();
+  }
+
+  return {};
+}

--- a/src/plugin/updatePluginData.ts
+++ b/src/plugin/updatePluginData.ts
@@ -1,0 +1,118 @@
+import { NodeTokenRefMap } from '@/types/NodeTokenRefMap';
+import { SharedPluginDataNamespaces } from '@/constants/SharedPluginDataNamespaces';
+import { Properties } from '@/constants/Properties';
+import { MessageFromPluginTypes } from '@/types/messages';
+import { BackgroundJobs } from '@/constants/BackgroundJobs';
+import { AnyTokenList } from '@/types/tokens';
+import { postToUI } from './notifiers';
+import { defaultNodeManager, NodeManagerNode } from './NodeManager';
+import { defaultWorker } from './Worker';
+import { ProgressTracker } from './ProgressTracker';
+import { CompositionTokenProperty } from '@/types/CompositionTokenProperty';
+import { removePluginData, setNonePluginData } from './pluginData';
+
+export async function updatePluginData({
+  entries: nodes, values: tokenValues, shouldOverride = false, shouldRemove = true, tokensMap,
+}: { entries: readonly NodeManagerNode[]; values: NodeTokenRefMap; shouldOverride?: boolean; shouldRemove?: boolean; tokensMap?: Map<string, AnyTokenList[number]>; }) {
+  // Big O (n * m): (n = amount of nodes, m = amount of applied tokens to the node)
+  const namespace = SharedPluginDataNamespaces.TOKENS;
+  postToUI({
+    type: MessageFromPluginTypes.START_JOB,
+    job: {
+      name: BackgroundJobs.PLUGIN_UPDATEPLUGINDATA,
+      timePerTask: 2,
+      completedTasks: 0,
+      totalTasks: nodes.length,
+    },
+  });
+
+  const tracker = new ProgressTracker(BackgroundJobs.PLUGIN_UPDATEPLUGINDATA);
+  const promises: Set<Promise<void>> = new Set();
+  nodes.forEach(({ node, tokens }) => {
+    promises.add(defaultWorker.schedule(async () => {
+      const figmaNode = figma.getNodeById(node.id);
+      if (!figmaNode) {
+        console.warn(`Node with ID ${node.id} no longer exists`);
+        return;
+      }
+      const currentValuesOnNode = tokens ?? {};
+      let newValuesOnNode: NodeTokenRefMap = {};
+      if (tokenValues.composition === 'delete') newValuesOnNode = { ...tokenValues, ...currentValuesOnNode, composition: tokenValues.composition };
+      else newValuesOnNode = { ...currentValuesOnNode, ...tokenValues };
+      if (currentValuesOnNode.composition && tokenValues.composition) {
+        // when select another composition token, reset applied properties by current composition token
+        const resolvedToken = tokensMap?.get(currentValuesOnNode.composition);
+        let removeProperties: string[] = [];
+        if (resolvedToken && resolvedToken.rawValue) {
+          removeProperties = Object.keys(resolvedToken.rawValue).map((property) => (
+            property
+          ));
+        }
+        if (removeProperties && removeProperties.length > 0) {
+          await Promise.all(removeProperties.map(async (property) => {
+            await removePluginData({ nodes: [node], key: property as Properties, shouldRemoveValues: shouldRemove });
+          }));
+        }
+        shouldOverride = true;
+      }
+      await Promise.all(Object.entries(newValuesOnNode).map(async ([key, value]) => {
+        if (value === currentValuesOnNode[key as CompositionTokenProperty] && !shouldOverride) {
+          return;
+        }
+
+        const jsonValue = JSON.stringify(value);
+        switch (value) {
+          case 'delete':
+            delete newValuesOnNode[key as CompositionTokenProperty];
+            await removePluginData({ nodes: [node], key: key as Properties, shouldRemoveValues: shouldRemove });
+            break;
+          case 'none':
+            await setNonePluginData({ nodes: [node], key: key as Properties });
+            break;
+          // Pre-Version 53 had horizontalPadding and verticalPadding.
+          case 'horizontalPadding':
+            newValuesOnNode.paddingLeft = jsonValue;
+            newValuesOnNode.paddingRight = jsonValue;
+            node.setSharedPluginData(namespace, Properties.paddingLeft, jsonValue);
+            node.setSharedPluginData(namespace, Properties.paddingRight, jsonValue);
+            break;
+          case 'verticalPadding':
+            newValuesOnNode.paddingTop = jsonValue;
+            newValuesOnNode.paddingBottom = jsonValue;
+            node.setSharedPluginData(namespace, Properties.paddingTop, jsonValue);
+            node.setSharedPluginData(namespace, Properties.paddingBottom, jsonValue);
+            break;
+          default:
+            node.setSharedPluginData(namespace, key, jsonValue);
+            break;
+        }
+      }));
+      await defaultNodeManager.updateNode(node, newValuesOnNode);
+
+      const nodeHasNoValues = Object.keys(newValuesOnNode).length === 0 && newValuesOnNode.constructor === Object;
+      const editRelaunchData = node.getRelaunchData() as {
+        edit?: string;
+      };
+
+      if (!nodeHasNoValues) {
+        const updatedRelaunchData = Object.keys(newValuesOnNode).join(', ');
+        if (updatedRelaunchData !== editRelaunchData.edit) {
+          node.setRelaunchData({
+            edit: updatedRelaunchData,
+          });
+        }
+      } else {
+        node.setRelaunchData({});
+      }
+
+      tracker.next();
+      tracker.reportIfNecessary();
+    }));
+  });
+  await Promise.all(promises);
+
+  postToUI({
+    type: MessageFromPluginTypes.COMPLETE_JOB,
+    name: BackgroundJobs.PLUGIN_UPDATEPLUGINDATA,
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2129

Removes `updatePluginData` calls from the `update` call, as we only used that for migration purposes. We would still do that when users apply tokens or remap tokens, but we won't do anymore on every Apply to.. call

* `src/plugin/asyncMessageHandlers/update.ts`: The `updatePluginData` function is no longer used in the `update.ts` file, so the import statement and call to the function have been removed. (remove `updatePluginData` references in `update.ts`)



https://github.com/tokens-studio/figma-plugin/assets/4548309/57759166-42be-4d1e-878a-89ecc63301f7

