### PR TITLE
2.0: Fix modal issues

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -20,12 +20,14 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
 
   const isPro = useIsProUser();
 
-  const [showOptions, setShowOptions] = React.useState(false);
-  const [activeTab, setActiveTab] = React.useState<'useThemes' | 'useSets'>(isPro? 'useThemes': 'useSets');
+  const [showOptions, setShowOptions] = React.useState(true);
+  const [activeTab, setActiveTab] = React.useState<'useThemes' | 'useSets'>(isPro ? 'useThemes' : 'useSets');
 
   const { ExportThemesTab, selectedThemes } = useExportThemesTab();
   const { ExportSetsTab, selectedSets } = useExportSetsTab();
-  const { createVariablesFromSets, createVariablesFromThemes, createStylesFromSelectedTokenSets, createStylesFromSelectedThemes } = useTokens();
+  const {
+    createVariablesFromSets, createVariablesFromThemes, createStylesFromSelectedTokenSets, createStylesFromSelectedThemes,
+  } = useTokens();
 
   const handleShowOptions = React.useCallback(() => {
     setShowOptions(true);
@@ -49,7 +51,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
   const [canExportToFigma, setCanExportToFigma] = React.useState(false);
 
   useEffect(() => {
-    setCanExportToFigma(activeTab === 'useSets'? true: selectedThemes.length > 0);
+    setCanExportToFigma(activeTab === 'useSets' ? true : selectedThemes.length > 0);
   }, [selectedThemes, activeTab]);
 
   const handleTabChange = React.useCallback((tab: 'useThemes' | 'useSets') => {
@@ -95,7 +97,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
   )}
         stickyFooter
       >
-        <Tabs defaultValue={isPro? 'useThemes': 'useSets'}>
+        <Tabs defaultValue={isPro ? 'useThemes' : 'useSets'}>
           <Tabs.List>
             <Tabs.Trigger value="useThemes" onClick={() => handleTabChange('useThemes')}>
               {t('tabs.exportThemes')}
@@ -107,7 +109,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
           <ExportSetsTab />
         </Tabs>
       </Modal>
-      <OptionsModal isOpen={showOptions} title="Manage / Export Options" closeAction={handleCancelOptions} />
+      <OptionsModal isOpen={showModal && showOptions} title="Export to Figma: Options" closeAction={handleCancelOptions} />
     </>
   );
 }

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -109,7 +109,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
           <ExportSetsTab />
         </Tabs>
       </Modal>
-      <OptionsModal isOpen={showModal && showOptions} title="Export to Figma: Options" closeAction={handleCancelOptions} />
+      <OptionsModal isOpen={showModal && showOptions} title={t('optionsModalTitle')} closeAction={handleCancelOptions} />
     </>
   );
 }

--- a/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
@@ -169,7 +169,7 @@ export function Modal({
               data-testid={id}
               css={{
                 scrollPaddingBlockEnd: footer ? '$4' : 0,
-                marginBottom: footer ? 'calc(var(--sizes-controlMedium) + var(--space-5))' : 0, // Size of the fixed footer incl default sized buttons
+                marginBottom: footer && size === 'fullscreen' ? 'calc(var(--sizes-controlMedium) + var(--space-6))' : 0, // Size of the fixed footer incl default sized buttons
               }}
             >
               {children}

--- a/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
+++ b/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
@@ -1,5 +1,5 @@
 {
-"modalTitle": "Manage Styles and Variables",
+"modalTitle": "Export to Figma",
 "buttonLabel": "Styles and Variables",
 "actions": {
   "export": "Export to Figma",

--- a/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
+++ b/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
@@ -1,6 +1,7 @@
 {
 "modalTitle": "Export to Figma",
 "buttonLabel": "Styles and Variables",
+"optionsModalTitle": "Export to Figma Options",
 "actions": {
   "export": "Export to Figma",
   "import": "Import from Figma",


### PR DESCRIPTION

### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/2579
Closes https://github.com/tokens-studio/figma-plugin/issues/2583

### What does this pull request do?

This pull request primarily updates the `ManageStylesAndVariables` component and the `Modal` component in the `tokens-studio-for-figma` package, and modifies the internationalization settings for the modal title. The most significant changes include setting the initial state of `showOptions` to `true`, adjusting the conditions for showing the `OptionsModal`, altering the `marginBottom` style in the `Modal` component, and updating the modal title in the internationalization settings.

### Testing this change

use the export to figma modal

### Additional Notes (if any)

<img width="510" alt="CleanShot 2024-04-09 at 00 15 36@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/58625997-65a6-4814-b044-d5aaee879454">

<img width="506" alt="CleanShot 2024-04-09 at 00 15 55@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/43010cd4-6109-4276-91ea-f44871301a25">

