### PR TITLE
2.0: on set create, put focus on new set

### DIFF
--- a/.changeset/small-coats-reflect.md
+++ b/.changeset/small-coats-reflect.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+After creating a new token set we now switch to this new set

--- a/packages/tokens-studio-for-figma/src/app/components/TokenSetSelector.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenSetSelector.tsx
@@ -54,6 +54,7 @@ export default function TokenSetSelector({ saveScrollPositionSet }: { saveScroll
     e.preventDefault();
     track('Created token set', { name: newTokenSetName });
     dispatch.tokenState.addTokenSet(newTokenSetName.trim());
+    dispatch.tokenState.setActiveTokenSet(newTokenSetName.trim());
     handleNewTokenSetNameChange('');
   }, [dispatch, newTokenSetName]);
 


### PR DESCRIPTION
### Why does this PR exist?

Fixes https://github.com/tokens-studio/figma-plugin/issues/2500

When creating a new token set, we should switch to that new set after creation.

### What does this pull request do?

Calls setActiveTokenSet after creation so that we switch to it