### PR TITLE
Fix id location

### DIFF
--- a/.changeset/slimy-files-reply.md
+++ b/.changeset/slimy-files-reply.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+The internal 'id' property is now properly stored on the 'studio.tokens' key in the '$extensions' object of a token

--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
@@ -53,7 +53,9 @@ describe('pullTokensFactory', () => {
               name: 'colors.red',
               value: '#ff0000',
               $extensions: {
-                id: 'mock-uuid',
+                'studio.tokens': {
+                  id: 'mock-uuid',
+                },
               },
             },
           ],
@@ -259,7 +261,9 @@ describe('pullTokensFactory', () => {
               name: 'colors.red',
               value: '#ff0000',
               $extensions: {
-                id: 'mock-uuid',
+                'studio.tokens': {
+                  id: 'mock-uuid',
+                },
               },
             },
           ],

--- a/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
@@ -140,7 +140,9 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              id: 'mock-uuid',
+              'studio.tokens': {
+                id: 'mock-uuid',
+              },
             },
             name: 'small',
             type: 'sizing',
@@ -182,7 +184,9 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              id: 'mock-uuid',
+              'studio.tokens': {
+                id: 'mock-uuid',
+              },
             },
             name: 'small',
             type: 'sizing',
@@ -191,7 +195,9 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              id: 'mock-uuid',
+              'studio.tokens': {
+                id: 'mock-uuid',
+              },
             },
             name: 'black',
             type: 'color',
@@ -200,7 +206,9 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              id: 'mock-uuid',
+              'studio.tokens': {
+                id: 'mock-uuid',
+              },
             },
             name: 'headline',
             type: 'boxShadow',
@@ -253,7 +261,9 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              id: 'mock-uuid',
+              'studio.tokens': {
+                id: 'mock-uuid',
+              },
             },
             name: 'black',
             type: 'color',
@@ -262,7 +272,9 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              id: 'mock-uuid',
+              'studio.tokens': {
+                id: 'mock-uuid',
+              },
             },
             name: 'headline',
             type: 'boxShadow',

