### PR TITLE
fixes minwidth instance overrides

### DIFF
--- a/.changeset/rare-seals-pump.md
+++ b/.changeset/rare-seals-pump.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes a bug that caused nodes to not get updates when min/max width tokens were applied on instances, which caused any subsequent updates to this node to fail. We now ignore instances for min/max width tokens, as they are unsupported by Figma.

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -262,7 +262,7 @@ export default async function setValuesOnNode(
       }
 
       // min width, max width, min height, max height only are applicable to autolayout frames or their direct children
-      if (node.type !== 'DOCUMENT' && node.type !== 'PAGE' && (isAutoLayout(node) || (node.parent && node.parent.type !== 'DOCUMENT' && node.parent.type !== 'PAGE' && isAutoLayout(node.parent)))) {
+      if (node.type !== 'DOCUMENT' && node.type !== 'PAGE' && node.type !== 'INSTANCE' && (isAutoLayout(node) || (node.parent && node.parent.type !== 'DOCUMENT' && node.parent.type !== 'PAGE' && isAutoLayout(node.parent)))) {
         // SIZING: MIN WIDTH
         if ('minWidth' in node && typeof values.minWidth !== 'undefined' && typeof data.minWidth !== 'undefined' && isPrimitiveValue(values.minWidth)) {
           if (!(await tryApplyVariableId(node, 'minWidth', data.minWidth, figmaVariableReferences))) {


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2182
Fixes https://github.com/tokens-studio/figma-plugin/issues/2209

This change to `src/plugin/setValuesOnNode.ts` excludes instances from sizing property checks in the `setValuesOnNode` function, ensuring they only apply to autolayout frames or their direct children, and not instances which would throw an error.

![CleanShot 2023-09-14 at 08 37 34](https://github.com/tokens-studio/figma-plugin/assets/4548309/225cdce2-358a-4489-88b9-7d52efcd587a)
