### PR TITLE
add network access to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,10 @@
   "editorType": ["figma", "dev"],
   "permissions": ["currentuser"],
   "capabilities": ["codegen"],
+  "networkAccess": {
+    "allowedDomains": ["*"],
+    "reasoning": "We use various external endpoints, read more: https://tokens.studio/figma-plugin-network-access"
+  },
   "codegenLanguages": [
     {
       "label": "Tokens",


### PR DESCRIPTION
fixes https://github.com/tokens-studio/planning/issues/81

adds an entry to manifest.json for networkAccess of the plugin