### PR TITLE
Feat/ reintroduce update on change

### DIFF
--- a/.changeset/sweet-walls-prove.md
+++ b/.changeset/sweet-walls-prove.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue with Update on change. It's now working again, but disabled for new users as intended.

--- a/src/app/store/models/settings.tsx
+++ b/src/app/store/models/settings.tsx
@@ -58,7 +58,7 @@ export const settings = createModel<RootModel>()({
     sessionRecording: false,
     updateMode: UpdateMode.SELECTION,
     updateRemote: true,
-    updateOnChange: true,
+    updateOnChange: false,
     updateStyles: true,
     tokenType: 'object',
     ignoreFirstPartForStyles: false,

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -517,7 +517,7 @@ export const tokenState = createModel<RootModel>()({
         dispatch.tokenState.updateAliases({ oldName: payload.oldName, newName: payload.name });
       }
 
-      if (payload.shouldUpdate) {
+      if (payload.shouldUpdate && rootState.settings.updateMode !== 'document') {
         dispatch.tokenState.updateDocument({ shouldUpdateNodes: rootState.settings.updateOnChange });
       }
     },

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -517,8 +517,8 @@ export const tokenState = createModel<RootModel>()({
         dispatch.tokenState.updateAliases({ oldName: payload.oldName, newName: payload.name });
       }
 
-      if (payload.shouldUpdate && rootState.settings.updateOnChange) {
-        dispatch.tokenState.updateDocument({ shouldUpdateNodes: false });
+      if (payload.shouldUpdate) {
+        dispatch.tokenState.updateDocument({ shouldUpdateNodes: rootState.settings.updateOnChange });
       }
     },
     deleteToken() {


### PR DESCRIPTION
Brings back the updateOnChange behavior when editing a token.

- If the user has the setting for update on change AND - their apply mode is set to page or selection

When: tokens are edited, update the nodes on either the page or their selection.