### PR TITLE
fix minwidth on instance children

### DIFF
--- a/.changeset/great-taxis-grow.md
+++ b/.changeset/great-taxis-grow.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixes an issue where min width tokens would stop tokens from being applied if part of an instance

--- a/src/plugin/__tests__/setValuesOnNode.test.ts
+++ b/src/plugin/__tests__/setValuesOnNode.test.ts
@@ -23,6 +23,7 @@ describe('Can set values on node', () => {
 
   beforeEach(() => {
     textNodeMock = ({
+      id: '123:456',
       type: 'TEXT',
       characters: 'foobar',
       fontName: {
@@ -36,6 +37,7 @@ describe('Can set values on node', () => {
     } as unknown) as TextNode;
 
     solidNodeMock = ({
+      id: '123:457',
       type: 'RECTANGLE',
       cornerRadius: 0,
       topLeftRadius: 0,
@@ -57,6 +59,7 @@ describe('Can set values on node', () => {
     } as unknown) as RectangleNode;
 
     frameNodeMock = ({
+      id: '123:458',
       type: 'FRAME',
       paddingLeft: 0,
       paddingTop: 0,
@@ -643,6 +646,7 @@ describe('Can set values on node', () => {
   it('should resize when dimension token applied to the node which has no itemSpacing property', async () => {
     const mockResize = jest.fn();
     const mockNode = {
+      id: '123:521',
       resize: mockResize,
     } as unknown as RectangleNode;
     const values = {
@@ -656,6 +660,7 @@ describe('Can set values on node', () => {
   it('should set itemSpacing when dimension token applied to the node which has itemSpacing property', async () => {
     const mockResize = jest.fn();
     const mockNode = {
+      id: '123:521',
       resize: mockResize,
       itemSpacing: 0,
       primaryAxisAlignItems: 'SPACE_BETWEEN',
@@ -710,6 +715,7 @@ describe('Can set values on node', () => {
   it('should resize when number token applied to the node which has no itemSpacing property', async () => {
     const mockResize = jest.fn();
     const mockNode = {
+      id: '123:522',
       resize: mockResize,
     } as unknown as RectangleNode;
     const values = {
@@ -723,6 +729,7 @@ describe('Can set values on node', () => {
   it('should set itemSpacing when number token applied to the node which has itemSpacing property', async () => {
     const mockResize = jest.fn();
     const mockNode = {
+      id: '123:521',
       resize: mockResize,
       itemSpacing: 0,
       primaryAxisAlignItems: 'SPACE_BETWEEN',

--- a/src/plugin/setValuesOnNode.test.ts
+++ b/src/plugin/setValuesOnNode.test.ts
@@ -11,12 +11,14 @@ describe('setValuesOnNode', () => {
       bottomRightRadius: 3,
       topLeftRadius: 3,
       topRightRadius: 3,
+      id: '123:456',
     } as RectangleNode;
     frameNodeMock = {
       paddingBottom: 3,
       paddingLeft: 3,
       paddingRight: 3,
       paddingTop: 3,
+      id: '123:457',
     } as FrameNode;
   });
   const data = {
@@ -31,6 +33,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(textNodeMock, borderRadiusTokenWithOneValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
+      ...textNodeMock,
       cornerRadius: 10,
       bottomLeftRadius: 3,
       bottomRightRadius: 3,
@@ -45,6 +48,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(textNodeMock, borderRadiusTokenWithTwoValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
+      ...textNodeMock,
       cornerRadius: 3,
       bottomLeftRadius: 20,
       bottomRightRadius: 10,
@@ -59,6 +63,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(textNodeMock, borderRadiusTokenWithThreeValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
+      ...textNodeMock,
       cornerRadius: 3,
       bottomLeftRadius: 20,
       bottomRightRadius: 30,
@@ -73,6 +78,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(textNodeMock, borderRadiusTokenWithFourValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
+      ...textNodeMock,
       cornerRadius: 3,
       bottomLeftRadius: 40,
       bottomRightRadius: 30,
@@ -87,6 +93,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(textNodeMock, borderRadiusTokenWithFiveValue, data, figmaStyleMaps);
     expect(textNodeMock).toEqual({
+      ...textNodeMock,
       cornerRadius: 3,
       bottomLeftRadius: 3,
       bottomRightRadius: 3,
@@ -101,6 +108,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(frameNodeMock, spacingTokenWithOneValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
+      ...frameNodeMock,
       paddingBottom: 10,
       paddingLeft: 10,
       paddingRight: 10,
@@ -114,6 +122,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(frameNodeMock, spacingTokenWithTwoValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
+      ...frameNodeMock,
       paddingBottom: 10,
       paddingLeft: 20,
       paddingRight: 20,
@@ -127,6 +136,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(frameNodeMock, spacingTokenWithThreeValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
+      ...frameNodeMock,
       paddingBottom: 30,
       paddingLeft: 20,
       paddingRight: 20,
@@ -140,6 +150,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(frameNodeMock, spacingTokenWithFourValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
+      ...frameNodeMock,
       paddingBottom: 30,
       paddingLeft: 40,
       paddingRight: 20,
@@ -153,6 +164,7 @@ describe('setValuesOnNode', () => {
     };
     await setValuesOnNode(frameNodeMock, spacingTokenWithFiveValue, data, figmaStyleMaps);
     expect(frameNodeMock).toEqual({
+      ...frameNodeMock,
       paddingBottom: 3,
       paddingLeft: 3,
       paddingRight: 3,

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -30,6 +30,7 @@ import { tryApplyVariableId } from '@/utils/tryApplyVariableId';
 import { ColorPaintType, tryApplyColorVariableId } from '@/utils/tryApplyColorVariableId';
 import { VariableReferenceMap } from '@/types/VariableReferenceMap';
 import { RawVariableReferenceMap } from '@/types/RawVariableReferenceMap';
+import { isPartOfInstance } from '@/utils/is/isPartOfInstance';
 
 // @README values typing is wrong
 
@@ -262,7 +263,7 @@ export default async function setValuesOnNode(
       }
 
       // min width, max width, min height, max height only are applicable to autolayout frames or their direct children
-      if (node.type !== 'DOCUMENT' && node.type !== 'PAGE' && node.type !== 'INSTANCE' && (isAutoLayout(node) || (node.parent && node.parent.type !== 'DOCUMENT' && node.parent.type !== 'PAGE' && isAutoLayout(node.parent)))) {
+      if (node.type !== 'DOCUMENT' && node.type !== 'PAGE' && node.type !== 'INSTANCE' && !isPartOfInstance(node.id) && (isAutoLayout(node) || (node.parent && node.parent.type !== 'DOCUMENT' && node.parent.type !== 'PAGE' && isAutoLayout(node.parent)))) {
         // SIZING: MIN WIDTH
         if ('minWidth' in node && typeof values.minWidth !== 'undefined' && typeof data.minWidth !== 'undefined' && isPrimitiveValue(values.minWidth)) {
           if (!(await tryApplyVariableId(node, 'minWidth', data.minWidth, figmaVariableReferences))) {

--- a/src/utils/is/isPartOfInstance.ts
+++ b/src/utils/is/isPartOfInstance.ts
@@ -1,0 +1,3 @@
+export function isPartOfInstance(nodeId: string) {
+  return nodeId.startsWith('I');
+}


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2270

This pull request includes changes to improve the functionality of a Figma plugin. The most important changes include adding a new function to check if a node is part of an instance, and updating a file to include a patch version for a dependency that fixes an issue with min width tokens in instances.

Main code changes:

* <a href="diffhunk://#diff-4ff7114e0f959bb00bfb7f861178407900b5158b1b2baab191f38be35e281970R33">`src/plugin/setValuesOnNode.ts`</a>: The `setValuesOnNode` function now checks if a node is part of an instance before applying min/max width/height values, using the `isPartOfInstance` function. <a href="diffhunk://#diff-4ff7114e0f959bb00bfb7f861178407900b5158b1b2baab191f38be35e281970R33">[1]</a> <a href="diffhunk://#diff-4ff7114e0f959bb00bfb7f861178407900b5158b1b2baab191f38be35e281970L265-R266">[2]</a>
* <a href="diffhunk://#diff-be4f030682db512a1c0934cb4be5060546af00befd8c9df58c96a9bd49014b1cR1-R3">`src/utils/is/isPartOfInstance.ts`</a>: Added `isPartOfInstance` function to check if a given `nodeId` starts with the character 'I', indicating that the node is part of an instance.

Dependency updates:

* <a href="diffhunk://#diff-ab70dd7c56f03fc56adfe3a850b99db819dd74b6fc5cc98ca7784546e9b6b163R1-R5">`.changeset/great-taxis-grow.md`</a>: Updated file to include a patch version for `@tokens-studio/figma-plugin` that fixes an issue with min width tokens preventing application within instances. 