### PR TITLE
Introduce dark figma theme

### DIFF
--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -31,7 +31,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@tokens-studio/ui": "0.5.3",
+    "@tokens-studio/ui": "0.5.4",
     "@tokens-studio/tokens": "0.1.1",
     "@tokens-studio/sdk": "1.1.2",
     "@figma-plugin/helpers": "^0.15.2",

--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -31,8 +31,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@tokens-studio/ui": "0.5.2",
-    "@tokens-studio/tokens": "0.0.24",
+    "@tokens-studio/ui": "0.5.3",
+    "@tokens-studio/tokens": "0.1.1",
     "@tokens-studio/sdk": "1.1.2",
     "@figma-plugin/helpers": "^0.15.2",
     "@gitbeaker/rest": "^39.21.2",

--- a/packages/tokens-studio-for-figma/src/stitches.config.ts
+++ b/packages/tokens-studio-for-figma/src/stitches.config.ts
@@ -1,6 +1,6 @@
 // stitches.config.ts
 import { createStitches } from '@stitches/react';
-import { lightTheme, darkTheme, core } from '@tokens-studio/tokens';
+import { lightTheme, darkFigmaTheme as darkTheme, core } from '@tokens-studio/tokens';
 
 export const stitchesInstance = createStitches({
   theme: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5990,10 +5990,10 @@
   resolved "https://registry.yarnpkg.com/@tokens-studio/types/-/types-0.3.0.tgz#ac0579df362b6b9e47c8893e3ca110d3831f7f26"
   integrity sha512-MgGe1HFH2R/advBxpETgB1VGnCmh3j08igsPmc/1xvm/m2A5fYPmnzqjX6SFlHiajIJ5DEwYbHDzUAO4POn0tw==
 
-"@tokens-studio/ui@0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@tokens-studio/ui/-/ui-0.5.3.tgz#c8ac9ba96569768b1945d31f1c3aaa62607183ba"
-  integrity sha512-elRT6QP3aAO2T5Ls5A5CnwQc0H7lFBeNpK4b7IKfYSKL8HVs9fcYt78HaDpTy8SLxsqZHv9dZFANoEuYlzuW3w==
+"@tokens-studio/ui@0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@tokens-studio/ui/-/ui-0.5.4.tgz#ee971e4ec74d35545d63962121a796d912523815"
+  integrity sha512-q7Mln4I50AWZCoJiDlqPTn17Rx/XRfSJDKV/Y910rS5YFFytmYd31XUnZgXk28vnOP1J9P8B/RaPCSyKg2XW3w==
   dependencies:
     "@iconicicons/react" "^1.5.1"
     "@radix-ui/react-accordion" "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5980,20 +5980,20 @@
     eslint "^8.31.0"
     prettier "^2.8.3"
 
-"@tokens-studio/tokens@0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@tokens-studio/tokens/-/tokens-0.0.24.tgz#1063825e87cd07492b2aedd6dcd6ffb207ac3e7c"
-  integrity sha512-0fuuYAmR5LuaMQelsliuPAvBJ29Aa7pw5fCF6WJd0wpOoLqSV3ttap0D6YRbi67cCmWsKH57mM7jn0jAbEqm4A==
+"@tokens-studio/tokens@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tokens-studio/tokens/-/tokens-0.1.1.tgz#59b73bf435a3365f9d493af794b15c9a0b78f2ee"
+  integrity sha512-s71KqzAHSZAwcYRtA497jAwXKJu79F0Dmwu4zk8CYmmcREH5fUVO+pdy8IINVuTIzX+8WPgA4ZKsNy0SslL4jg==
 
 "@tokens-studio/types@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@tokens-studio/types/-/types-0.3.0.tgz#ac0579df362b6b9e47c8893e3ca110d3831f7f26"
   integrity sha512-MgGe1HFH2R/advBxpETgB1VGnCmh3j08igsPmc/1xvm/m2A5fYPmnzqjX6SFlHiajIJ5DEwYbHDzUAO4POn0tw==
 
-"@tokens-studio/ui@0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@tokens-studio/ui/-/ui-0.5.2.tgz#c05c1d261d4d5fdc5807b935e7633b36e2976492"
-  integrity sha512-DiwzqhyzadtOjtAJd8zROKmupiIJ6ID+3gUbpqO4NigWd3FjfpjXYc+u9WGAsTEx0eFBXRseoCC/6vn5anURxA==
+"@tokens-studio/ui@0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@tokens-studio/ui/-/ui-0.5.3.tgz#c8ac9ba96569768b1945d31f1c3aaa62607183ba"
+  integrity sha512-elRT6QP3aAO2T5Ls5A5CnwQc0H7lFBeNpK4b7IKfYSKL8HVs9fcYt78HaDpTy8SLxsqZHv9dZFANoEuYlzuW3w==
   dependencies:
     "@iconicicons/react" "^1.5.1"
     "@radix-ui/react-accordion" "^1.1.2"


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Changes styling of dark figma to be closer to Figma again (neutral grays)

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Import the newly created darkFigmaTheme from tokens-studio/tokens

<img width="532" alt="CleanShot 2024-03-28 at 08 58 49@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/e91875e7-a1a1-448d-8d46-17d5228d339f">

