### PR TITLE
add support email to license key error message

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/AddLicenseKey/AddLicenseKey.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/AddLicenseKey/AddLicenseKey.test.tsx
@@ -238,7 +238,7 @@ describe('Add license key', () => {
 
     await waitFor(() => {
       notifyToUISpy.mockReturnValueOnce();
-      expect(notifyToUISpy).toBeCalledWith('Error removing license, please contact support', { error: true });
+      expect(notifyToUISpy).toBeCalledWith('Error removing license, please contact support@tokens.studio', { error: true });
     });
   });
 

--- a/packages/tokens-studio-for-figma/src/app/store/models/userState.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/userState.ts
@@ -140,7 +140,7 @@ export const userState = createModel<RootModel>()({
       if (licenseKey && !licenseError) {
         const { error } = await removeLicense(licenseKey, userId);
         if (error) {
-          notifyToUI('Error removing license, please contact support', { error: true });
+          notifyToUI('Error removing license, please contact support@tokens.studio', { error: true });
         }
       }
       // clear license key related state


### PR DESCRIPTION
### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/2548

### What does this pull request do?

Adds email address to licnse key error message