### PR TITLE
Update svgo.config.js to preserve removeViewBox

### DIFF
--- a/svgo.config.js
+++ b/svgo.config.js
@@ -1,7 +1,12 @@
-{
-    plugins: [
-      {
-        removeViewBox: true
-      },
-    ]
-  }
+module.exports = {
+  plugins: [
+    {
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+        }
+      }
+    }
+  ]
+};


### PR DESCRIPTION
Fixes an issue on `main` with svgo's new config

Before

<img width="468" alt="CleanShot 2023-11-20 at 23 19 55@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/e55df69c-9f5a-4630-b42f-9e0d261a79c3">

After

<img width="558" alt="CleanShot 2023-11-20 at 23 18 25@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/a67be8d6-8a1a-4ed0-8500-df30e72dc3f0">
