### PR TITLE
remove skip inv instance children

### DIFF
--- a/.changeset/invisible-children.md
+++ b/.changeset/invisible-children.md
@@ -1,0 +1,4 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+We now no longer ignore invisible instance children from updating, as we're no longer relying on a Cache. This means you can start using `boolean` tokens in instances.

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -10,8 +10,6 @@ import { init } from '@/utils/plugin';
 import { sendDocumentChange } from './sendDocumentChange';
 import { performCodeGen } from './performCodeGen';
 
-figma.skipInvisibleInstanceChildren = true;
-
 AsyncMessageChannel.PluginInstance.connect();
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CREDENTIALS, asyncHandlers.credentials);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CHANGED_TABS, asyncHandlers.changedTabs);


### PR DESCRIPTION
Removes the flag to skip invisible instance children given we no longer use a cache this now allows users to use boolean tokens on instances. Perf hit isnt an issue as we only operate on nodes that have pluginData stored.