### PR TITLE
Fix a crash when interacting with a numeric token

### DIFF
--- a/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/src/app/components/DownshiftInput/MentionInput.tsx
@@ -78,13 +78,14 @@ export default function MentionsInput({
   }, [handleBlur]);
 
   const getHighlightedText = React.useCallback((text: string, highlight: string) => {
+    // Note that the highlight might be numeric, hence we cast it to a string
     // Split on highlight term and include term into parts, ignore case
-    const parts = text.split(new RegExp(`(${highlight.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')})`, 'gi'));
+    const parts = text.split(new RegExp(`(${String(highlight).replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')})`, 'gi'));
     return (
       <span>
         {parts.map((part, i) => (
           // eslint-disable-next-line react/no-array-index-key
-          <StyledPart key={i} matches={part.toLowerCase() === highlight.toLowerCase()}>
+          <StyledPart key={i} matches={part.toLowerCase() === String(highlight).toLowerCase()}>
             {part}
           </StyledPart>
         ))}


### PR DESCRIPTION
Interacting with numeric tokens is causing a crash. This is due to interactions with the token assumed to be a string and then calling string functions like replace.

This was detected through a crash in Sentry, but I think there are more cases where the assumption that the values are always string is likely an issue