### PR TITLE
Add number/dimension token types to suggestions for typography tokens

### DIFF
--- a/.changeset/late-planes-buy.md
+++ b/.changeset/late-planes-buy.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Typography tokens such as line heights, font sizes, paragrap spacing, paragraph indent and letter spacing now take number and dimension tokens as suggested tokens

--- a/packages/tokens-studio-for-figma/src/app/hooks/useReferenceTokenType.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useReferenceTokenType.ts
@@ -12,6 +12,16 @@ export function useReferenceTokenType(type: TokenTypes): TokenTypes[] {
         return [TokenTypes.BORDER_RADIUS, TokenTypes.DIMENSION, TokenTypes.NUMBER];
       case TokenTypes.BORDER_WIDTH:
         return [TokenTypes.BORDER_WIDTH, TokenTypes.DIMENSION, TokenTypes.NUMBER];
+      case TokenTypes.LINE_HEIGHTS:
+        return [TokenTypes.LINE_HEIGHTS, TokenTypes.NUMBER, TokenTypes.DIMENSION];
+      case TokenTypes.FONT_SIZES:
+        return [TokenTypes.FONT_SIZES, TokenTypes.NUMBER, TokenTypes.DIMENSION];
+      case TokenTypes.PARAGRAPH_SPACING:
+        return [TokenTypes.PARAGRAPH_SPACING, TokenTypes.NUMBER, TokenTypes.DIMENSION];
+      case TokenTypes.PARAGRAPH_INDENT:
+        return [TokenTypes.PARAGRAPH_INDENT, TokenTypes.NUMBER, TokenTypes.DIMENSION];
+      case TokenTypes.LETTER_SPACING:
+        return [TokenTypes.LETTER_SPACING, TokenTypes.NUMBER, TokenTypes.DIMENSION];
       default:
         return [type];
     }


### PR DESCRIPTION
### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/2528

### What does this pull request do?

Adds number and dimension token types to a couple of typography suggested types
