### PR TITLE
feat: added regex support to bulk remap

### DIFF
--- a/.changeset/honest-clouds-add.md
+++ b/.changeset/honest-clouds-add.md
@@ -1,0 +1,5 @@
+---
+'@tokens-studio/figma-plugin': minor
+---
+
+Added regex support to bulk remap

--- a/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
@@ -95,7 +95,7 @@ describe('bulkRemapTokens', () => {
     ]));
     await bulkRemapTokens({
       type: AsyncMessageTypes.BULK_REMAP_TOKENS,
-      oldName: 'old-size.*',
+      oldName: '/old-size.*/g',
       newName: 'new-size.1000',
       updateMode: UpdateMode.SELECTION,
     });

--- a/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
@@ -55,4 +55,53 @@ describe('bulkRemapTokens', () => {
     expect(mockSetSharedPluginData.mock.calls[0]).toEqual(['tokens', 'borderRadius', '"new.border-radius"']);
     expect(mockSetSharedPluginData.mock.calls[5]).toEqual(['tokens', 'fill', '"new-color.gray.300"']);
   });
+
+  it('should be able to replace all matching token names with new token name using regex', async () => {
+    findNodesSpy.mockImplementationOnce(() => Promise.resolve([
+      {
+        id: '295:3',
+        node: {
+          id: '295:3',
+          setSharedPluginData: mockSetSharedPluginData,
+        } as unknown as BaseNode,
+        tokens: {
+          borderRadius: 'old.border-radius',
+          fill: 'old.slate.400',
+          sizing: 'old-size.450',
+          spacing: 'something-else.foobar',
+        },
+      },
+      {
+        id: '295:4',
+        node: {
+          id: '295:4',
+          setSharedPluginData: mockSetSharedPluginData,
+        } as unknown as RectangleNode,
+        tokens: {
+          fill: 'old.red.500',
+          sizing: 'old-size.1600',
+        },
+      },
+      {
+        id: '295:5',
+        node: {
+          id: '295:5',
+          setSharedPluginData: mockSetSharedPluginData,
+        } as unknown as TextNode,
+        tokens: {
+          fill: 'old-color.gray.300',
+        },
+      },
+    ]));
+    await bulkRemapTokens({
+      type: AsyncMessageTypes.BULK_REMAP_TOKENS,
+      oldName: 'old-size.*',
+      newName: 'new-size.1000',
+      updateMode: UpdateMode.SELECTION,
+    });
+
+    expect(mockSetSharedPluginData).toHaveBeenCalledTimes(2);
+    expect(mockSetSharedPluginData.mock.calls[0]).toEqual(['tokens', 'sizing', '"new-size.1000"']);
+    expect(mockSetSharedPluginData.mock.calls[1]).toEqual(['tokens', 'sizing', '"new-size.1000"']);
+  });
 });

--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -27,11 +27,14 @@ export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK
 
     const tracker = new ProgressTracker(BackgroundJobs.PLUGIN_UPDATEPLUGINDATA);
     const promises: Set<Promise<void>> = new Set();
+    const regexPattern = /^\/(.*)\/([gimsuy]*)$/;
 
     allWithData.forEach(({ node, tokens }) => {
       promises.add(defaultWorker.schedule(async () => {
         Object.entries(tokens).forEach(([key, value]) => {
-          const pattern = (/^\/.*\/$/.test(oldName)) ? new RegExp(oldName.slice(1, -1)) : new RegExp(oldName);
+          const regexTest = oldName.match(regexPattern);
+          // If the pattern passed is a regex, use it, otherwise use the old name with a global flag
+          const pattern = regexTest ? new RegExp(regexTest[1], regexTest[2]) : new RegExp(oldName, 'g');
           if (pattern.test(value)) {
             const newValue = value.replace(pattern, newName);
             const jsonValue = JSON.stringify(newValue);

--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -31,8 +31,9 @@ export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK
     allWithData.forEach(({ node, tokens }) => {
       promises.add(defaultWorker.schedule(async () => {
         Object.entries(tokens).forEach(([key, value]) => {
-          if (value.includes(oldName)) {
-            const newValue = value.replace(oldName, newName);
+          const pattern = (/^\/.*\/$/.test(oldName)) ? new RegExp(oldName.slice(1, -1)) : new RegExp(oldName);
+          if (pattern.test(value)) {
+            const newValue = value.replace(pattern, newName);
             const jsonValue = JSON.stringify(newValue);
             node.setSharedPluginData(namespace, key, jsonValue);
           }


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

The Bulk Remap feature is incredibly useful, as it saves a ton of time and work when renaming multiple tokens. 
By adding [regex support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) to it, one can provide more precise patterns to the token search, allowing them to bulk remap tokens even faster.

### What does this pull request do?

- `bulkRemapTokens.ts`
  - Added support for regex
  - Added test for regex search

### Testing this change

1. Select multiple layers.
2. Use the bulk remap feature and enter a regular expression that matches a portion of the tokens in those layers.
3. Enter a value to change that portion to. Note how only the portion that matches the regex will change.

https://github.com/tokens-studio/figma-plugin/assets/25635678/cf2bb7a2-7f0c-4372-9147-8fe4701f6be3

### Additional Notes (if any)

- Although I changed how the code tests the token for `pattern` instead of `oldName`, this does not affect the current way of searching for a normal string, as normal strings are also valid regex.
- When creating the `pattern` const, it checks to see if the string passed is already a regex with slashes, and if so, ~~it strips the first and last slashes — if the slashes remained, then the matches wouldn't be the same anymore, as it would actually search for the slashes.~~ it uses that regex pattern with the given flags, if any. 
  - However, I also made it so that the user doesn't need to pass slashes to use a regex — if there are no slashes, it just uses that pattern with a global flag (matches all occurrences of that pattern in the token), as you can see in the video above.
  - When doing this, I thought that maybe you'd prefer to enforce the usage the slashes if the user is trying to include regex in the search. Which one would you prefer? 😅