### PR TITLE
fix studio sync by removing metadata createdAt for set

### DIFF
--- a/packages/tokens-studio-for-figma/src/storage/TokensStudioTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/TokensStudioTokenStorage.ts
@@ -6,6 +6,7 @@ import {
   Raw_Token_border,
   Raw_Token_boxShadow,
 } from '@tokens-studio/sdk';
+import * as Sentry from '@sentry/react';
 import { AnyTokenSet, SingleToken } from '@/types/tokens';
 import { RemoteTokenStorage, RemoteTokenstorageErrorMessage, RemoteTokenStorageFile } from './RemoteTokenStorage';
 import { ErrorMessages } from '../constants/ErrorMessages';
@@ -147,6 +148,7 @@ async function getTokens(urn: string): Promise<AnyTokenSet | null> {
     }, {});
     return returnData;
   } catch (e) {
+    Sentry.captureException(e);
     console.error('Error fetching tokens', e);
     return null;
   }


### PR DESCRIPTION
Studio sync was not working in our 2.0 branch, and it seems to have been caused (after we fixed some of the api key bugs) by the `createdAt` set metadata we queried. Removing that seems to have fixed the problem.