### PR TITLE
2585 20 tools and styles and variables menu zindex clashes with token sets

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/StylesDropdown.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StylesDropdown.tsx
@@ -30,11 +30,13 @@ export default function StylesDropdown() {
           </Button>
         </DropdownMenu.Trigger>
 
-        <DropdownMenu.Content side="top" css={{ zIndex: 100 }}>
-          <DropdownMenu.Item textValue="Export styles & variables" onSelect={handleOpenModal}>{t('exportStylesAndVariables')}</DropdownMenu.Item>
-          <DropdownMenu.Item textValue="Import variables" disabled={importDisabled} onSelect={pullVariables}>{t('importVariables')}</DropdownMenu.Item>
-          <DropdownMenu.Item textValue="Import styles" disabled={importDisabled} onSelect={pullStyles}>{t('importStyles')}</DropdownMenu.Item>
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content side="top">
+            <DropdownMenu.Item textValue="Export styles & variables" onSelect={handleOpenModal}>{t('exportStylesAndVariables')}</DropdownMenu.Item>
+            <DropdownMenu.Item textValue="Import variables" disabled={importDisabled} onSelect={pullVariables}>{t('importVariables')}</DropdownMenu.Item>
+            <DropdownMenu.Item textValue="Import styles" disabled={importDisabled} onSelect={pullStyles}>{t('importStyles')}</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu>
       <ManageStylesAndVariables showModal={showModal} setShowModal={setShowModal} />
     </>

--- a/packages/tokens-studio-for-figma/src/app/components/StylesDropdown.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StylesDropdown.tsx
@@ -30,7 +30,7 @@ export default function StylesDropdown() {
           </Button>
         </DropdownMenu.Trigger>
 
-        <DropdownMenu.Content side="top">
+        <DropdownMenu.Content side="top" css={{ zIndex: 100 }}>
           <DropdownMenu.Item textValue="Export styles & variables" onSelect={handleOpenModal}>{t('exportStylesAndVariables')}</DropdownMenu.Item>
           <DropdownMenu.Item textValue="Import variables" disabled={importDisabled} onSelect={pullVariables}>{t('importVariables')}</DropdownMenu.Item>
           <DropdownMenu.Item textValue="Import styles" disabled={importDisabled} onSelect={pullStyles}>{t('importStyles')}</DropdownMenu.Item>

--- a/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
@@ -38,7 +38,7 @@ export default function ToolsDropdown() {
           <IconButton tooltip={t('tools')} aria-label={t('tools')} size="small" variant="invisible" icon={<FileZipIcon />} />
         </DropdownMenu.Trigger>
 
-        <DropdownMenu.Content side="top">
+        <DropdownMenu.Content side="top" css={{ zIndex: 100 }}>
           <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowPresetModal}>{t('loadFromFileOrPreset')}</DropdownMenu.Item>
           <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowExportModal}>{t('exportToFile')}</DropdownMenu.Item>
         </DropdownMenu.Content>

--- a/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
@@ -38,10 +38,12 @@ export default function ToolsDropdown() {
           <IconButton tooltip={t('tools')} aria-label={t('tools')} size="small" variant="invisible" icon={<FileZipIcon />} />
         </DropdownMenu.Trigger>
 
-        <DropdownMenu.Content side="top" css={{ zIndex: 100 }}>
-          <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowPresetModal}>{t('loadFromFileOrPreset')}</DropdownMenu.Item>
-          <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowExportModal}>{t('exportToFile')}</DropdownMenu.Item>
-        </DropdownMenu.Content>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content side="top">
+            <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowPresetModal}>{t('loadFromFileOrPreset')}</DropdownMenu.Item>
+            <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowExportModal}>{t('exportToFile')}</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
       </DropdownMenu>
       {exportModalVisible && <ExportModal onClose={handleCloseExportModal} />}
       {presetModalVisible && <PresetModal onClose={handleClosePresetModal} />}


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?
The current plugin has css issue which the portal modals (`Load examples` and `Export Styles & Variables modals`) is behind the token sets entries.

Closes #2585 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?
Wrapped `DropdownMenu,Content` with `DropdownMenu,Portal`.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->



https://github.com/tokens-studio/figma-plugin/assets/103296157/8dea4743-5b58-408f-a659-c84776058e95

