### PR TITLE
2.0: fix cmd click

### DIFF
--- a/.changeset/smart-countries-repair.md
+++ b/.changeset/smart-countries-repair.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue where cmd+clicking a token allowed you to edit even without edit rights

--- a/packages/tokens-studio-for-figma/src/app/components/MoreButton/MoreButton.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/MoreButton/MoreButton.tsx
@@ -123,13 +123,13 @@ export const MoreButton: React.FC<React.PropsWithChildren<React.PropsWithChildre
   const handleTokenClick = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       const isMacBrowser = /Mac/.test(navigator.platform);
-      if ((isMacBrowser && event.metaKey) || (!isMacBrowser && event.ctrlKey)) {
+      if (!editProhibited && ((isMacBrowser && event.metaKey) || (!isMacBrowser && event.ctrlKey))) {
         handleEditClick();
       } else {
         handleClick(properties[0]);
       }
     },
-    [properties, handleClick, handleEditClick],
+    [properties, handleClick, handleEditClick, editProhibited],
   );
 
   return (
@@ -189,7 +189,7 @@ export const MoreButton: React.FC<React.PropsWithChildren<React.PropsWithChildre
           <ContextMenu.Item onSelect={handleDuplicateClick} disabled={editProhibited}>
             Duplicate Token
           </ContextMenu.Item>
-          <ContextMenu.Item onSelect={(event) => handleCopyTokenName(event, token.name)} disabled={editProhibited}>
+          <ContextMenu.Item onSelect={(event) => handleCopyTokenName(event, token.name)}>
             Copy Token Path
           </ContextMenu.Item>
           <ContextMenu.Item onSelect={handleDeleteClick} disabled={editProhibited}>


### PR DESCRIPTION
### Why does this PR exist?

Fixes #2514

Users were able to cmd+click a token to reach the edit token form even if they didnt have edit rights

### What does this pull request do?

Adds the editProhibited condition to the cmd+click check