### PR TITLE
Fix issue with error boundary and UI error messages

### DIFF
--- a/.changeset/large-cows-guess.md
+++ b/.changeset/large-cows-guess.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue with the plugins error boundary, error messages should now show up in the UI again

--- a/packages/tokens-studio-for-figma/src/app/components/ErrorFallback/ErrorFallback.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ErrorFallback/ErrorFallback.tsx
@@ -1,30 +1,14 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Heading } from '@tokens-studio/ui';
-import { styled } from '@/stitches.config';
 import Stack from '../Stack';
 import Text from '../Text';
 
-const StyledLink = styled('a', {
-  color: '$accentDefault',
-  textDecoration: 'underline',
-});
-
 export function ErrorFallback({ error }: { error: Error }) {
-  const { t } = useTranslation(['errors']);
-
   return (
     <Stack direction="column" align="center" gap={4} justify="center" css={{ padding: '$4', height: '100%', textAlign: 'center' }}>
-      <Heading>{t('wentWrong')}</Heading>
+      <Heading>An unexpected error has occured</Heading>
       <Stack direction="column" gap={3}>
         <Text size="xsmall" muted>{error.message}</Text>
-        <Text size="xsmall" muted>{t('restart')}</Text>
-        <Text size="xsmall" muted>
-          {t('reset')}
-          {' '}
-          <StyledLink href="https://docs.tokens.studio/reset-tokens" target="_blank" rel="noreferrer">{t('readHow')}</StyledLink>
-        </Text>
-
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
### Why does this PR exist?

Previously when errors occured the plugin wouldnt display the error boundary correctly, which we seem to have introduced somewhere along the way. This PR fixes that.

### What does this pull request do?

Remove hooks from the Error boundary which seems to fix the issue.