### PR TITLE
Reintroduce support for nested references

### DIFF
--- a/.changeset/new-beers-visit.md
+++ b/.changeset/new-beers-visit.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': patch
+---
+
+Reintroduces support for nested references (use at your own risk, this affects performance)

--- a/.changeset/new-beers-visit.md
+++ b/.changeset/new-beers-visit.md
@@ -2,4 +2,4 @@
 '@tokens-studio/figma-plugin': patch
 ---
 
-Reintroduces support for nested references (use at your own risk, this affects performance)
+Reintroduces support for nested references for 1 level deep (use at your own risk, this affects performance). For example, you can use `{colors.{primary}.500}` but not `{colors.{brand.{primary}}}`.

--- a/src/constants/AliasRegex.ts
+++ b/src/constants/AliasRegex.ts
@@ -2,6 +2,6 @@
 export const checkAliasStartRegex = /(\$[^\s,]+\w)|({([^]*))/g;
 
 // evaluates tokens such as $foo or {foo}
-export const AliasRegex = /(?:\$([^\s,]+\w))|(?:{([^}]*)})/g;
+export const AliasRegex = /\{((?:[^{}]|{[^{}]*})*)\}|(\$[a-zA-Z0-9_.]+)/g;
 
 export const AliasDollarRegex = /(?:\$([^\s,]+\w))/g;