--- a/packages/tokens-studio-for-figma/src/app/components/Initiator.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Initiator.test.tsx
@@ -236,7 +236,9 @@ describe('Initiator', () => {
       global: [
         {
           $extensions: {
-            id: 'mock-uuid',
+            'studio.tokens': {
+              id: 'mock-uuid',
+            },
           },
           type: TokenTypes.COLOR,
           name: 'colors.red',

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.test.ts
@@ -174,6 +174,7 @@ describe('editToken', () => {
           settings: {
             updateRemote: true,
             updateOnChange: true,
+            storeTokenIdInJsonEditor: false,
           },
         },
       },
@@ -674,7 +675,9 @@ describe('editToken', () => {
         type: TokenTypes.COLOR,
         value: '#000000',
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
       },
     ];
@@ -810,8 +813,8 @@ describe('editToken', () => {
         type: TokenTypes.COLOR,
         value: '#000000',
         $extensions: {
-          id: 'mock-uuid',
           'studio.tokens': {
+            id: 'mock-uuid',
             modify: {
               type: 'lighten',
               value: '0.5',
@@ -860,7 +863,9 @@ describe('editToken', () => {
     expect(tokens.global).toEqual([
       {
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
         name: '1',
         type: 'sizing',
@@ -868,7 +873,9 @@ describe('editToken', () => {
       },
       {
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
         name: 'header',
         type: 'borderRadius',
@@ -876,7 +883,9 @@ describe('editToken', () => {
       },
       {
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
         inheritTypeLevel: 2,
         name: 'black.100',
@@ -885,7 +894,9 @@ describe('editToken', () => {
       },
       {
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
         inheritTypeLevel: 2,
         name: 'black.500',
@@ -925,8 +936,8 @@ describe('editToken', () => {
         value: '1',
         type: 'sizing',
         $extensions: {
-          id: 'mock-uuid',
           'studio.tokens': {
+            id: 'mock-uuid',
             modify: {
               type: 'lighten',
               value: '0.5',
@@ -1038,8 +1049,8 @@ describe('editToken', () => {
         value: '1',
         type: 'sizing',
         $extensions: {
-          id: 'mock-uuid',
           'studio.tokens': {
+            id: 'mock-uuid',
             modify: {
               type: 'lighten',
               value: '0.5',
@@ -1080,12 +1091,14 @@ describe('editToken', () => {
         value: '1',
       },
       {
-        $extensions: {
-          id: 'mock-uuid',
-        },
         name: 'primary-copy',
         value: '1',
         type: 'sizing',
+        $extensions: {
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
+        },
       },
       {
         name: 'alias',
@@ -1672,7 +1685,9 @@ describe('editToken', () => {
     const expectedTokens = [
       {
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
         type: TokenTypes.COLOR,
         value: '#ff0000',
@@ -1680,7 +1695,9 @@ describe('editToken', () => {
       },
       {
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
         type: TokenTypes.COLOR,
         value: '#000000',
@@ -1688,7 +1705,9 @@ describe('editToken', () => {
       },
       {
         $extensions: {
-          id: 'mock-uuid',
+          'studio.tokens': {
+            id: 'mock-uuid',
+          },
         },
         type: TokenTypes.BORDER_RADIUS,
         value: '12px',

--- a/packages/tokens-studio-for-figma/src/types/payloads/DuplicateTokenPayload.ts
+++ b/packages/tokens-studio-for-figma/src/types/payloads/DuplicateTokenPayload.ts
@@ -15,6 +15,7 @@ export type DuplicateTokenPayload = {
     [key: string]: any;
     'studio.tokens'?: {
       [key: string]: any;
+      id?: string;
       modify?: ColorModifier
     }
   }

--- a/packages/tokens-studio-for-figma/src/types/payloads/UpdateTokenVariablePayload.ts
+++ b/packages/tokens-studio-for-figma/src/types/payloads/UpdateTokenVariablePayload.ts
@@ -12,6 +12,7 @@ export type UpdateTokenVariablePayload = {
     [key: string]: any;
     'studio.tokens'?: {
       [key: string]: any;
+      id?: string;
       modify?: ColorModifier
     }
   }

--- a/packages/tokens-studio-for-figma/src/types/tokens/SingleGenericToken.ts
+++ b/packages/tokens-studio-for-figma/src/types/tokens/SingleGenericToken.ts
@@ -15,6 +15,7 @@ export type SingleGenericToken<T extends TokenTypes, V = string, Named extends b
     [key: string]: any;
     'studio.tokens'?: {
       [key: string]: any;
+      id?: string;
       modify?: ColorModifier;
     },
     id?: string;

--- a/packages/tokens-studio-for-figma/src/utils/addIdPropertyToTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/addIdPropertyToTokens.ts
@@ -4,13 +4,26 @@ import { AnyTokenList } from '@/types/tokens';
 export default function addIdPropertyToTokens(tokens: Record<string, AnyTokenList>) {
   const tokenObj = Object.entries(tokens).reduce<Record<string, AnyTokenList>>((acc, [key, val]) => {
     const newTokenList = val.map((token) => {
-      if (typeof token.$extensions?.id === 'undefined') {
-        return {
-          ...token,
-          $extensions: {
-            ...token.$extensions,
+      if (typeof token.$extensions?.['studio.tokens']?.id === 'undefined') {
+        const extensionsObj = {
+          ...token.$extensions,
+          'studio.tokens': {
+            ...token?.$extensions?.['studio.tokens'],
             id: uuidv4(),
           },
+        };
+        return {
+          ...token,
+          // Only when extensions obj is not empty do we set it again
+          ...(Object.entries(extensionsObj).length > 0 ? {
+            $extensions: {
+              ...token.$extensions,
+              'studio.tokens': {
+                ...token?.$extensions?.['studio.tokens'],
+                id: uuidv4(),
+              },
+            },
+          } : {}),
         };
       }
       return token;

--- a/packages/tokens-studio-for-figma/src/utils/removeTokenId.ts
+++ b/packages/tokens-studio-for-figma/src/utils/removeTokenId.ts
@@ -2,17 +2,15 @@ import omit from 'just-omit';
 import { SingleToken } from '@/types/tokens';
 
 export default function removeTokenId(token: SingleToken, shouldRemove: boolean): SingleToken {
-  if (token.$extensions && shouldRemove) {
-    const newToken = {
-      ...token,
-      $extensions: {
-        ...omit(token?.$extensions, 'id'),
-      },
-    };
-    if (Object.keys(newToken.$extensions ?? {}).length < 1) {
-      return omit(newToken, '$extensions') as SingleToken;
+  if (token.$extensions && shouldRemove && token.$extensions['studio.tokens']) {
+    delete token.$extensions?.['studio.tokens']?.id;
+    if (Object.keys(token.$extensions?.['studio.tokens'] || {}).length === 0) {
+      delete token.$extensions?.['studio.tokens'];
     }
-    return newToken;
+  }
+
+  if (Object.keys(token.$extensions || {}).length === 0) {
+    delete token.$extensions;
   }
   return token;
 }

--- a/packages/tokens-studio-for-figma/src/utils/updateTokenPayloadToSingleToken.ts
+++ b/packages/tokens-studio-for-figma/src/utils/updateTokenPayloadToSingleToken.ts
@@ -11,13 +11,10 @@ export function updateTokenPayloadToSingleToken(
     type: payload.type,
     $extensions: {
       ...payload.$extensions,
-      ...(id ? { id } : {}),
-      ...(payload.$extensions?.['studio.tokens'] ? {
-        'studio.tokens': {
-          ...payload.$extensions['studio.tokens'],
-          modify: payload.$extensions['studio.tokens']?.modify,
-        },
-      } : {}),
+      'studio.tokens': {
+        ...(id ? { id } : {}),
+        ...payload?.$extensions?.['studio.tokens'],
+      },
     },
     ...(payload.description ? {
       description: payload.description,


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

We falsely stored the `id` property of tokens in the `$extensions` object, instead of properly placing it in the `$extensions` / `studio.tokens` property. This PR fixes that.

### Testing this change

Tests were updated