### PR TITLE
Fix inspect being unresponsive

### DIFF
--- a/.changeset/famous-flies-cover.md
+++ b/.changeset/famous-flies-cover.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixed a bug where Inspect would become unresponsive if you had a shadow and a background blur applied on the same node

--- a/src/plugin/getAppliedStylesFromNode.ts
+++ b/src/plugin/getAppliedStylesFromNode.ts
@@ -22,17 +22,18 @@ export default function getAppliedStylesFromNode(node: BaseNode): SelectionStyle
     const styleIdBackupKey = 'effectStyleId_original';
     const localStyle = getLocalStyle(node, styleIdBackupKey, 'effects');
     if (localStyle) {
-      const effects = localStyle.effects as DropShadowEffect[];
+      const effects = localStyle.effects as Effect[];
       // convert paint to object containg x, y, spread, color
-      const shadows: TokenBoxshadowValue[] = effects.map((effect) => {
+      const shadows: TokenBoxshadowValue[] = effects.filter((effect) => effect.type === 'DROP_SHADOW' || effect.type === 'INNER_SHADOW').map((effect) => {
+        const rootEffect = effect as DropShadowEffect | InnerShadowEffect;
         const effectObject: TokenBoxshadowValue = {} as TokenBoxshadowValue;
 
-        effectObject.color = figmaRGBToHex(effect.color);
-        effectObject.type = convertBoxShadowTypeFromFigma(effect.type);
-        effectObject.x = effect.offset.x;
-        effectObject.y = effect.offset.y;
-        effectObject.blur = effect.radius;
-        effectObject.spread = effect.spread || 0;
+        effectObject.color = figmaRGBToHex(rootEffect.color);
+        effectObject.type = convertBoxShadowTypeFromFigma(rootEffect.type);
+        effectObject.x = rootEffect.offset.x;
+        effectObject.y = rootEffect.offset.y;
+        effectObject.blur = rootEffect.radius;
+        effectObject.spread = rootEffect.spread || 0;
 
         return effectObject;
       });
@@ -43,6 +44,7 @@ export default function getAppliedStylesFromNode(node: BaseNode): SelectionStyle
           .map((section) => section.trim())
           .join('.');
 
+        // TODO: Handle backgroundBlur here. Right now we're skipping it
         const styleObject: SelectionStyle = {
           value: shadows.length > 1 ? shadows : shadows[0],
           type: Properties.boxShadow,

--- a/src/plugin/getAppliedStylesFromNode.ts
+++ b/src/plugin/getAppliedStylesFromNode.ts
@@ -21,10 +21,10 @@ export default function getAppliedStylesFromNode(node: BaseNode): SelectionStyle
   if ('effects' in node) {
     const styleIdBackupKey = 'effectStyleId_original';
     const localStyle = getLocalStyle(node, styleIdBackupKey, 'effects');
-    if (localStyle) {
+    if (localStyle && localStyle.effects.every((effect) => effect.type === 'DROP_SHADOW' || effect.type === 'INNER_SHADOW')) {
       const effects = localStyle.effects as Effect[];
       // convert paint to object containg x, y, spread, color
-      const shadows: TokenBoxshadowValue[] = effects.filter((effect) => effect.type === 'DROP_SHADOW' || effect.type === 'INNER_SHADOW').map((effect) => {
+      const shadows: TokenBoxshadowValue[] = effects.map((effect) => {
         const rootEffect = effect as DropShadowEffect | InnerShadowEffect;
         const effectObject: TokenBoxshadowValue = {} as TokenBoxshadowValue;
 
@@ -44,7 +44,6 @@ export default function getAppliedStylesFromNode(node: BaseNode): SelectionStyle
           .map((section) => section.trim())
           .join('.');
 
-        // TODO: Handle backgroundBlur here. Right now we're skipping it
         const styleObject: SelectionStyle = {
           value: shadows.length > 1 ? shadows : shadows[0],
           type: Properties.boxShadow,

--- a/src/plugin/removeValuesFromNode.ts
+++ b/src/plugin/removeValuesFromNode.ts
@@ -79,6 +79,11 @@ export default function removeValuesFromNode(node: BaseNode, prop: Properties) {
         node.effects = node.effects.filter((effect) => effect.type !== 'DROP_SHADOW');
       }
       break;
+    case 'backgroundBlur':
+      if ('effects' in node && typeof node.effects !== 'undefined') {
+        node.effects = node.effects.filter((effect) => effect.type !== 'BACKGROUND_BLUR');
+      }
+      break;
     case 'opacity':
       if (
         'opacity' in node


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2205

The bug was basically caused by us trying to read effect values on a style, and expected those to be only of type `dropShadow` or `innerShadow` - however styles can also contain backgroundblur, which doesnt share the same object schema, causing an error when trying to parse those colors.

Changed it so that we only show styles which are of type shadow