### PR TITLE
fix: documentation tokens

### DIFF
--- a/.changeset/curvy-laws-attend.md
+++ b/.changeset/curvy-laws-attend.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixes a bug that caused raw value documentation tokens to stop working


### PR DESCRIPTION
This pull request includes changes to the `mapValuesToTokens` function in `src/plugin/node.ts` to modify the way descriptions and modifiers are added to tokens. 

* <a href="diffhunk://#diff-d2f51661f1da6b8ef9b60d8b500bad2293d880dccf9bea47ac00df746a8183e5R72-R81">`src/plugin/node.ts`</a>: Updated `mapValuesToTokens` function to modify the way descriptions and modifiers are added to tokens. <a href="diffhunk://#diff-d2f51661f1da6b8ef9b60d8b500bad2293d880dccf9bea47ac00df746a8183e5R72-R81">[1]</a> <a href="diffhunk://#diff-d2f51661f1da6b8ef9b60d8b500bad2293d880dccf9bea47ac00df746a8183e5L58-R58">[2]</a>
