### PR TITLE
2165 duplicating a token to another set displays error 1

### DIFF
--- a/.changeset/chatty-turkeys-explain.md
+++ b/.changeset/chatty-turkeys-explain.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix to duplicate token to other token sets with same name.

--- a/.changeset/chatty-turkeys-explain.md
+++ b/.changeset/chatty-turkeys-explain.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-Fix to duplicate token to other token sets with same name.
+Fixes an issue where duplicating a token to another set incorrectly displayed an error message about token names needing to be unique.

--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -92,7 +92,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
   const hasNameThatExistsAlready = React.useMemo(
     () => {
       const editToken = resolvedTokens
-        .filter((t) => t.internal__Parent === activeTokenSet)
+        .filter((t) => selectedTokenSets.includes(t.internal__Parent ?? ''))
         .find((t) => t.name === internalEditToken?.name);
 
       if (editToken) {
@@ -101,7 +101,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
 
       return editToken;
     },
-    [internalEditToken, resolvedTokens, activeTokenSet],
+    [internalEditToken, resolvedTokens, activeTokenSet, selectedTokenSets],
   );
 
   const hasAnotherTokenThatStartsWithName = React.useMemo(
@@ -478,6 +478,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
 
   const handleSelectedItemChange = React.useCallback((selectedItems: string[]) => {
     setSelectedTokenSets(selectedItems);
+    if (selectedItems.length > 0) setError(null);
   }, []);
 
   const renderTokenForm = () => {


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?
When try to duplicate token to another token set with same name, there is a error alert 'Token names must be unique'.

Closes #2165 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?
Resolved to duplicate token to other token sets with same name.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change
Updated `EditTokenForm.tsx` and added a condition whether the `activeTokenSet` is included in `selectedItems` (token sets which user wants to duplicate the token to) list.

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->

https://github.com/tokens-studio/figma-plugin/assets/103296157/f1af8a8f-d613-4517-8d2e-77a721fb92a5


