### PR TITLE
Fix/When we create the variable, collections are created 2 times

### DIFF
--- a/src/plugin/createLocalVariablesInPlugin.ts
+++ b/src/plugin/createLocalVariablesInPlugin.ts
@@ -20,9 +20,8 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
   });
   const allVariableCollectionIds: Record<string, LocalVariableInfo> = {};
   let referenceVariableCandidates: ReferenceVariableType[] = [];
-  const existingVariableCollections = figma.variables.getLocalVariableCollections();
   themeInfo.themes.forEach((theme) => {
-    const collection = existingVariableCollections.find((vr) => vr.name === (theme.group ?? theme.name));
+    const collection = figma.variables.getLocalVariableCollections().find((vr) => vr.name === (theme.group ?? theme.name));
     if (collection) {
       const mode = collection.modes.find((m) => m.name === theme.name);
       const modeId: string = mode?.modeId ?? createVariableMode(collection, theme.name);


### PR DESCRIPTION
Fixed the bug where the variable collections are created 2 times in the epic branch.
In the epic branch, 2 collections are created.

![image](https://github.com/tokens-studio/figma-plugin/assets/25951419/8903d7ff-2215-455c-9c76-6cbe98f9bf9a)
![image](https://github.com/tokens-studio/figma-plugin/assets/25951419/51a4abc3-0740-4c54-bf28-5f461826a524)

Fixed so that there will be only one collection.
![image](https://github.com/tokens-studio/figma-plugin/assets/25951419/f25b44fa-55c4-4693-81dd-47bc011bf6ac)
