### PR TITLE
2411 allow users to select whether to create styles or variables or both while exporting to figma

### DIFF
--- a/.changeset/tough-guests-tease.md
+++ b/.changeset/tough-guests-tease.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Allow users to create styles together when creating variables

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -25,7 +25,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
 
   const { ExportThemesTab, selectedThemes } = useExportThemesTab();
   const { ExportSetsTab, selectedSets } = useExportSetsTab();
-  const { createVariablesFromSets, createVariablesFromThemes, createStylesFromTokens } = useTokens();
+  const { createVariablesFromSets, createVariablesFromThemes, createStylesFromSelectedTokenSets } = useTokens();
 
   const handleShowOptions = React.useCallback(() => {
     setShowOptions(true);
@@ -39,9 +39,9 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
   const handleExportToFigma = React.useCallback(() => {
     if (activeTab === 'useSets') {
       createVariablesFromSets(selectedSets);
+      createStylesFromSelectedTokenSets(selectedSets);
     } else if (activeTab === 'useThemes') {
       createVariablesFromThemes(selectedThemes);
-      createStylesFromTokens();
     }
   }, [activeTab, selectedThemes, selectedSets]);
 

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -25,7 +25,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
 
   const { ExportThemesTab, selectedThemes } = useExportThemesTab();
   const { ExportSetsTab, selectedSets } = useExportSetsTab();
-  const { createVariablesFromSets, createVariablesFromThemes } = useTokens();
+  const { createVariablesFromSets, createVariablesFromThemes, createStylesFromTokens } = useTokens();
 
   const handleShowOptions = React.useCallback(() => {
     setShowOptions(true);
@@ -41,6 +41,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
       createVariablesFromSets(selectedSets);
     } else if (activeTab === 'useThemes') {
       createVariablesFromThemes(selectedThemes);
+      createStylesFromTokens();
     }
   }, [activeTab, selectedThemes, selectedSets]);
 

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -25,7 +25,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
 
   const { ExportThemesTab, selectedThemes } = useExportThemesTab();
   const { ExportSetsTab, selectedSets } = useExportSetsTab();
-  const { createVariablesFromSets, createVariablesFromThemes, createStylesFromSelectedTokenSets } = useTokens();
+  const { createVariablesFromSets, createVariablesFromThemes, createStylesFromSelectedTokenSets, createStylesFromSelectedThemes } = useTokens();
 
   const handleShowOptions = React.useCallback(() => {
     setShowOptions(true);
@@ -42,6 +42,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
       createStylesFromSelectedTokenSets(selectedSets);
     } else if (activeTab === 'useThemes') {
       createVariablesFromThemes(selectedThemes);
+      createStylesFromSelectedThemes(selectedThemes);
     }
   }, [activeTab, selectedThemes, selectedSets]);
 

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -44,7 +44,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
       createVariablesFromThemes(selectedThemes);
       createStylesFromSelectedThemes(selectedThemes);
     }
