### PR TITLE
Change font-size input field position in Typography composite token modal 

### DIFF
--- a/.changeset/spicy-scissors-sparkle.md
+++ b/.changeset/spicy-scissors-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Reordered the typography composite token fields to have lineHeight follow fontSize

--- a/src/config/tokenType.defs.json
+++ b/src/config/tokenType.defs.json
@@ -94,8 +94,8 @@
         "properties": {
           "fontFamily": { "type": "string" },
           "fontWeight": { "type": "string" },
-          "lineHeight": { "type": "string" },
           "fontSize": { "type": "string" },
+          "lineHeight": { "type": "string" },
           "letterSpacing": { "type": "string" },
           "paragraphSpacing": { "type": "string" },
           "paragraphIndent": { "type": "string" },


### PR DESCRIPTION
Current: Font size is after line-height 

Problem: Line-height is often dependent on font-size, so it would help to first set the font-size and then the line-height. 

Solution: Change the font-size input field position in the Typography composite token modal. 


PS: this is my first ever contribution to an open-source project, please be gentle when looking at naming conventions for branches/commits