### PR TITLE
fix onboarding links

### DIFF
--- a/.changeset/selfish-lobsters-flash.md
+++ b/.changeset/selfish-lobsters-flash.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Fixed some of the onboarding links pointing to a 404

--- a/src/app/components/InspectorMultiView.tsx
+++ b/src/app/components/InspectorMultiView.tsx
@@ -27,7 +27,7 @@ export default function InspectorMultiView({ resolvedTokens, tokenToSearch }: { 
   const onboardingData = {
     title: t('inspect'),
     text: t('inspectOnboard'),
-    url: 'https://docs.figmatokens.com/inspect/multi-inspect?ref=onboarding_explainer_inspect',
+    url: 'https://docs.tokens.studio/inspect/multi-inspect?ref=onboarding_explainer_inspect',
   };
 
   const inspectState = useSelector(inspectStateSelector, isEqual);

--- a/src/app/components/Settings/Settings.tsx
+++ b/src/app/components/Settings/Settings.tsx
@@ -33,7 +33,7 @@ function Settings() {
   const onboardingData = {
     title: t('whereTokensStored'),
     text: t('whereTokensStoredOnboarding'),
-    url: 'https://docs.figmatokens.com/sync/sync?ref=onboarding_explainer_syncproviders',
+    url: 'https://docs.tokens.studio/sync/sync?ref=onboarding_explainer_syncproviders',
   };
 
   const { removeRelaunchData } = useDebug();

--- a/src/app/components/TokenSetSelector.tsx
+++ b/src/app/components/TokenSetSelector.tsx
@@ -39,7 +39,7 @@ export default function TokenSetSelector({ saveScrollPositionSet }: { saveScroll
   const onboardingData = {
     title: t('sets.title'),
     text: t('sets.description'),
-    url: 'https://docs.figmatokens.com/themes/token-sets?ref=onboarding_explainer_sets',
+    url: 'https://docs.tokens.studio/themes/token-sets?ref=onboarding_explainer_sets',
   };
 
   const tokens = useSelector(tokensSelector);


### PR DESCRIPTION
This pull request updates URLs in several components to point to a new domain, `docs.tokens.studio`, instead of the old domain, `docs.figmatokens.com`. A

* `src/app/components/Settings/Settings.tsx`: Updated `onboardingData` object's `url` property to point to a new URL in `docs.tokens.studio` domain. (Ff9d8573L3R3)
* `src/app/components/InspectorMultiView.tsx`: Updated `onboardingData` object's `url` property to point to a new URL in `docs.tokens.studio` domain. (Ff4d8573L3R3)
* `src/app/components/TokenSetSelector.tsx`: Updated `onboardingData` object's `url` property to point to a new URL in `docs.tokens.studio` domain. (Ff8d8573L3R3)