### PR TITLE
border token style issue: fix in destructure

### DIFF
--- a/src/plugin/node.test.ts
+++ b/src/plugin/node.test.ts
@@ -59,6 +59,15 @@ const borderToken = {
   },
 };
 
+const borderTokenWithAliasColor = {
+  type: TokenTypes.BORDER,
+  value: {
+    color: '{global.colors.blue}',
+    width: '12px',
+    type: 'solid',
+  },
+};
+
 const tokens = new Map([
   ['global.colors.blue',
     {
@@ -142,6 +151,14 @@ const tokens = new Map([
       value: borderToken.value,
     },
   ],
+  ['global.border.aliased',
+    {
+      ...borderTokenWithAliasColor,
+      name: 'border.aliased',
+      rawValue: borderTokenWithAliasColor.value,
+      value: borderTokenWithAliasColor.value,
+    },
+  ],
 ]);
 
 const values = [
@@ -207,7 +224,8 @@ const applyTokens = [
   { boxShadow: 'global.shadow.multiple' },
   { boxShadow: 'global.shadow.single' },
   { boxShadow: 'global.shadow.multiple' },
-  { border: 'global.border.general', borderColor: 'global.border.general' },
+  { border: 'global.border.general', borderColor: '#ff0000' },
+  { borderLeft: 'global.border.aliased', borderColor: 'global.colors.blue' },
 ];
 
 describe('mapValuesToTokens', () => {

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -397,10 +397,9 @@ export default async function setValuesOnNode(
 
       // BORDER COLOR
       if (typeof values.borderColor !== 'undefined' && typeof values.borderColor === 'string') {
-        const borderColorData = data.borderColor?.replace('{', '').replace('}', '') as string;
         if ('strokes' in node && data.borderColor) {
           setBorderColorValuesOnTarget({
-            node, data: borderColorData, value: values.borderColor, stylePathPrefix, stylePathSlice, styleReferences: figmaStyleReferences ?? {}, paintStyles: figmaStyleMaps.paintStyles, figmaVariableReferences,
+            node, data: data.borderColor, value: values.borderColor, stylePathPrefix, stylePathSlice, styleReferences: figmaStyleReferences ?? {}, paintStyles: figmaStyleMaps.paintStyles, figmaVariableReferences,
           });
         }
       }

--- a/src/plugin/updatePluginDataAndNodes.ts
+++ b/src/plugin/updatePluginDataAndNodes.ts
@@ -58,13 +58,6 @@ export async function updatePluginDataAndNodes({
         const rawTokenMap = destructureTokenForAlias(tokensMap, tokenValues);
         const mappedValues = mapValuesToTokens(tokensMap, tokenValues);
 
-        if (typeof rawTokenMap.borderColor !== undefined && typeof mappedValues.borderColor === 'string') {
-          const resolvedToken = tokensMap.get(tokenValues.border as string);
-          if (resolvedToken && resolvedToken.rawValue && typeof resolvedToken.rawValue === 'object') {
-            if ('color' in resolvedToken.rawValue) rawTokenMap.borderColor = resolvedToken.rawValue.color as string;
-          }
-        }
-
         setValuesOnNode(
           node,
           mappedValues,


### PR DESCRIPTION
Moves the logic to the `destructure` function and adds a test