### PR TITLE
FIX: #2607 [2.0] border tokens with hex value not being applied

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
@@ -22,8 +22,6 @@ export default async function setColorValuesOnTarget(target: BaseNode | PaintSty
       existingPaint = target.strokes[0] ?? null;
     }
 
-   
-
     if (value.startsWith('linear-gradient')) {
       const { gradientStops, gradientTransform } = convertStringToFigmaGradient(value);
       const newPaint: GradientPaint = {
@@ -65,25 +63,23 @@ export default async function setColorValuesOnTarget(target: BaseNode | PaintSty
     Promise.resolve();
   } catch (e) {
     // It's not a token value, it's actually a color value
-    try{
-      const value = token // the token is not a token, it's a misnomer
-      if(value.startsWith('linear-gradient')) {
+    try {
+      const value = token; // the token is not a token, it's a misnomer
+      if (value.startsWith('linear-gradient')) {
         const { gradientStops, gradientTransform } = convertStringToFigmaGradient(value);
         const newPaint: GradientPaint = {
           type: 'GRADIENT_LINEAR',
           gradientTransform,
           gradientStops,
         };
-        target[key] = [newPaint]
+        target[key] = [newPaint];
       } else {
-        const { color, opacity } = convertToFigmaColor(value)
+        const { color, opacity } = convertToFigmaColor(value);
         const newPaint: SolidPaint = { color, opacity, type: 'SOLID' };
-        target[key] = [newPaint]
+        target[key] = [newPaint];
       }
-      
-
     } catch (e) {
-      console.error('Error setting color', e)
+      console.error('Error setting color', e);
     }
   }
 }


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #2607 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

The setColorValuesOnTarget method expects a 'token' value

I've added a failover that if the value isn't a token to resolve, it's probably a raw value, and we should try setting that.

It's not the cleanest of fixes, but it should work for users. 

Ideally, I would like to refactor the method entirely, to take a boolean isTokenReference flag, which would make this logic a bit nicer - however given the current priorities, I've avoided over-solutionising. 
If we're happy with this, I'll make a follow up issue to address as a future thing to fix.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
