### PR TITLE
2578 20 spacing missing on manage themes modal buttons

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ManageThemesModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ManageThemesModal.tsx
@@ -189,21 +189,23 @@ export const ManageThemesModal: React.FC<React.PropsWithChildren<React.PropsWith
                 </Button>
                 )}
               </Box>
-              <Button
-                data-testid="button-manage-themes-modal-cancel"
-                variant="secondary"
-                onClick={handleToggleOpenThemeEditor}
-              >
-                Cancel
-              </Button>
-              <Button
-                data-testid="button-manage-themes-modal-save-theme"
-                variant="primary"
-                type="submit"
-                form="form-create-or-edit-theme"
-              >
-                Save theme
-              </Button>
+              <Stack direction="row" gap={4}>
+                <Button
+                  data-testid="button-manage-themes-modal-cancel"
+                  variant="secondary"
+                  onClick={handleToggleOpenThemeEditor}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  data-testid="button-manage-themes-modal-save-theme"
+                  variant="primary"
+                  type="submit"
+                  form="form-create-or-edit-theme"
+                >
+                  Save theme
+                </Button>
+              </Stack>
             </>
           )}
         </Stack>


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?
The current plugin does not have spacing between buttons in new theme modal.

Closes #2578 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?
Added spacing between buttons in new theme modal.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->

![image](https://github.com/tokens-studio/figma-plugin/assets/103296157/09bf978c-efd6-4884-bf4a-39baa4a7aa76)

