### PR TITLE
fix rename/updatemode and input issues

### DIFF
--- a/.changeset/curly-ravens-prove.md
+++ b/.changeset/curly-ravens-prove.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixes an issue where renaming a token or token group would cause `Apply to` to be changed

--- a/.changeset/rare-cups-join.md
+++ b/.changeset/rare-cups-join.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixes an issue where the choice of `Rename styles` was not remembered per session

--- a/.changeset/young-kangaroos-brake.md
+++ b/.changeset/young-kangaroos-brake.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixes an issue with token edit inputs being focused after a timeout

--- a/src/app/components/ConfirmDialog.tsx
+++ b/src/app/components/ConfirmDialog.tsx
@@ -79,16 +79,13 @@ function ConfirmDialog() {
   }, [chosen, inputValue, confirmState, onConfirm]);
 
   React.useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      if (confirmState.choices) setChosen(confirmState.choices.filter((c) => c.enabled).map((c) => c.key));
-      if (firstInput.current) {
-        firstInput.current.focus();
-      } else if (confirmButton.current) {
-        confirmButton.current.focus();
-      }
-    }, 50);
-    return () => clearTimeout(timeoutId);
-  }, [confirmState.show, confirmButton, confirmState.choices]);
+    if (confirmState.choices) setChosen(confirmState.choices.filter((c) => c.enabled).map((c) => c.key));
+    if (firstInput.current) {
+      firstInput.current.focus();
+    } else if (confirmButton.current) {
+      confirmButton.current.focus();
+    }
+  }, [confirmState.show, confirmButton, confirmState.choices, firstInput]);
 
   return confirmState.show ? (
     <Modal isOpen close={onCancel}>

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -41,6 +41,7 @@ import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
 import { ModalOptions } from '@/constants/ModalOptions';
 
 let lastUsedRenameOption: UpdateMode = UpdateMode.SELECTION;
+let lastUsedRenameStyles = false;
 
 type Props = {
   resolvedTokens: ResolveTokenValuesResult[];
@@ -358,7 +359,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           ];
           if (themes.length > 0 && [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(internalEditToken.type)) {
             choices.push({
-              key: StyleOptions.RENAME, label: 'Rename styles',
+              key: StyleOptions.RENAME, label: 'Rename styles', enabled: lastUsedRenameStyles,
             });
           }
           if (themes.length > 0 && tokenTypesToCreateVariable.includes(internalEditToken.type)) {
@@ -392,6 +393,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
             }
             if (confirmData.data.includes(StyleOptions.RENAME)) {
               renameStylesFromTokens({ oldName, newName, parent: activeTokenSet });
+              lastUsedRenameStyles = true;
             }
             if (confirmData.data.includes(ModalOptions.RENAME_VARIABLE)) {
               renameVariablesFromToken({ oldName, newName });

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -16,7 +16,7 @@ import {
 import { checkIfAlias, checkIfContainsAlias, getAliasValue } from '@/utils/alias';
 import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 import {
-  activeTokenSetSelector, updateModeSelector, editTokenSelector, themesListSelector, tokensSelector,
+  activeTokenSetSelector, editTokenSelector, themesListSelector, tokensSelector,
 } from '@/selectors';
 import { TokenTypes } from '@/constants/TokenTypes';
 import TypographyInput from './TypographyInput';
@@ -40,6 +40,8 @@ import { MultiSelectDropdown } from './MultiSelectDropdown';
 import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
 import { ModalOptions } from '@/constants/ModalOptions';
 
+let lastUsedRenameOption: UpdateMode = UpdateMode.SELECTION;
+
 type Props = {
   resolvedTokens: ResolveTokenValuesResult[];
 };
@@ -53,7 +55,6 @@ function EditTokenForm({ resolvedTokens }: Props) {
   const tokens = useSelector(tokensSelector);
   const editToken = useSelector(editTokenSelector);
   const themes = useSelector(themesListSelector);
-  const updateMode = useSelector(updateModeSelector);
   const [selectedTokenSets, setSelectedTokenSets] = React.useState<string[]>([activeTokenSet]);
   const {
     editSingleToken, createSingleToken, duplicateSingleToken, renameTokensAcrossSets,
@@ -341,18 +342,18 @@ function EditTokenForm({ resolvedTokens }: Props) {
             ...($extensions ? { $extensions } : {}),
           });
         }
-        // When users change token names references are still pointing to the old name, ask user to remap
+        // When users change token names the applied tokens on layers are still pointing to the old name, ask user to remap
         if (oldName && oldName !== newName) {
           track('Edit token', { renamed: true, type: internalEditToken.type });
           const choices: Choice[] = [
             {
-              key: UpdateMode.SELECTION, label: 'Selection', unique: true, enabled: UpdateMode.SELECTION === updateMode,
+              key: UpdateMode.SELECTION, label: 'Selection', unique: true, enabled: UpdateMode.SELECTION === lastUsedRenameOption,
             },
             {
-              key: UpdateMode.PAGE, label: 'Page', unique: true, enabled: UpdateMode.PAGE === updateMode,
+              key: UpdateMode.PAGE, label: 'Page', unique: true, enabled: UpdateMode.PAGE === lastUsedRenameOption,
             },
             {
-              key: UpdateMode.DOCUMENT, label: 'Document', unique: true, enabled: UpdateMode.DOCUMENT === updateMode,
+              key: UpdateMode.DOCUMENT, label: 'Document', unique: true, enabled: UpdateMode.DOCUMENT === lastUsedRenameOption,
             },
           ];
           if (themes.length > 0 && [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(internalEditToken.type)) {
@@ -384,7 +385,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           if (confirmData && confirmData.result) {
             if (confirmData.data.some((data: string) => [UpdateMode.DOCUMENT, UpdateMode.PAGE, UpdateMode.SELECTION].includes(data as UpdateMode))) {
               remapToken(oldName, newName, confirmData.data[0]);
-              dispatch.settings.setUpdateMode(confirmData.data[0]);
+              lastUsedRenameOption = confirmData.data[0] as UpdateMode;
             }
             if (confirmData.data.includes(ModalOptions.RENAME_ACROSS_SETS)) {
               renameTokensAcrossSets(oldName, newName, type, tokenSetsContainsSameToken);

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -184,9 +184,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
 
   React.useEffect(() => {
     if (autofocus && htmlInputRef && htmlInputRef.current) {
-      setTimeout(() => {
-        htmlInputRef.current?.focus();
-      }, 50);
+      htmlInputRef.current.focus();
     }
   }, [autofocus, htmlInputRef]);
 

--- a/src/app/components/TokenTooltip/TokenTooltip.tsx
+++ b/src/app/components/TokenTooltip/TokenTooltip.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { SingleToken } from '@/types/tokens';
 import Tooltip from '../Tooltip';
 import { TokenTooltipContent } from './TokenTooltipContent';
+import { showEditFormSelector } from '@/selectors';
 
 type Props = {
   token: SingleToken;
@@ -11,6 +13,9 @@ export const TokenTooltip: React.FC<Props> = ({
   children,
   token,
 }) => {
+  // When we open the token edit form we don't want tooltips to show through, which is happening sometimes
+  const showEditForm = useSelector(showEditFormSelector);
+
   if (!children || !React.isValidElement(children)) {
     return null;
   }
@@ -18,7 +23,7 @@ export const TokenTooltip: React.FC<Props> = ({
   return (
     <Tooltip
       side="bottom"
-      label={(
+      label={showEditForm ? '' : (
         <TokenTooltipContent
           token={token}
         />

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -49,6 +49,8 @@ type GetFormattedTokensOptions = {
 
 type RemoveTokensByValueData = { property: Properties; nodes: NodeInfo[] }[];
 
+let lastUsedRenameOption: UpdateMode = UpdateMode.SELECTION;
+
 export type SyncOption = 'removeStyle' | 'renameStyle';
 export type SyncVariableOption = 'removeVariable' | 'renameVariable';
 
@@ -198,13 +200,13 @@ export default function useTokens() {
       description: 'This will change all layers that used the old token name. This could take a while.',
       choices: [
         {
-          key: UpdateMode.SELECTION, label: 'Selection', unique: true, enabled: UpdateMode.SELECTION === settings.updateMode,
+          key: UpdateMode.SELECTION, label: 'Selection', unique: true, enabled: UpdateMode.SELECTION === lastUsedRenameOption,
         },
         {
-          key: UpdateMode.PAGE, label: 'Page', unique: true, enabled: UpdateMode.PAGE === settings.updateMode,
+          key: UpdateMode.PAGE, label: 'Page', unique: true, enabled: UpdateMode.PAGE === lastUsedRenameOption,
         },
         {
-          key: UpdateMode.DOCUMENT, label: 'Document', unique: true, enabled: UpdateMode.DOCUMENT === settings.updateMode,
+          key: UpdateMode.DOCUMENT, label: 'Document', unique: true, enabled: UpdateMode.DOCUMENT === lastUsedRenameOption,
         },
         {
           key: 'rename-variable-token-group', label: 'Rename variable',
@@ -214,7 +216,7 @@ export default function useTokens() {
     if (confirmData && confirmData.result) {
       if (Array.isArray(confirmData.data) && confirmData.data.some((data: string) => [UpdateMode.DOCUMENT, UpdateMode.PAGE, UpdateMode.SELECTION].includes(data as UpdateMode))) {
         await handleBulkRemap(newGroupName, oldGroupName, confirmData.data[0]);
-        dispatch.settings.setUpdateMode(confirmData.data[0] as UpdateMode);
+        lastUsedRenameOption = confirmData.data[0] as UpdateMode;
       }
       if (confirmData.data.includes('rename-variable-token-group')) {
         track('renameVariablesInTokenGroup', { newGroupName, oldGroupName });


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2031
Fixes https://github.com/tokens-studio/figma-plugin/issues/2097
Fixes https://github.com/tokens-studio/figma-plugin/issues/1799


This set of changes includes improvements to the user experience and state management, as well as bug fixes. The `ConfirmDialog` and `Input` components were updated to ensure immediate focus on the input element after rendering. The `useTokens` module and `EditTokenForm` component now store the last used update mode when renaming tokens, improving state management and UI. Two bug fixes were also included, related to issues when renaming tokens or token groups.

* `src/app/components/Input.tsx`: `setTimeout` function removed and `focus()` called directly on `htmlInputRef.current` to ensure immediate focus on input element after rendering. (F6c8a7b5L3)
* `src/app/components/ConfirmDialog.tsx`: Improved UX by focusing on first input field after `ConfirmDialog` is shown by removing setTimeout function and adding `firstInput` to useEffect dependencies in `ConfirmDialog.tsx`. (F7d9e2c8L1)
* `src/app/store/useTokens.tsx`: Stores last used update mode when renaming tokens and groups, and UI now defaults to last used update mode instead of current mode. (F5a6b1e4L1)
* `src/app/components/EditTokenForm.tsx`: Stores last used update mode when renaming tokens, ensuring it is selected by default instead of current mode. Improves state management and UI. (F2b5c8f1L1)
* `.changeset/curly-ravens-prove.md` and `.changeset/young-kangaroos-brake.md`: Updated `@tokens-studio/figma-plugin` to fix bug causing issues when renaming tokens or token groups. (Bug fixes) 