### PR TITLE
2.0: fix tests and modals

### DIFF
--- a/packages/tokens-studio-for-figma/cypress/e2e/manage-themes.cy.js
+++ b/packages/tokens-studio-for-figma/cypress/e2e/manage-themes.cy.js
@@ -111,12 +111,9 @@ describe('TokenListing', () => {
     cy.get('[data-testid="button-manage-themes-modal-new-group"]').click();
     cy.get('[data-testid="create-or-edit-theme-form--group--name"]').type('GroupA');
     cy.get('[data-testid="create-or-edit-theme-form--input--name"]').type('My first theme');
-    cy.get('[data-testid="tokensettheme-item--select-trigger--token-source-set"]').click();
-    cy.get('[data-testid="tokensettheme-item--select-content--source"]').click();
-    cy.get('[data-testid="tokensettheme-item--select-trigger--token-enabled-set"]').click();
-    cy.get('[data-testid="tokensettheme-item--select-content--enabled"]').click();
-    cy.get('[data-testid="tokensettheme-item--select-trigger--token-disabled-set"]').click();
-    cy.get('[data-testid="tokensettheme-item--select-content--disabled"]').click();
+    cy.get('[data-testid="tokensettheme-item--ToggleGroup-content--token-source--source"]').click();
+    cy.get('[data-testid="tokensettheme-item--ToggleGroup-content--token-enabled--enabled"]').click();
+    cy.get('[data-testid="tokensettheme-item--ToggleGroup-content--token-disabled--disabled"]').click();
     cy.get('[data-testid="button-manage-themes-modal-save-theme"]').click({ force: true });
     cy.get('[data-testid="close-button"]').click();
     createTokenSet({ name: 'token-extra' });

--- a/packages/tokens-studio-for-figma/cypress/e2e/themes.cy.js
+++ b/packages/tokens-studio-for-figma/cypress/e2e/themes.cy.js
@@ -71,8 +71,7 @@ describe('Themes', () => {
     cy.get('[data-testid="button-manage-themes-modal-new-group"]').click();
     cy.get('[data-testid="create-or-edit-theme-form--group--name"]').type('GroupA');
     cy.get('[data-testid="create-or-edit-theme-form--input--name"]').type('My first theme');
-    cy.get('[data-testid="tokensettheme-item--select-trigger--global-set"]').click();
-    cy.get('[data-testid="tokensettheme-item--select-content--source"]').click();
+    cy.get('[data-testid="tokensettheme-item--ToggleGroup-content--global--source"]').click();
     cy.get('[data-testid="button-manage-themes-modal-save-theme"]').click();
     cy.get('[data-testid="singlethemeentry"]').should('have.length', 1)
   });

--- a/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
@@ -90,7 +90,7 @@ describe('ImportedTokensDialog', () => {
     );
 
     waitFor(async () => {
-      expect(result.queryByText('import')).toBeInTheDocument();
+      expect(result.queryByText('imported')).toBeInTheDocument();
       expect(result.queryByText('newTokens')).toBeInTheDocument();
       expect(result.queryByText('createAll')).toBeInTheDocument();
       expect(result.queryByText('existingTokens')).toBeInTheDocument();
@@ -460,6 +460,6 @@ describe('ImportedTokensDialog', () => {
     });
     expect(mockStore.getState().tokenState.importedTokens.newTokens).toEqual([]);
     expect(mockStore.getState().tokenState.importedTokens.updatedTokens).toEqual([]);
-    expect(result.queryByText('import')).not.toBeInTheDocument();
+    expect(result.queryByText('imported')).not.toBeInTheDocument();
   });
 });

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/SingleThemeEntry.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/SingleThemeEntry.tsx
@@ -30,10 +30,7 @@ const StyledCountLabel = styled('span', {
   gap: '$2',
   fontSize: '$xsmall',
   fontVariantNumeric: 'tabular-nums',
-  svg: {
-    width: '$4',
-    height: '$4',
-  },
+  color: '$fgMuted',
 });
 
 export const SingleThemeEntry: React.FC<React.PropsWithChildren<React.PropsWithChildren<Props>>> = ({
@@ -94,24 +91,27 @@ export const SingleThemeEntry: React.FC<React.PropsWithChildren<React.PropsWithC
       <StyledCountLabel>
         {tokenSetCount > 0 && (
         <>
-          <FileDirectoryIcon />
           {tokenSetCount}
+          {' '}
+          sets
         </>
         )}
       </StyledCountLabel>
       <StyledCountLabel>
         {stylesCount > 0 && (
         <>
-          <StyleIcon />
           {tokenSetCount}
+          {' '}
+          {stylesCount === 1 ? 'style' : 'styles'}
         </>
         )}
       </StyledCountLabel>
       <StyledCountLabel>
         {variablesCount > 0 && (
         <>
-          <VariableIcon />
           {tokenSetCount}
+          {' '}
+          variables
         </>
         )}
       </StyledCountLabel>

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/TokenSetThemeItem.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/TokenSetThemeItem.tsx
@@ -101,7 +101,7 @@ export const TokenSetThemeItem: React.FC<React.PropsWithChildren<React.PropsWith
           >
             {tokenSetStatusValues.map((status) => (
 
-              <ToggleGroup.Item key={status} tooltip={tokenSetStatusLabels[status]} tooltipSide="top" value={status} data-testid={`tokensettheme-item--ToggleGroup-content--${status}`}>
+              <ToggleGroup.Item key={status} tooltip={tokenSetStatusLabels[status]} tooltipSide="top" value={status} data-testid={`tokensettheme-item--ToggleGroup-content--${item.label}--${status}`}>
                 {statusIcon(status)}
               </ToggleGroup.Item>
 

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/__tests__/SingleThemeEntry.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/__tests__/SingleThemeEntry.test.tsx
@@ -32,7 +32,7 @@ describe('SingleThemeEntry', () => {
     );
 
     expect(result.queryByText('Light')).not.toBeNull();
-    expect(result.queryByText('1 sets, 1 styles, 0 variables')).not.toBeNull();
+    expect(result.queryByText('1 style')).not.toBeNull();
 
     const openButton = await result.findByTestId('singlethemeentry-light');
     openButton.click();

--- a/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
@@ -62,7 +62,7 @@ const StyledDialogContent = styled(Dialog.Content, {
         boxShadow: 'none',
       },
       regular: {
-        padding: '0 0 0 $4',
+        padding: '0',
       },
     },
   },
@@ -168,7 +168,7 @@ export function Modal({
               data-testid={id}
               css={{
                 scrollPaddingBlockEnd: footer ? '$8' : 0,
-                paddingBlockEnd: footer ? '$8' : 0,
+                paddingBlockEnd: footer ? '$8' : '$4',
               }}
             >
               {children}

--- a/packages/tokens-studio-for-figma/src/app/components/Settings/Settings.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Settings/Settings.test.tsx
@@ -18,28 +18,6 @@ describe('Settings Component', () => {
     render(<Settings />);
   });
 
-  it('can toggle ignoreFirstPartForStyles', () => {
-    render(<Settings />);
-
-    const ignoreButton = screen.getByTestId('ignoreFirstPartForStyles');
-    fireEvent.click(ignoreButton, {
-      target: ignoreButton,
-    });
-
-    expect(store.getState().settings.ignoreFirstPartForStyles).toBe(true);
-  });
-
-  it('can toggle prefixStylesWithThemeName', () => {
-    render(<Settings />);
-
-    const prefixButton = screen.getByTestId('prefixStylesWithThemeName');
-    fireEvent.click(prefixButton, {
-      target: prefixButton,
-    });
-
-    expect(store.getState().settings.prefixStylesWithThemeName).toBe(true);
-  });
-
   it('show onboarding explainer syncproviders', () => {
     store.dispatch.uiState.setOnboardingExplainerSyncProviders(true);
 

--- a/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
@@ -35,7 +35,7 @@ export default function ToolsDropdown() {
     <>
       <DropdownMenu>
         <DropdownMenu.Trigger asChild>
-          <IconButton size="small" variant="invisible" icon={<FileZipIcon />} />
+          <IconButton tooltip={t('tools')} aria-label={t('tools')} size="small" variant="invisible" icon={<FileZipIcon />} />
         </DropdownMenu.Trigger>
 
         <DropdownMenu.Content side="top">

--- a/packages/tokens-studio-for-figma/src/app/components/__tests__/TokenBottomBar.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/__tests__/TokenBottomBar.test.tsx
@@ -24,7 +24,7 @@ describe('TokenBottomBar', () => {
       </Provider>,
     );
 
-    const toolsButton = await result.findByText('tools');
+    const toolsButton = await result.findByLabelText('tools');
     await userEvent.click(toolsButton);
     const loadButton = await result.findByText('loadFromFileOrPreset');
     await userEvent.click(loadButton, { pointerEventsCheck: 0 });
@@ -46,7 +46,7 @@ describe('TokenBottomBar', () => {
       </Provider>,
     );
 
-    const toolsButton = await result.findByText('tools');
+    const toolsButton = await result.findByLabelText('tools');
     await userEvent.click(toolsButton);
     const exportButton = await result.findByText('exportToFile');
     await userEvent.click(exportButton, { pointerEventsCheck: 0 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -17943,7 +17943,7 @@ react-window@^1.8.8:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^18.2.0:
+react@^18, react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
### Why does this PR exist?

Fixes failing tests on `release-139` as well as the incorrect modal styling

<img width="520" alt="CleanShot 2024-02-28 at 09 39 37@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/d7bfba57-0145-496d-94e2-1791eeea8b18">
