### PR TITLE
2.0: fix alias in edit token form

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -132,7 +132,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
       if (internalEditToken?.status === EditTokenFormStatus.CREATE) {
         // If we are creating a new token, disallow naming it as a prefix of an existing token
         return tokensWithSameParent.find((t) => internalEditToken.name?.startsWith(`${t.name}.`));
-      } else if (internalEditToken?.status === EditTokenFormStatus.EDIT) {
+      } if (internalEditToken?.status === EditTokenFormStatus.EDIT) {
         // If we are editing a token, only disallow the name if it's prefix matches another token and it is not the token we are currently editing
         return tokensWithSameParent.find((t) => internalEditToken.name?.startsWith(`${t.name}.`) && internalEditToken.initialName !== t.name);
       }
@@ -630,7 +630,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
             </Box>
           )
         }
-      <Stack direction="row" justify="end" gap={2}>
+      <Stack direction="row" justify="end" gap={4}>
         <Button variant="secondary" type="button" onClick={handleReset}>
           {t('cancel')}
         </Button>

--- a/packages/tokens-studio-for-figma/src/utils/alias/getAliasValue.ts
+++ b/packages/tokens-studio-for-figma/src/utils/alias/getAliasValue.ts
@@ -10,6 +10,7 @@ import { isSingleTokenValueObject } from '../is';
 import { checkAndEvaluateMath } from '../math';
 // eslint-disable-next-line import/no-cycle
 import { checkIfAlias } from './checkIfAlias';
+import { isSingleInternalTokenValueObject } from '../is/isSingleInternalTokenValueObject';
 
 type TokenNameNodeType = string | undefined;
 
@@ -17,7 +18,7 @@ function getReturnedValue(token: SingleToken | string | number) {
   if (typeof token === 'object' && typeof token.value === 'object' && (token?.type === TokenTypes.BOX_SHADOW || token?.type === TokenTypes.TYPOGRAPHY || token?.type === TokenTypes.BORDER)) {
     return token.value;
   }
-  if (isSingleTokenValueObject(token)) {
+  if (isSingleInternalTokenValueObject(token)) {
     return token.value.toString();
   }
   return token.toString();

--- a/packages/tokens-studio-for-figma/src/utils/is/isSingleInternalTokenValueObject.ts
+++ b/packages/tokens-studio-for-figma/src/utils/is/isSingleInternalTokenValueObject.ts
@@ -1,0 +1,14 @@
+import { SingleTokenValueObject } from './isSingleTokenValueObject';
+
+export function isSingleInternalTokenValueObject(token: SingleTokenValueObject | any): token is SingleTokenValueObject {
+  return !!(
+    token
+    && typeof token === 'object'
+    && 'value' in token
+    && (
+      typeof token.value !== 'undefined'
+      && token.value !== null
+      && !(typeof token.value === 'object' && (token && 'value' in token.value))
+    )
+  );
+}

--- a/packages/tokens-studio-for-figma/src/utils/is/isSingleTokenValueObject.ts
+++ b/packages/tokens-studio-for-figma/src/utils/is/isSingleTokenValueObject.ts
@@ -1,7 +1,7 @@
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { SingleToken } from '@/types/tokens';
 
-type SingleTokenValueObject = Pick<SingleToken, 'value'>;
+export type SingleTokenValueObject = Pick<SingleToken, 'value'>;
 
 export function isSingleTokenValueObject(token: SingleTokenValueObject | any): token is SingleTokenValueObject {
   return !!(


### PR DESCRIPTION
### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/2574
Closes https://github.com/tokens-studio/figma-plugin/issues/2573

### What does this pull request do?

The edit token form uses `internalToken` which is our internal token object. When resolving, we were relying on the `isSingleTokenValueObject` to give us the proper resolution based on $value or value. However, internally we always store `value`. Changed this so that internally we have the proper results.

Before:
<img width="495" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/d870bcbf-faa6-4cc2-ba73-5138f531fedd">

After:
![CleanShot 2024-04-12 at 09 10 10@2x](https://github.com/tokens-studio/figma-plugin/assets/4548309/f96bdcfc-a925-4022-9909-3adf1224a3cf)

