### PR TITLE
2386 ability to edit tokens to add nested levels

### DIFF
--- a/.changeset/fuzzy-flies-fry.md
+++ b/.changeset/fuzzy-flies-fry.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Provide ability to users to add nested levels to a token

--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -126,13 +126,6 @@ function EditTokenForm({ resolvedTokens }: Props) {
     return false;
   }, [internalEditToken]);
 
-  const hasPriorTokenName = React.useMemo(
-    () => resolvedTokens
-      .filter((t) => t.internal__Parent === activeTokenSet)
-      .find((t) => t.type === internalEditToken.type && internalEditToken.name?.startsWith(`${t.name}.`)),
-    [internalEditToken, resolvedTokens, activeTokenSet],
-  );
-
   const nameWasChanged = React.useMemo(() => internalEditToken?.initialName !== internalEditToken?.name, [
     internalEditToken,
   ]);
@@ -144,16 +137,13 @@ function EditTokenForm({ resolvedTokens }: Props) {
     if ((internalEditToken?.status !== EditTokenFormStatus.EDIT || nameWasChanged) && hasAnotherTokenThatStartsWithName) {
       setError(t('mustNotUseNameOfAnotherGroup', { ns: 'errors' }));
     }
-    if ((internalEditToken?.status || nameWasChanged) && hasPriorTokenName) {
-      setError(t('tokensCantShareNameWithGroup', { ns: 'errors' }));
-    }
     if ((internalEditToken?.status || nameWasChanged) && hasDollarForFirstCharacter) {
       setError(t('tokenNamesCantStartWithDollar', { ns: 'errors' }));
     }
     if ((internalEditToken?.status || nameWasChanged) && hasCurlyBraces) {
       setError(t('tokenNamesCantContainCurlyBraces', { ns: 'errors' }));
     }
-  }, [internalEditToken, hasNameThatExistsAlready, nameWasChanged, hasPriorTokenName, hasAnotherTokenThatStartsWithName]);
+  }, [internalEditToken, hasNameThatExistsAlready, nameWasChanged, hasAnotherTokenThatStartsWithName]);
 
   const handleChange = React.useCallback(
     (property: string, value: string) => {


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?
User can't edit token to add nested levels.

Closes #2386 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?
This PR gives ability to users to add nested levels to a token.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change
The current implementation has a if condition to check the new token name starts with one of resolved tokens name to check if token share the same name with group name which is a block to add nested levels.
This PR added a new condition here to check whether the user action is `create` or `edit` token.

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

https://github.com/tokens-studio/figma-plugin/assets/103296157/f2a98cdd-a053-4487-bbea-ca493ff3c733


<!--
  Add any other context or screenshots about the pull request
-->
