### PR TITLE
2.0: Variable and style creation improvements

### DIFF
--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -144,7 +144,7 @@
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.12.16",
     "@changesets/cli": "^2.26.2",
-    "@figma/plugin-typings": "^1.85.0",
+    "@figma/plugin-typings": "^1.90.0",
     "@sentry/webpack-plugin": "^2.2.0",
     "@storybook/addon-actions": "^6.5.8",
     "@storybook/addon-docs": "^6.5.8",

--- a/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
@@ -25,6 +25,7 @@ export const backgroundJobTitles = {
   [BackgroundJobs.UI_UNDOING]: 'Undoing action...',
   [BackgroundJobs.UI_ATTACHING_LOCAL_STYLES]: 'Attaching local styles to theme...',
   [BackgroundJobs.UI_CREATEVARIABLES]: 'Creating variables...',
+  [BackgroundJobs.UI_CREATE_STYLES]: 'Creating styles...',
 };
 
 export default function LoadingBar() {

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -38,15 +38,15 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
     setShowOptions(false);
   }, []);
 
-  const handleExportToFigma = React.useCallback(() => {
+  const handleExportToFigma = React.useCallback(async () => {
+    setShowModal(false);
     if (activeTab === 'useSets') {
-      createVariablesFromSets(selectedSets);
+      await createVariablesFromSets(selectedSets);
       createStylesFromSelectedTokenSets(selectedSets);
     } else if (activeTab === 'useThemes') {
-      createVariablesFromThemes(selectedThemes);
+      await createVariablesFromThemes(selectedThemes);
       createStylesFromSelectedThemes(selectedThemes);
     }
-    setShowModal(false);
   }, [setShowModal, activeTab, selectedThemes, selectedSets, createVariablesFromSets, createStylesFromSelectedTokenSets, createVariablesFromThemes, createStylesFromSelectedThemes]);
 
   const [canExportToFigma, setCanExportToFigma] = React.useState(false);

--- a/packages/tokens-studio-for-figma/src/constants/BackgroundJobs.ts
+++ b/packages/tokens-studio-for-figma/src/constants/BackgroundJobs.ts
@@ -20,4 +20,5 @@ export enum BackgroundJobs {
   UI_ATTACHING_LOCAL_VARIABLES = 'ui_attaching_local_variables',
   UI_RENAME_TOKEN_ACROSS_SETS = 'ui_rename_token_across_sets',
   UI_CREATEVARIABLES = 'ui_create_variables',
+  UI_CREATE_STYLES = 'ui_create_styles',
 }

--- a/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
@@ -6,7 +6,9 @@ import { ColorPaintType, tryApplyColorVariableId } from '@/utils/tryApplyColorVa
 import { unbindVariableFromTarget } from './unbindVariableFromTarget';
 
 export default async function setColorValuesOnTarget(target: BaseNode | PaintStyle, token: string, key: 'paints' | 'fills' | 'strokes' = 'paints') {
-  const shouldCreateStylesWithVariables = defaultTokenValueRetriever.createStylesWithVariableReferences;
+  // If we're creating styles we need to check the user's setting. If we're applying on a layer, always try to apply variables.
+  // 'consumers' only exists in styles, so we can use that to determine if we're creating a style or applying to a layer
+  const shouldCreateStylesWithVariables = defaultTokenValueRetriever.createStylesWithVariableReferences || !('consumers' in target);
   try {
     const resolvedToken = defaultTokenValueRetriever.get(token);
     if (typeof resolvedToken === 'undefined') return;

--- a/packages/tokens-studio-for-figma/src/plugin/setEffectValuesOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setEffectValuesOnTarget.ts
@@ -37,7 +37,9 @@ async function tryApplyCompositeVariable({
   baseFontSize: string;
   resolvedValue: ResolvedShadowObject;
 }) {
-  const shouldCreateStylesWithVariables = defaultTokenValueRetriever.createStylesWithVariableReferences;
+  // If we're creating styles we need to check the user's setting. If we're applying on a layer, always try to apply variables.
+  // 'consumers' only exists in styles, so we can use that to determine if we're creating a style or applying to a layer
+  const shouldCreateStylesWithVariables = defaultTokenValueRetriever.createStylesWithVariableReferences || !('consumers' in target);
 
   const { color, opacity: a } = convertToFigmaColor(value.color);
   const { r, g, b } = color;

--- a/packages/tokens-studio-for-figma/src/plugin/updatePluginDataAndNodes.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updatePluginDataAndNodes.ts
@@ -11,7 +11,6 @@ import { removePluginData, setNonePluginData } from './pluginData';
 import { SettingsState } from '@/app/store/models/settings';
 import { destructureTokenForAlias, mapValuesToTokens } from './node';
 import setValuesOnNode from './setValuesOnNode';
-import { defaultTokenValueRetriever } from './TokenValueRetriever';
 
 export async function updatePluginDataAndNodes({
   entries: nodes, values: tokenValues, tokensMap, settings,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,10 +3038,10 @@
     lodash "^4.17.15"
     matrix-inverse "^1.0.1"
 
-"@figma/plugin-typings@^1.85.0":
-  version "1.85.0"
-  resolved "https://registry.yarnpkg.com/@figma/plugin-typings/-/plugin-typings-1.85.0.tgz#dfbe722ebffd3e84e070b3a75c62ba0a932c7c56"
-  integrity sha512-o6oJ4FrjBIVbwteJ6DbCvjU8UXbN9QzA5FgjNosTE+HpwntPSEbpVFPkgEFuI1G/GhJXrhXR8/QcuBabwZ+JLw==
+"@figma/plugin-typings@^1.90.0":
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/@figma/plugin-typings/-/plugin-typings-1.90.0.tgz#b69d9cf6605ab3050d4076ea0e28671be0531889"
+  integrity sha512-RvZrSkuV0SABRaYuRFO/S30u9+RGKJm6+CPjSG7MaMo60p8S1sX5YOWT+zDWZC6mqNEaxLkrbXdiyqWXsfdHQg==
 
 "@floating-ui/core@^1.4.2":
   version "1.5.1"


### PR DESCRIPTION
### Why does this PR exist?

Fixes https://github.com/tokens-studio/figma-plugin/issues/2614
Also changes behavior of styles and variables menu to close on export
Adds a check to only create variables or styles if either there's some selected sets/themes, as well as the various settings were checked

### What does this pull request do?

Changes the logic to await creation of variables before we're creating styles to make sure users just need to run it once. Also added checks to make sure we're only creating when needed.

### Testing this change

Create variables using either modes as well as a combination of styles and variables

https://github.com/tokens-studio/figma-plugin/assets/4548309/ef5d92fd-7e50-408c-bba4-818183a74828

