### PR TITLE
Adds support for stroke weight and opacity variable binding

### DIFF
--- a/.changeset/tough-ways-do.md
+++ b/.changeset/tough-ways-do.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Adds support for binding variables to stroke weight and opacity

--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -139,7 +139,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.12.16",
     "@changesets/cli": "^2.26.2",
-    "@figma/plugin-typings": "^1.71.1",
+    "@figma/plugin-typings": "^1.82.0",
     "@sentry/webpack-plugin": "^2.2.0",
     "@storybook/addon-actions": "^6.5.8",
     "@storybook/addon-docs": "^6.5.8",

--- a/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
@@ -95,6 +95,8 @@ describe('Can set values on node', () => {
       borderRadiusTopRight: 'border-radius-10',
       borderRadiusBottomRight: 'border-radius-10',
       borderRadiusBottomLeft: 'border-radius-10',
+      borderWidth: 'border-width-2',
+      opacity: 'opacity-50',
     };
 
     await setValuesOnNode(solidNodeMock, values, data, emptyStylesMap);

--- a/packages/tokens-studio-for-figma/src/plugin/setBorderValuesOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setBorderValuesOnTarget.ts
@@ -3,24 +3,62 @@ import { SingleBorderToken } from '@/types/tokens';
 import { isPrimitiveValue } from '@/utils/is';
 import { transformValue } from './helpers';
 import getFigmaDashPattern from './getFigmaDashPattern';
+import { tryApplyVariableId } from '@/utils/tryApplyVariableId';
+import { RawVariableReferenceMap } from '@/types/RawVariableReferenceMap';
 
-export default function setBorderValuesOnTarget(target: BaseNode, token: Pick<SingleBorderToken, 'value'>, baseFontSize: string, side?: 'top' | 'right' | 'bottom' | 'left') {
+export default async function setBorderValuesOnTarget(
+  target: BaseNode,
+  token: Pick<SingleBorderToken, 'value'>,
+  baseFontSize: string,
+  figmaVariableReferences: RawVariableReferenceMap,
+  side?: 'top' | 'right' | 'bottom' | 'left',
+) {
   const { value } = token;
   const { width, style } = value;
   try {
-    if ('strokeWeight' in target && typeof width !== 'undefined' && isPrimitiveValue(width) && !side) {
+    if (
+      'strokeWeight' in target
+      && typeof width !== 'undefined'
+      && isPrimitiveValue(width)
+      && !side
+      && !(await tryApplyVariableId(target, 'strokeWeight', width, figmaVariableReferences))
+    ) {
       target.strokeWeight = transformValue(String(width), 'borderWidth', baseFontSize);
     }
-    if ('strokeTopWeight' in target && typeof width !== 'undefined' && isPrimitiveValue(width) && side === 'top') {
+    if (
+      'strokeTopWeight' in target
+      && typeof width !== 'undefined'
+      && isPrimitiveValue(width)
+      && side === 'top'
+      && !(await tryApplyVariableId(target, 'strokeTopWeight', width, figmaVariableReferences))
+    ) {
       target.strokeTopWeight = transformValue(String(width), 'borderWidth', baseFontSize);
     }
-    if ('strokeRightWeight' in target && typeof width !== 'undefined' && isPrimitiveValue(width) && side === 'right') {
+    if (
+      'strokeRightWeight' in target
+      && typeof width !== 'undefined'
+      && isPrimitiveValue(width)
+      && side === 'right'
+      && !(await tryApplyVariableId(target, 'strokeRightWeight', width, figmaVariableReferences))
+    ) {
       target.strokeRightWeight = transformValue(String(width), 'borderWidth', baseFontSize);
     }
-    if ('strokeBottomWeight' in target && typeof width !== 'undefined' && isPrimitiveValue(width) && side === 'bottom') {
+    if (
+      'strokeBottomWeight' in target
+      && typeof width !== 'undefined'
+      && isPrimitiveValue(width)
+      && side === 'bottom'
+      && !(await tryApplyVariableId(target, 'strokeBottomWeight', width, figmaVariableReferences))
+    ) {
       target.strokeBottomWeight = transformValue(String(width), 'borderWidth', baseFontSize);
     }
-    if ('strokeLeftWeight' in target && typeof width !== 'undefined' && isPrimitiveValue(width) && side === 'left') {
+    if (
+      'strokeLeftWeight' in target
+      && typeof width !== 'undefined'
+      && isPrimitiveValue(width)
+      && side === 'left'
+      && !(await tryApplyVariableId(target, 'strokeLeftWeight', width, figmaVariableReferences))
+    ) {
       target.strokeLeftWeight = transformValue(String(width), 'borderWidth', baseFontSize);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@
     lodash "^4.17.15"
     matrix-inverse "^1.0.1"
 
-"@figma/plugin-typings@^1.71.1":
-  version "1.79.0"
-  resolved "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.79.0.tgz"
-  integrity sha512-Nzi+ShWOs/0IHWQqUwBS4xydglgcgqNEKPSUhTXM+io4o4vSspwpKWy7XBrl5azqqoCozzBa10aPhwXsA+tJfg==
+"@figma/plugin-typings@^1.82.0":
+  version "1.82.0"
+  resolved "https://registry.yarnpkg.com/@figma/plugin-typings/-/plugin-typings-1.82.0.tgz#7f8c8514bb18dc303e3b194b60827fec1f2a5e9f"
+  integrity sha512-To5M9VRpNysrGGtZtPF5Ke9eobfhTUr7kieAsYMhpPg+VKdr0EM6XDFtCqhtuDrLfPAZFa/cBQo68auWwD4mlA==
 
 "@floating-ui/core@^1.4.2":
   version "1.5.1"


### PR DESCRIPTION
### Why does this PR exist?

Fixes https://github.com/tokens-studio/figma-plugin/issues/2414

Figma recently added support for binding variables to stroke weight and opacity (among others). This PR adds support for that.

### What does this pull request do?

Integrates our already used `tryApplyVariableId` to the stroke weight and opacity properties.

### Testing this change

Create a dimension token, right click it and set `border width` to any of the properties. Make sure that that dimension token exists as a variable

### Additional Notes (if any)

Merging into `release-139` as the next major release.

<img width="941" alt="CleanShot 2023-12-28 at 01 11 11@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/4a9812df-f1f9-492f-8011-d261e5070460">