-  }, [activeTab, selectedThemes, selectedSets]);
+  }, [activeTab, selectedThemes, selectedSets, createVariablesFromSets, createStylesFromSelectedTokenSets, createVariablesFromThemes, createStylesFromSelectedThemes]);
 
   const [canExportToFigma, setCanExportToFigma] = React.useState(false);
 

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/OptionsModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/OptionsModal.tsx
@@ -158,7 +158,7 @@ export default function OptionsModal({ isOpen, title, closeAction }: { isOpen: b
     dispatch.settings.setStylesTypography(stylesTypography);
     dispatch.settings.setStylesColor(stylesColor);
     closeAction();
-  }, [exportOptions]);
+  }, [closeAction, dispatch.settings, variablesColor, variablesNumber, variablesString, variablesBoolean, stylesEffect, stylesTypography, stylesColor]);
 
   const onInteractOutside = (event: Event) => {
     event.preventDefault();

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.test.tsx
@@ -569,7 +569,6 @@ describe('useToken test', () => {
     });
 
     it('respects decision to only create text styles', async () => {
-      // mockConfirm.mockImplementation(() => Promise.resolve({ data: ['textStyles'] }));
 
       const mockStore = createMockStore({
         settings: {

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -363,7 +363,7 @@ export default function useTokens() {
     }));
 
     dispatch.tokenState.assignStyleIdsToCurrentTheme(createStylesResult.styleIds, tokensToCreate);
-  }, [tokens, settings, dispatch.tokenState, activeTokenSet]);
+  }, [tokens, settings, dispatch.tokenState]);
 
   const createStylesFromSelectedThemes = useCallback(async (selectedThemes: string[]) => {
     track('createStyles', {
@@ -413,7 +413,7 @@ export default function useTokens() {
     }));
 
     dispatch.tokenState.assignStyleIdsToCurrentTheme(createStylesResult.styleIds, tokensToCreate);
-  }, [dispatch.tokenState, tokens, settings]);
+  }, [dispatch.tokenState, tokens, settings, themes]);
 
   const syncStyles = useCallback(async () => {
     const userConfirmation = await confirm({

--- a/packages/tokens-studio-for-figma/src/constants/TokenTypes.ts
+++ b/packages/tokens-studio-for-figma/src/constants/TokenTypes.ts
@@ -25,3 +25,12 @@ export enum TokenTypes {
   BOOLEAN = 'boolean',
   NUMBER = 'number',
 };
+
+export const ExportNumberVariablesTokenTypes = [
+  TokenTypes.BORDER_RADIUS,
+  TokenTypes.SIZING,
+  TokenTypes.SPACING,
+  TokenTypes.BORDER_WIDTH,
+  TokenTypes.DIMENSION,
+  TokenTypes.NUMBER
+];

--- a/packages/tokens-studio-for-figma/src/constants/TokenTypes.ts
+++ b/packages/tokens-studio-for-figma/src/constants/TokenTypes.ts
@@ -25,12 +25,3 @@ export enum TokenTypes {
   BOOLEAN = 'boolean',
   NUMBER = 'number',
 };
-
-export const ExportNumberTokenType = [
-  TokenTypes.SIZING,
-  TokenTypes.SPACING,
-  TokenTypes.BORDER_WIDTH,
-  TokenTypes.DIMENSION,
-  TokenTypes.NUMBER,
-  TokenTypes.DIMENSION
-];

--- a/packages/tokens-studio-for-figma/src/constants/TokenTypes.ts
+++ b/packages/tokens-studio-for-figma/src/constants/TokenTypes.ts
@@ -24,4 +24,13 @@ export enum TokenTypes {
   ASSET = 'asset',
   BOOLEAN = 'boolean',
   NUMBER = 'number',
-}
+};
+
+export const ExportNumberTokenType = [
+  TokenTypes.SIZING,
+  TokenTypes.SPACING,
+  TokenTypes.BORDER_WIDTH,
+  TokenTypes.DIMENSION,
+  TokenTypes.NUMBER,
+  TokenTypes.DIMENSION
+];

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.test.ts
@@ -51,6 +51,47 @@ describe('updateStyles', () => {
     expect(effectSpy).not.toHaveBeenCalled();
   });
 
+  it('calls update functions with correct tokens and theme prefix', async () => {
+    const colorTokens = [
+      {
+        name: 'primary.500',
+        path: 'light/primary/500',
+        value: '#ff0000',
+        type: 'color',
+        styleId: '1234',
+        internal__Parent: 'global',
+      },
+    ] as ExtendedSingleToken[];
+
+    mockGetThemeInfo.mockImplementationOnce(() => (
+      Promise.resolve({
+        type: AsyncMessageTypes.GET_THEME_INFO,
+        activeTheme: {
+          [INTERNAL_THEMES_NO_GROUP]: 'light',
+        },
+        themes: [{
+          id: 'light',
+          name: 'light',
+          selectedTokenSets: {
+            global: TokenSetStatus.ENABLED,
+          },
+          $figmaStyleReferences: {
+            'primary.500': '1234',
+          },
+        }],
+      })
+    ));
+
+    await updateStyles([...colorTokens], {
+      prefixStylesWithThemeName: true,
+      stylesColor: true
+    } as SettingsState, false);
+    expect(colorSpy).toHaveBeenCalledWith(
+      colorTokens,
+      false,
+    );
+  });
+
   it('calls update functions with correct tokens when all tokens are given', async () => {
     const colorTokens = [
       {
@@ -94,6 +135,9 @@ describe('updateStyles', () => {
     await updateStyles([...typographyTokens, ...colorTokens, ...effectTokens], {
       prefixStylesWithThemeName: true,
       ignoreFirstPartForStyles: true,
+      stylesColor: true,
+      stylesEffect: true,
+      stylesTypography: true
     } as SettingsState);
     expect(colorSpy).toHaveBeenCalledWith(
       [{
@@ -155,6 +199,7 @@ describe('updateStyles', () => {
 
     await updateStyles(colorTokens, {
       prefixStylesWithThemeName: true,
+      stylesColor: true
     } as SettingsState);
     expect(colorSpy).toHaveBeenCalledWith(
       colorTokens,
@@ -181,6 +226,7 @@ describe('updateStyles', () => {
 
     await updateStyles(typographyTokens, {
       prefixStylesWithThemeName: true,
+      stylesTypography: true
     } as SettingsState);
     expect(textSpy).toHaveBeenCalledWith(
       typographyTokens,
@@ -212,6 +258,9 @@ describe('updateStyles', () => {
 
     await updateStyles(effectTokens, {
       prefixStylesWithThemeName: true,
+      stylesColor: false,
+      stylesEffect: true,
+      stylesTypography: false
     } as SettingsState);
     expect(effectSpy).toHaveBeenCalledWith(
       {
@@ -221,45 +270,5 @@ describe('updateStyles', () => {
     );
     expect(colorSpy).not.toHaveBeenCalled();
     expect(textSpy).not.toHaveBeenCalled();
-  });
-
-  it('calls update functions with correct tokens and theme prefix', async () => {
-    const colorTokens = [
-      {
-        name: 'primary.500',
-        path: 'light/primary/500',
-        value: '#ff0000',
-        type: 'color',
-        styleId: '1234',
-        internal__Parent: 'global',
-      },
-    ] as ExtendedSingleToken[];
-
-    mockGetThemeInfo.mockImplementationOnce(() => (
-      Promise.resolve({
-        type: AsyncMessageTypes.GET_THEME_INFO,
-        activeTheme: {
-          [INTERNAL_THEMES_NO_GROUP]: 'light',
-        },
-        themes: [{
-          id: 'light',
-          name: 'light',
-          selectedTokenSets: {
-            global: TokenSetStatus.ENABLED,
-          },
-          $figmaStyleReferences: {
-            'primary.500': '1234',
-          },
-        }],
-      })
-    ));
-
-    await updateStyles([...colorTokens], {
-      prefixStylesWithThemeName: true,
-    } as SettingsState, false);
-    expect(colorSpy).toHaveBeenCalledWith(
-      colorTokens,
-      false,
-    );
   });
 });

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
@@ -10,7 +10,6 @@ import updateEffectStyles from './updateEffectStyles';
 import updateTextStyles from './updateTextStyles';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { notifyUI } from './notifiers';
-import set from 'set-value';
 
 export default async function updateStyles(
   tokens: AnyTokenList,

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
@@ -10,6 +10,7 @@ import updateEffectStyles from './updateEffectStyles';
 import updateTextStyles from './updateTextStyles';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { notifyUI } from './notifiers';
+import set from 'set-value';
 
 export default async function updateStyles(
   tokens: AnyTokenList,
@@ -51,9 +52,9 @@ export default async function updateStyles(
   if (!colorTokens && !textTokens && !effectTokens) return {};
 
   const allStyleIds = {
-    ...(colorTokens.length > 0 ? updateColorStyles(colorTokens, shouldCreate) : {}),
-    ...(textTokens.length > 0 ? updateTextStyles(textTokens, settings.baseFontSize, shouldCreate) : {}),
-    ...(effectTokens.length > 0 ? await updateEffectStyles({
+    ...(colorTokens.length > 0 && settings.stylesColor ? updateColorStyles(colorTokens, shouldCreate) : {}),
+    ...(textTokens.length > 0 && settings.stylesTypography ? updateTextStyles(textTokens, settings.baseFontSize, shouldCreate) : {}),
+    ...(effectTokens.length > 0 && settings.stylesEffect ? await updateEffectStyles({
       effectTokens, baseFontSize: settings.baseFontSize, shouldCreate,
     }) : {}),
   };

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -6,7 +6,7 @@ import checkIfTokenCanCreateVariable from '@/utils/checkIfTokenCanCreateVariable
 import setValuesOnVariable from './setValuesOnVariable';
 import { mapTokensToVariableInfo } from '@/utils/mapTokensToVariableInfo';
 import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
-import { ExportNumberTokenType, TokenTypes } from '@/constants/TokenTypes';
+import { TokenTypes } from '@/constants/TokenTypes';
 
 export type CreateVariableTypes = {
   collection: VariableCollection;
@@ -27,7 +27,7 @@ export default function updateVariables({
     if (checkIfTokenCanCreateVariable(token)) {
       if (
         (token.type === TokenTypes.COLOR && settings.variablesColor) ||
-        (ExportNumberTokenType.includes[token.type] && settings.variablesNumber) ||
+        (token.type === TokenTypes.NUMBER && settings.variablesNumber) ||
         (token.type === TokenTypes.TEXT && settings.variablesString) ||
         (token.type === TokenTypes.BOOLEAN && settings.variablesBoolean)
       ) {

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -6,6 +6,7 @@ import checkIfTokenCanCreateVariable from '@/utils/checkIfTokenCanCreateVariable
 import setValuesOnVariable from './setValuesOnVariable';
 import { mapTokensToVariableInfo } from '@/utils/mapTokensToVariableInfo';
 import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
+import { ExportNumberTokenType, TokenTypes } from '@/constants/TokenTypes';
 
 export type CreateVariableTypes = {
   collection: VariableCollection;
@@ -25,10 +26,10 @@ export default function updateVariables({
   tokensToCreate.forEach((token) => {
     if (checkIfTokenCanCreateVariable(token)) {
       if (
-        (token.type === 'color' && settings.variablesColor) ||
-        (token.type === 'number' && settings.variablesNumber) ||
-        (token.type === 'text' && settings.variablesString) ||
-        (token.type === 'boolean' && settings.variablesBoolean)
+        (token.type === TokenTypes.COLOR && settings.variablesColor) ||
+        (ExportNumberTokenType.includes[token.type] && settings.variablesNumber) ||
+        (token.type === TokenTypes.TEXT && settings.variablesString) ||
+        (token.type === TokenTypes.BOOLEAN && settings.variablesBoolean)
       ) {
         variablesToCreate.push(mapTokensToVariableInfo(token, theme, settings));
       }

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -6,7 +6,7 @@ import checkIfTokenCanCreateVariable from '@/utils/checkIfTokenCanCreateVariable
 import setValuesOnVariable from './setValuesOnVariable';
 import { mapTokensToVariableInfo } from '@/utils/mapTokensToVariableInfo';
 import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
-import { TokenTypes } from '@/constants/TokenTypes';
+import { ExportNumberVariablesTokenTypes, TokenTypes } from '@/constants/TokenTypes';
 
 export type CreateVariableTypes = {
   collection: VariableCollection;
@@ -27,7 +27,7 @@ export default function updateVariables({
     if (checkIfTokenCanCreateVariable(token)) {
       if (
         (token.type === TokenTypes.COLOR && settings.variablesColor) ||
-        (token.type === TokenTypes.NUMBER && settings.variablesNumber) ||
+        (ExportNumberVariablesTokenTypes.includes(token.type) && settings.variablesNumber) ||
         (token.type === TokenTypes.TEXT && settings.variablesString) ||
         (token.type === TokenTypes.BOOLEAN && settings.variablesBoolean)
       ) {


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?
The current implementation only create styles based on selected sets.

Closes #2411 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?
Provide a new feature that allow users to create styles based on selected themes.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
