### PR TITLE
fix mentions input color

### DIFF
--- a/.changeset/happy-penguins-work.md
+++ b/.changeset/happy-penguins-work.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes an issue where the token picker didn't show an active state when highlighted

--- a/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
+++ b/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
@@ -43,7 +43,7 @@ export const StyledList = styled(List, {
 });
 
 export const StyledItemValue = styled('div', {
-  color: '$fgMuted',
+  color: 'var(--mentions-color-muted, var(--colors-fgMuted))',
   fontWeight: '$bold',
   textAlign: 'right',
   maxWidth: '300px',

--- a/src/app/components/DownshiftInput/mentions.css
+++ b/src/app/components/DownshiftInput/mentions.css
@@ -3,6 +3,7 @@
   display: inline-block;
   position: relative;
   white-space: pre-wrap;
+  --mentions-color-muted: var(--colors-fgSubtle);
 }
 
 .rc-mentions > textarea,
@@ -65,9 +66,10 @@
   list-style-type: none;
   font-size: var(--fontSizes-small);
   padding: var(--space-2);
-  border-radius: var(--radii-contextMenu);
+  border: '1px solid var(--colors-borderMuted)';
+  border-radius: var(--radii-medium);
   box-shadow: var(--shadows-contextMenu);
-  background: var(--colors-bgDefault);
+  background: var(--colors-contextMenuBg);
   cursor: pointer;
   z-index: 10;
 }
@@ -76,14 +78,17 @@
   width: 100%;
   min-width: 150px;
   position: relative;
+  border-radius: var(--radii-small);
 }
 
 .rc-mentions-dropdown-menu-item:focus {
-  background: var(--colors-interaction);
+  background: var(--colors-accentEmphasis);
+  --mentions-color-muted: var(--colors-fgOnEmphasis);
 }
 
 .rc-mentions-dropdown-menu-item-active {
-  background: var(--colors-interaction);
+  background: var(--colors-accentEmphasis);
+  --mentions-color-muted: var(--colors-fgOnEmphasis);
 }
 
 /* width */
@@ -93,7 +98,7 @@
 
 /* Track */
 .rc-mentions-dropdown-menu::-webkit-scrollbar-track {
-  background: var(--canvas-Muted);
+  background: var(--bgSubtle);
 }
 
 /* Handle */


### PR DESCRIPTION
Fixes our `Mentions` input to have a proper focus bg again.
Before

<img width="451" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/df116a0c-42a4-4ad4-ab5e-5d1fd7dec71d">

After

<img width="432" alt="CleanShot 2023-09-18 at 19 19 01@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/bcc44f36-26a0-4e79-921e-dcaa8e8ac50a">