--- a/src/constants/AliasRegex.ts
+++ b/src/constants/AliasRegex.ts
@@ -2,6 +2,6 @@
 export const checkAliasStartRegex = /(\$[^\s,]+\w)|({([^]*))/g;
 
 // evaluates tokens such as $foo or {foo}
-export const AliasRegex = /\{((?:[^{}]|{[^{}]*})*)\}|(\$[a-zA-Z0-9_.]+)/g;
+export const AliasRegex = /\{((?:[^{}]|{[^{}]*})*)\}|(?:\$([^\s,]+\w))/g;
 
 export const AliasDollarRegex = /(?:\$([^\s,]+\w))/g;

--- a/src/utils/TokenResolver.test.ts
+++ b/src/utils/TokenResolver.test.ts
@@ -216,6 +216,31 @@ const tokens = [
     value: '{typography.all.fontFamily}',
     type: TokenTypes.FONT_FAMILIES,
   },
+  {
+    name: 'colors.lilac.500',
+    value: '#ff0000',
+    type: TokenTypes.COLOR,
+  },
+  {
+    name: 'primary',
+    value: 'lilac',
+    type: TokenTypes.OTHER,
+  },
+  {
+    name: 'nestedprimary',
+    value: '{primary}',
+    type: TokenTypes.OTHER,
+  },
+  {
+    name: 'thatprimarycolor',
+    value: '{colors.{primary}.500}',
+    type: TokenTypes.COLOR,
+  },
+  {
+    name: 'thatnestedprimarycolor',
+    value: '{colors.{nestedprimary}.500}',
+    type: TokenTypes.COLOR,
+  },
 ];
 
 const output = [
@@ -467,6 +492,36 @@ const output = [
     value: 'IBM Plex Sans',
     rawValue: '{typography.all.fontFamily}',
     type: TokenTypes.FONT_FAMILIES,
+  },
+  {
+    name: 'colors.lilac.500',
+    value: '#ff0000',
+    rawValue: '#ff0000',
+    type: TokenTypes.COLOR,
+  },
+  {
+    name: 'primary',
+    value: 'lilac',
+    rawValue: 'lilac',
+    type: TokenTypes.OTHER,
+  },
+  {
+    name: 'nestedprimary',
+    value: 'lilac',
+    rawValue: '{primary}',
+    type: TokenTypes.OTHER,
+  },
+  {
+    name: 'thatprimarycolor',
+    value: '#ff0000',
+    rawValue: '{colors.{primary}.500}',
+    type: TokenTypes.COLOR,
+  },
+  {
+    name: 'thatnestedprimarycolor',
+    value: '#ff0000',
+    rawValue: '{colors.{nestedprimary}.500}',
+    type: TokenTypes.COLOR,
   },
 ];
 describe('resolveTokenValues deep nested', () => {

--- a/src/utils/TokenResolver.ts
+++ b/src/utils/TokenResolver.ts
@@ -124,14 +124,39 @@ class TokenResolver {
           } as ResolveTokenValuesResult;
         }
 
+        // Users can nest references, so we need to make sure to resolve any nested references first.
+        let resolvedPath = path;
+        let matches: boolean = true;
+
+        // As long as we have matches, we need to resolve them. This is needed for multiple levels of nesting. Performance will suffer, but that's the user's choice.
+        while (matches !== false) {
+          const match = resolvedPath.match(AliasRegex);
+          matches = false;
+          if (!match?.length) {
+            matches = false;
+            break;
+          }
+
+          const nestedTokenName = getPathName(match[0]);
+          const nestedTokenValue = this.tokenMap.get(nestedTokenName);
+
+          if (nestedTokenValue) {
+            const resolvedNestedToken = this.resolveReferences({ ...nestedTokenValue, name: nestedTokenName } as SingleToken, new Set(resolvedReferences));
+
+            if (typeof resolvedNestedToken.value === 'string') {
+              resolvedPath = resolvedPath.replace(match[0], resolvedNestedToken.value);
+            }
+          }
+        }
+
         // We have the special case of deep references where we can reference the .fontFamily property of a typography token.
         // For that case, we need to split the path and get the last part, which might be the property name.
         // However, it might not be. If we have a token called "color.primary" and we reference "color.primary.fontFamily", we need to check if "color.primary" exists. If it does, we prefer to return that one.
         // If it doesn't it might be a composite token where we want to return the atomic property
-        const propertyPath = path.split('.');
+        const propertyPath = resolvedPath.split('.');
         const propertyName = propertyPath.pop() as string;
         const tokenNameWithoutLastPart = propertyPath.join('.');
-        const foundToken = this.tokenMap.get(path);
+        const foundToken = this.tokenMap.get(resolvedPath);
 
         if (foundToken) {
           // We add the already resolved references to the new set, so we can check for circular references

--- a/src/utils/TokenResolver.ts
+++ b/src/utils/TokenResolver.ts
@@ -132,20 +132,19 @@ class TokenResolver {
         while (matches !== false) {
           const match = resolvedPath.match(AliasRegex);
           matches = Boolean(match?.length);
-          if (!match?.length) {
-            matches = false;
-            break;
-          }
+          if (!match?.length) break;
 
           const nestedTokenName = getPathName(match[0]);
-          const nestedTokenValue = this.tokenMap.get(nestedTokenName);
+          const nestedToken = this.tokenMap.get(nestedTokenName);
 
-          if (nestedTokenValue) {
-            const resolvedNestedToken = this.resolveReferences({ ...nestedTokenValue, name: nestedTokenName } as SingleToken, new Set(resolvedReferences));
+          if (nestedToken && nestedToken.value) {
+            const resolvedNestedToken = this.resolveReferences({ ...nestedToken, name: nestedTokenName } as SingleToken, new Set(resolvedReferences));
 
-            if (typeof resolvedNestedToken.value === 'string') {
+            if (typeof resolvedNestedToken.value === 'string' || typeof resolvedNestedToken.value === 'number') {
               resolvedPath = resolvedPath.replace(match[0], resolvedNestedToken.value);
             }
+          } else {
+            break;
           }
         }
 
@@ -161,9 +160,9 @@ class TokenResolver {
         if (foundToken) {
           // We add the already resolved references to the new set, so we can check for circular references
           const newResolvedReferences = new Set(resolvedReferences);
-          newResolvedReferences.add(path);
+          newResolvedReferences.add(resolvedPath);
           // We initiate a new resolveReferences call, as we need to resolve the references of the reference
-          const resolvedTokenValue = this.resolveReferences({ ...foundToken, name: path } as SingleToken, newResolvedReferences);
+          const resolvedTokenValue = this.resolveReferences({ ...foundToken, name: resolvedPath } as SingleToken, newResolvedReferences);
 
           // We weren't able to resolve the reference, so we return the token as is, but mark it as failed to resolve
           if (resolvedTokenValue.value === undefined) {

--- a/src/utils/TokenResolver.ts
+++ b/src/utils/TokenResolver.ts
@@ -131,7 +131,7 @@ class TokenResolver {
         // As long as we have matches, we need to resolve them. This is needed for multiple levels of nesting. Performance will suffer, but that's the user's choice.
         while (matches !== false) {
           const match = resolvedPath.match(AliasRegex);
-          matches = false;
+          matches = Boolean(match?.length);
           if (!match?.length) {
             matches = false;
             break;


### PR DESCRIPTION
Closes https://github.com/tokens-studio/figma-plugin/issues/2311

This pull request adds support for nested references to the `TokenResolver` utility, allowing for more complex references to be resolved. The most important changes include adding support for nested references in the `TokenResolver` class, updating the `TokenResolver.test.ts` file to test the new functionality, and updating the `AliasRegex` constant in `AliasRegex.ts` to match nested references.

Main changes:

* <a href="diffhunk://#diff-b4809e6851ac3bf8ff55467e9606b901d782180f05572177646b5b87641099e8R127-R159">`src/utils/TokenResolver.ts`</a>: Added support for nested references in `TokenResolver` class by resolving them using a while loop until there are no more matches.
* <a href="diffhunk://#diff-0a3339bdfaf2a5f4e6713b9b421551a456db51d5ffe9c106a236eb565cf791e7R219-R243">`src/utils/TokenResolver.test.ts`</a>: Updated to test the new functionality of nested references in the `TokenResolver` utility. <a href="diffhunk://#diff-0a3339bdfaf2a5f4e6713b9b421551a456db51d5ffe9c106a236eb565cf791e7R219-R243">[1]</a> <a href="diffhunk://#diff-0a3339bdfaf2a5f4e6713b9b421551a456db51d5ffe9c106a236eb565cf791e7R496-R525">[2]</a>
* <a href="diffhunk://#diff-866d491039a677240470f687af23ccc10dcfc778ee2a2f6c4fdb558beb2ae128R1-R5">`.changeset/new-beers-visit.md`</a>: A new changeset file updates the version of `@tokens-studio/figma-plugin` package to a patch version and reintroduces support for nested references, with a note that it may affect performance.

Regex changes:

* <a href="diffhunk://#diff-e25163c22a472b190059fe641ccc68e5a0f218ab6c1f80f63ba65dbaa7b92e38L5-R5">`src/constants/AliasRegex.ts`</a>: Updated the `AliasRegex` constant to match nested references in the form of `{...}`.