### PR TITLE
fix: box shadow array values

### DIFF
--- a/.changeset/six-berries-exist.md
+++ b/.changeset/six-berries-exist.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixes a bug that caused shadow tokens that were using array values to not get a value if they were redefined in another token set

--- a/src/utils/__tests__/mergeTokenGroups.test.ts
+++ b/src/utils/__tests__/mergeTokenGroups.test.ts
@@ -1,6 +1,7 @@
 import { TokenTypes } from '@/constants/TokenTypes';
 import { mergeTokenGroups } from '@/utils/tokenHelpers';
 import { AnyTokenList, SingleToken } from '@/types/tokens';
+import { BoxShadowTypes } from '@/constants/BoxShadowTypes';
 
 describe('mergeTokenGroups', () => {
   it('merges all token groups into a single list overriding the previous set from left to right', () => {
@@ -25,6 +26,28 @@ describe('mergeTokenGroups', () => {
             height: 100,
           },
         },
+        {
+          type: TokenTypes.BOX_SHADOW,
+          name: 'shadow.large',
+          value: [
+            {
+              type: BoxShadowTypes.DROP_SHADOW,
+              color: '#000000',
+              x: 0,
+              y: 0,
+              blur: 32,
+              spread: 0,
+            },
+            {
+              type: BoxShadowTypes.INNER_SHADOW,
+              color: '#000000',
+              x: 0,
+              y: 0,
+              blur: 16,
+              spread: 0,
+            },
+          ],
+        },
       ],
       v1: [
         {
@@ -38,6 +61,28 @@ describe('mergeTokenGroups', () => {
           value: {
             fill: '{color.secondary}',
           },
+        },
+        {
+          type: TokenTypes.BOX_SHADOW,
+          name: 'shadow.large',
+          value: [
+            {
+              type: BoxShadowTypes.DROP_SHADOW,
+              color: '#ffffff',
+              x: 0,
+              y: 0,
+              blur: 32,
+              spread: 0,
+            },
+            {
+              type: BoxShadowTypes.INNER_SHADOW,
+              color: '#ffffff',
+              x: 0,
+              y: 0,
+              blur: 16,
+              spread: 0,
+            },
+          ],
         },
       ],
     };
@@ -58,6 +103,29 @@ describe('mergeTokenGroups', () => {
           borderRadius: 32,
           height: 100,
         },
+      },
+      {
+        internal__Parent: 'v1',
+        type: TokenTypes.BOX_SHADOW,
+        name: 'shadow.large',
+        value: [
+          {
+            type: BoxShadowTypes.DROP_SHADOW,
+            color: '#ffffff',
+            x: 0,
+            y: 0,
+            blur: 32,
+            spread: 0,
+          },
+          {
+            type: BoxShadowTypes.INNER_SHADOW,
+            color: '#ffffff',
+            x: 0,
+            y: 0,
+            blur: 16,
+            spread: 0,
+          },
+        ],
       },
       {
         internal__Parent: 'v0',

--- a/src/utils/tokenHelpers.ts
+++ b/src/utils/tokenHelpers.ts
@@ -146,7 +146,9 @@ export function mergeTokenGroups(tokens: Record<string, SingleToken[]>, usedSets
               internal__Parent: tokenGroup[0],
             } as SingleToken);
           }
-          if (mergedTokenIndex > -1 && typeof mergedToken.value === 'object' && typeof token.value === 'object') {
+          if (mergedTokenIndex > -1 && Array.isArray(mergedToken.value) && Array.isArray(token.value)) {
+            mergedTokens.splice(mergedTokenIndex, 1, mergedToken);
+          } else if (mergedTokenIndex > -1 && typeof mergedToken.value === 'object' && typeof token.value === 'object') {
             mergedTokens.splice(mergedTokenIndex, 1, {
               ...mergedToken,
               value: {


### PR DESCRIPTION
This fixes an issue where we did merge token sets in a wrong way. Previously, we'd merge tokens itself if they were of type `object`, but we didn't check specifically if it's an array. In the case of an array, merging is the wrong thing, we need to just replace it. This caused some tokens to not get any value if there was another set that had the same token (e.g. box shadows)

This pull request to the codebase improves the functionality and testing of the `mergeTokenGroups` function and fixes a bug related to shadow tokens with array values not being properly defined.

* `src/utils/__tests__/mergeTokenGroups.test.ts`: Updated test file to include new box shadow tokens and test their functionality with array values and multiple token sets. (<a href="diffhunk://#diff-c2addc55ccbc37a8c635fc2db401f60d1672788b6bb39ed9242a3a23d1e604dfR4">src/utils/__tests__/mergeTokenGroups.test.tsR4</a>, <a href="diffhunk://#diff-c2addc55ccbc37a8c635fc2db401f60d1672788b6bb39ed9242a3a23d1e604dfR29-R50">src/utils/__tests__/mergeTokenGroups.test.tsR29-R50</a>, <a href="diffhunk://#diff-c2addc55ccbc37a8c635fc2db401f60d1672788b6bb39ed9242a3a23d1e604dfR65-R86">src/utils/__tests__/mergeTokenGroups.test.tsR65-R86</a>, <a href="diffhunk://#diff-c2addc55ccbc37a8c635fc2db401f60d1672788b6bb39ed9242a3a23d1e604dfR107-R129">src/utils/__tests__/mergeTokenGroups.test.tsR107-R129</a>)
* `src/utils/tokenHelpers.ts`: Changed condition for merging tokens with object values to check if both tokens have array values, and if so, the merged token is updated with the new array value. (<a href="diffhunk://#diff-9cd965142d180e40b946c513140eb6092721ecfae029c7e0316489494b42a5fcL149-R151">src/utils/tokenHelpers.tsL149-R151</a>)