### PR TITLE
fix re-render of manage styles modal (sets) + polish

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
@@ -1,0 +1,154 @@
+import { FileDirectoryIcon } from '@primer/octicons-react';
+import {
+  Tabs, Stack, Heading, Button, Link,
+} from '@tokens-studio/ui';
+import React, { useMemo } from 'react';
+import { useDispatch, useSelector, useStore } from 'react-redux';
+import { useForm, Controller } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import Modal from '../Modal';
+import { TokenSetTreeContent } from '../TokenSetTree/TokenSetTreeContent';
+import { StyledCard } from './StyledCard';
+
+import { ExplainerModal } from '../ExplainerModal';
+import OnboardingExplainer from '../OnboardingExplainer';
+import { Dispatch } from '../../store';
+
+import { allTokenSetsSelector, usedTokenSetSelector } from '@/selectors';
+import { docsLinks } from './docsLinks';
+import { RootState } from '@/app/store';
+import { tokenSetListToTree, TreeItem } from '@/utils/tokenset';
+import { TokenSetThemeItem } from '../ManageThemesModal/TokenSetThemeItem';
+import { FormValues } from '../ManageThemesModal/CreateOrEditThemeForm';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { ExportTokenSet } from '@/types/ExportTokenSet';
+import useExportSetsTab from './useExportSetsTab';
+
+export default function ExportSetsTab() {
+  const dispatch = useDispatch<Dispatch>();
+  const closeOnboarding = React.useCallback(() => {
+    dispatch.uiState.setOnboardingExplainerExportSets(false);
+  }, [dispatch]);
+  const onboardingExplainerExportSets = useSelector((state: RootState) => state.uiState.onboardingExplainerExportSets);
+
+  const { t } = useTranslation(['manageStylesAndVariables']);
+  const { selectedSets, setSelectedSets } = useExportSetsTab();
+
+  const store = useStore<RootState>();
+
+  const [showChangeSets, setShowChangeSets] = React.useState(false);
+
+  const allSets = useSelector(allTokenSetsSelector);
+
+  const selectedTokenSets = React.useMemo(() => (
+    usedTokenSetSelector(store.getState())
+  ), [store]);
+
+  const availableTokenSets = useSelector(allTokenSetsSelector);
+
+  const setsTree = React.useMemo(() => tokenSetListToTree(availableTokenSets), [availableTokenSets]);
+
+  const handleCancelChangeSets = React.useCallback(() => {
+    // DO NOT SAVE THE SET CHANGES
+    setShowChangeSets(false);
+  }, []);
+
+  const handleShowChangeSets = React.useCallback(() => {
+    setShowChangeSets(true);
+  }, []);
+
+  const { control, getValues } = useForm<FormValues>({
+    defaultValues: {
+      tokenSets: { ...selectedTokenSets },
+    },
+  });
+
+  const TokenSetThemeItemInput = React.useCallback((props: React.PropsWithChildren<{ item: TreeItem }>) => (
+    <Controller
+      name="tokenSets"
+      control={control}
+      // this is the only way to do this
+      // eslint-disable-next-line
+      render={({ field }) => (
+        <TokenSetThemeItem
+          {...props}
+          value={field.value}
+          onChange={field.onChange}
+        />
+      )}
+    />
+  ), [control]);
+
+  const selectedEnabledSets = useMemo(() => selectedSets.filter((set) => set.status === TokenSetStatus.ENABLED), [selectedSets]);
+
+  React.useEffect(() => {
+    if (!showChangeSets) {
+      const currentSelectedSets = getValues();
+      const internalSelectedTokenSets: ExportTokenSet[] = Object.keys(currentSelectedSets.tokenSets).reduce((acc: ExportTokenSet[], curr: string) => {
+        if (currentSelectedSets.tokenSets[curr] !== TokenSetStatus.DISABLED) {
+          const tokenSet = {
+            set: curr,
+            status: currentSelectedSets.tokenSets[curr],
+          } as ExportTokenSet;
+          acc.push(tokenSet);
+        }
+        return acc;
+      }, [] as ExportTokenSet[]);
+      setSelectedSets([...internalSelectedTokenSets]);
+    }
+  }, [showChangeSets, getValues, setSelectedSets]);
+
+  return (
+    <Tabs.Content value="useSets">
+      <StyledCard>
+        <Stack direction="column" align="start" gap={6}>
+          <Stack direction="column" align="start" gap={4}>
+            {onboardingExplainerExportSets ? (
+              <OnboardingExplainer
+                data={{
+                  text: t('exportSetsTab.intro'),
+                  title: t('exportSetsTab.confirmSets'),
+                  url: docsLinks.stylesAndVariables,
+                }}
+                closeOnboarding={closeOnboarding}
+              />
+            ) : (
+              <Stack direction="row" align="center" gap={2}>
+                <Heading>{t('exportSetsTab.confirmSets')}</Heading>
+                <ExplainerModal title={t('exportSetsTab.confirmSets')}>
+                  {t('exportSetsTab.intro')}
+                  <Link target="_blank" href={docsLinks.stylesAndVariables}>{`${t('generic.learnMore')} – ${t('docs.stylesAndVariables')}`}</Link>
+                </ExplainerModal>
+              </Stack>
+            )}
+          </Stack>
+          <Stack direction="row" align="start" gap={2}>
+            <FileDirectoryIcon size="small" />
+            <span>
+              {selectedEnabledSets.length}
+              {' of '}
+              {allSets.length}
+              {' '}
+              {t('exportSetsTab.setsSelectedForExport')}
+            </span>
+          </Stack>
+          <Button variant="secondary" size="small" onClick={handleShowChangeSets}>{t('actions.changeSets')}</Button>
+        </Stack>
+      </StyledCard>
+      <Modal size="fullscreen" full compact isOpen={showChangeSets} close={handleCancelChangeSets} backArrow title="Styles and Variables / Export Sets">
+        <Heading>{t('exportSetsTab.changeSetsHeading')}</Heading>
+        <Link target="_blank" href={docsLinks.sets}>{`${t('generic.learnMore')} – ${t('docs.referenceOnlyMode')}`}</Link>
+        <Stack
+          direction="column"
+          gap={2}
+          css={{
+            marginBlockStart: '$4',
+          }}
+        >
+          <TokenSetTreeContent items={setsTree} renderItemContent={TokenSetThemeItemInput} keyPosition="end" />
+        </Stack>
+      </Modal>
+    </Tabs.Content>
+  );
+}

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportThemesTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportThemesTab.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+  Button, Heading, Tabs, Link, Box, Stack, Checkbox, Label,
+} from '@tokens-studio/ui';
+import { useTranslation } from 'react-i18next';
+import { StyledCard } from './StyledCard';
+import {
+  themesListSelector,
+} from '@/selectors';
+import { useIsProUser } from '@/app/hooks/useIsProUser';
+import { ThemeObject } from '@/types';
+import { ExportThemeRow } from './ExportThemeRow';
+import { docsLinks } from './docsLinks';
+import { LabelledCheckbox } from './LabelledCheckbox';
+import useExportThemesTab from './useExportThemesTab';
+
+export default function ExportThemesTab() {
+  const { t } = useTranslation(['manageStylesAndVariables']);
+  const themes = useSelector(themesListSelector);
+  const isPro = useIsProUser();
+
+  const ThemeGroups = React.useMemo(() => {
+    const uniqueGroups: string[] = themes.reduce((unique: string[], theme) => {
+      if (theme.group && !unique.includes(theme.group)) {
+        unique.push(theme.group);
+      }
+      return unique;
+    }, []);
+    return uniqueGroups;
+  }, [themes]);
+
+  const ungroupedThemes = React.useMemo(() => themes.filter((theme) => !theme.group), [themes]);
+  const { selectedThemes, setSelectedThemes } = useExportThemesTab();
+
+  // TODO: Remeber selected themes in document storage
+  // Reloading the plugin shouldn't forget the selected themes
+
+  const handleSelectTheme = React.useCallback((themeId: string) => {
+    if (selectedThemes.includes(themeId)) {
+      setSelectedThemes(selectedThemes.filter((id) => id !== themeId));
+    } else {
+      setSelectedThemes([...selectedThemes, themeId]);
+    }
+  }, [selectedThemes, setSelectedThemes]);
+
+  const handleSelectAllThemes = React.useCallback(() => {
+    if (selectedThemes.length === themes.length) {
+      setSelectedThemes([]);
+    } else {
+      setSelectedThemes(themes.map((theme) => theme.id));
+    }
+  }, [themes, selectedThemes, setSelectedThemes]);
+
+  function createThemeRow(theme: ThemeObject) {
+    return (
+      <ExportThemeRow
+        key={theme.id}
+      >
+        {/* eslint-disable-next-line react/jsx-no-bind */}
+        <LabelledCheckbox id={theme.id} checked={selectedThemes.includes(theme.id)} onChange={() => handleSelectTheme(theme.id)} label={theme.name} />
+        {/* TODO: Add theme details */}
+        {/* <ThemeDetails /> */}
+        {/* <IconButton variant="invisible" size="small" tooltip="Details" icon={<ChevronRightIcon />} /> */}
+      </ExportThemeRow>
+    );
+  }
+
+  return (
+    <Tabs.Content value="useThemes">
+      {themes.length === 0 ? (
+        <StyledCard>
+          <Stack direction="column" align="start" gap={4}>
+            {isPro ? (
+              <>
+                <Heading size="medium">{t('exportThemesTab.headingPro')}</Heading>
+                <p>{t('exportThemesTab.introPro')}</p>
+                <Link target="_blank" href={docsLinks.themes}>
+                  {' '}
+                  {t('generic.learnMore')}
+                  {' – '}
+                  {t('generic.themes')}
+                </Link>
+              </>
+            ) : (
+              <>
+                <Heading size="medium">{t('exportThemesTab.headingBasic')}</Heading>
+                <p>{t('exportThemesTab.introBasic')}</p>
+                <Link target="_blank" href={docsLinks.themes}>
+                  {t('generic.learnMore')}
+                  {' – '}
+                  {t('generic.themes')}
+                </Link>
+                <Box css={{
+                  alignSelf: 'flex-end',
+                }}
+                >
+                  <Button variant="secondary" size="small">{t('actions.getPRO')}</Button>
+                </Box>
+              </>
+            )}
+          </Stack>
+
+        </StyledCard>
+      ) : (
+        <StyledCard>
+          <Stack direction="column" align="start" gap={4}>
+            <Heading>{t('exportThemesTab.confirmThemes')}</Heading>
+            <p>{t('exportThemesTab.combinationsOfSetsMakeThemes')}</p>
+            <Stack direction="column" width="full" gap={4}>
+              <Stack direction="row" gap={3} align="center">
+                <Checkbox id="check-all-themes" checked={selectedThemes.length === themes.length} onCheckedChange={handleSelectAllThemes} />
+                <Label htmlFor="check-all-themes">{t('generic.selectAll')}</Label>
+              </Stack>
+              {ThemeGroups.map((group) => (
+                <Stack direction="column" gap={2}>
+                  <Heading size="small">{group}</Heading>
+                  {themes.filter((theme) => theme.group === group).map((theme) => createThemeRow(theme))}
+                </Stack>
+              ))}
+              {ungroupedThemes.length ? (
+                <Stack direction="column" gap={2}>
+                  <Heading size="small">{t('generic.noGroup')}</Heading>
+                  {ungroupedThemes.map((theme) => createThemeRow(theme))}
+                </Stack>
+              ) : null}
+            </Stack>
+          </Stack>
+
+        </StyledCard>
+      )}
+    </Tabs.Content>
+  );
+}

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -14,6 +14,8 @@ import useExportThemesTab from './useExportThemesTab';
 import useExportSetsTab from './useExportSetsTab';
 import OptionsModal from './OptionsModal';
 import useTokens from '@/app/store/useTokens';
+import ExportSetsTab from './ExportSetsTab';
+import ExportThemesTab from './ExportThemesTab';
 
 export default function ManageStylesAndVariables({ showModal, setShowModal }: { showModal: boolean, setShowModal: (show: boolean) => void }) {
   const { t } = useTranslation(['manageStylesAndVariables']);
@@ -23,8 +25,8 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
   const [showOptions, setShowOptions] = React.useState(true);
   const [activeTab, setActiveTab] = React.useState<'useThemes' | 'useSets'>(isPro ? 'useThemes' : 'useSets');
 
-  const { ExportThemesTab, selectedThemes } = useExportThemesTab();
-  const { ExportSetsTab, selectedSets } = useExportSetsTab();
+  const { selectedThemes } = useExportThemesTab();
+  const { selectedSets } = useExportSetsTab();
   const {
     createVariablesFromSets, createVariablesFromThemes, createStylesFromSelectedTokenSets, createStylesFromSelectedThemes,
   } = useTokens();
@@ -67,9 +69,9 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
     }
   }, [setShowModal, showOptions]);
 
-  const onInteractOutside = (event: Event) => {
+  const onInteractOutside = React.useCallback((event: Event) => {
     event.preventDefault();
-  };
+  }, []);
 
   return (
     <>
@@ -79,8 +81,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
         showClose
         isOpen={showModal}
         close={handleClose}
-        // eslint-disable-next-line react/jsx-no-bind
-        onInteractOutside={(event: Event) => onInteractOutside(event)}
+        onInteractOutside={onInteractOutside}
         footer={(
           <Stack direction="row" gap={4} justify="between">
             <Button variant="invisible" id="manageStyles-button-close" onClick={handleClose} icon={<ChevronLeftIcon />}>

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/OptionsModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/OptionsModal.tsx
@@ -95,6 +95,8 @@ export default function OptionsModal({ isOpen, title, closeAction }: { isOpen: b
   const handleExportVariablesColor = React.useCallback(
     (state: CheckedState) => {
       dispatch.settings.setVariablesColor(!!state);
+      // color can be created *either* styles or variables, we dont want both. if we're setting this to true, disable the other one
+      if (state) dispatch.settings.setStylesColor(!state);
     },
     [dispatch.settings],
   );
@@ -120,6 +122,8 @@ export default function OptionsModal({ isOpen, title, closeAction }: { isOpen: b
   const handleExportStylesColor = React.useCallback(
     (state: CheckedState) => {
       dispatch.settings.setStylesColor(!!state);
+      // color can be created *either* styles or variables, we dont want both. if we're setting this to true, disable the other one
+      if (state) dispatch.settings.setVariablesColor(!state);
     },
     [dispatch.settings],
   );
@@ -169,80 +173,77 @@ export default function OptionsModal({ isOpen, title, closeAction }: { isOpen: b
 )}
       stickyFooter
     >
-      <Stack direction="column" align="start" gap={6} css={{ overflowY: 'scroll' }}>
-        <Stack direction="column" align="start" gap={4}>
-          <Stack direction="row" align="center" gap={2}>
-            <SlidersIcon />
-            <Heading size="medium">{t('options.title')}</Heading>
-          </Stack>
+      <Stack direction="column" align="start" gap={4}>
+        <Stack direction="column" align="start" gap={3}>
+          <Text>{t('options.intro')}</Text>
           <Link target="_blank" href="https://docs.tokens.studio/">{`${t('generic.learnMore')} – ${t('docs.exportToFigmaOptions')}`}</Link>
         </Stack>
         <form>
-          <Stack direction="column" justify="between" gap={5} align="start" css={{ width: '100%' }}>
+          <Stack direction="row" justify="start" gap={5} align="start" css={{ width: '100%', marginBottom: '$6' }}>
             <StyledCheckboxGrid>
-              <Text css={{ fontSize: '$medium', gridColumnStart: 1, gridColumnEnd: 3 }}>{t('options.whichVariablesShouldBeCreatedAndUpdated')}</Text>
+              <Text bold css={{ fontSize: '$medium', gridColumnStart: 1, gridColumnEnd: 3 }}>{t('options.whichVariablesShouldBeCreatedAndUpdated')}</Text>
               <LabelledCheckbox id="variablesColor" onChange={handleExportVariablesColor} checked={exportOptions.variablesColor} label={t('variables.color')} />
               <LabelledCheckbox id="variablesString" onChange={handleExportVariablesString} checked={exportOptions.variablesString} label={t('variables.string')} />
               <LabelledCheckbox id="variablesNumber" onChange={handleExportVariablesNumber} checked={exportOptions.variablesNumber} label={t('variables.number')} />
               <LabelledCheckbox id="variablesBoolean" onChange={handleExportVariablesBoolean} checked={exportOptions.variablesBoolean} label={t('variables.boolean')} />
             </StyledCheckboxGrid>
+            <Box css={{ alignSelf: 'stretch', width: '1px', border: '1px solid $colors$borderSubtle' }} />
             <StyledCheckboxGrid>
-              <Text css={{ fontSize: '$medium', gridColumnStart: 1, gridColumnEnd: 3 }}>{t('options.whichStylesShouldBeCreatedAndUpdated')}</Text>
+              <Text bold css={{ fontSize: '$medium', gridColumnStart: 1, gridColumnEnd: 3 }}>{t('options.whichStylesShouldBeCreatedAndUpdated')}</Text>
               <LabelledCheckbox id="styleColor" onChange={handleExportStylesColor} checked={exportOptions.stylesColor} label={t('styles.color')} />
               <LabelledCheckbox id="stylesTypography" onChange={handleExportStylesTypography} checked={exportOptions.stylesTypography} label={t('styles.typography')} />
               <LabelledCheckbox id="stylesEffect" onChange={handleExportStylesEffect} checked={exportOptions.stylesEffect} label={t('styles.effects')} />
             </StyledCheckboxGrid>
-            <Box css={{
-              display: 'grid',
-              alignItems: 'center',
-              gridAutoRows: 'auto',
-              gridTemplateColumns: 'min-content max-content min-content',
-              width: '100%',
-              gridColumnGap: '$4',
-              gridRowGap: '$5',
-            }}
-            >
-              <Text css={{ fontSize: '$medium', gridColumnStart: 1, gridColumnEnd: 4 }}>{t('options.tokensExportedToFigmaShould')}</Text>
-
-              <Switch
-                data-testid="ignoreFirstPartForStyles"
-                id="ignoreFirstPartForStyles"
-                checked={!!rulesIgnoreFirstPartForStyles}
-                defaultChecked={rulesIgnoreFirstPartForStyles}
-                onCheckedChange={handleIgnoreChange}
-              />
-              <Label htmlFor="ignoreFirstPartForStyles">{t('options.ignorePrefix')}</Label>
-              <ExplainerModal title={t('options.ignorePrefix')}>
-                <Box as="img" src={ignoreFirstPartImage} css={{ borderRadius: '$small' }} />
-                <Box>{t('options.ignorePrefixExplanation')}</Box>
-              </ExplainerModal>
-
-              <Switch
-                data-testid="prefixStylesWithThemeName"
-                id="prefixStylesWithThemeName"
-                checked={!!rulesPrefixStylesWithThemeName}
-                defaultChecked={rulesPrefixStylesWithThemeName}
-                onCheckedChange={handlePrefixWithThemeNameChange}
-              />
-              <Label htmlFor="prefixStylesWithThemeName">{t('options.prefixStyles')}</Label>
-              <ExplainerModal title={t('options.prefixStyles')}>
-                <Box as="img" src={prefixStylesImage} css={{ borderRadius: '$small' }} />
-                <Box>{t('options.prefixStylesExplanation')}</Box>
-              </ExplainerModal>
-
-              <Switch
-                data-testid="createStylesWithVariableReferences"
-                id="createStylesWithVariableReferences"
-                checked={!!rulesCreateStylesWithVariableReferences}
-                defaultChecked={rulesCreateStylesWithVariableReferences}
-                onCheckedChange={handleCreateStylesWithVariableReferencesChange}
-              />
-              <Label htmlFor="createStylesWithVariableReferences">{t('options.createStylesWithVariableReferences')}</Label>
-              <ExplainerModal title={t('options.createStylesWithVariableReferences')}>
-                <Box>{t('options.createStylesWithVariableReferencesExplanation')}</Box>
-              </ExplainerModal>
-            </Box>
           </Stack>
+          <Box css={{
+            display: 'grid',
+            alignItems: 'center',
+            gridAutoRows: 'auto',
+            gridTemplateColumns: 'min-content max-content min-content',
+            width: '100%',
+            gridColumnGap: '$2',
+            gridRowGap: '$3',
+          }}
+          >
+            <Text bold css={{ fontSize: '$medium', gridColumnStart: 1, gridColumnEnd: 4 }}>{t('options.tokensExportedToFigmaShould')}</Text>
+            <Switch
+              data-testid="ignoreFirstPartForStyles"
+              id="ignoreFirstPartForStyles"
+              checked={!!rulesIgnoreFirstPartForStyles}
+              defaultChecked={rulesIgnoreFirstPartForStyles}
+              onCheckedChange={handleIgnoreChange}
+            />
+            <Label css={{ fontWeight: '$sansRegular' }} htmlFor="ignoreFirstPartForStyles">{t('options.ignorePrefix')}</Label>
+            <ExplainerModal title={t('options.ignorePrefix')}>
+              <Box as="img" src={ignoreFirstPartImage} css={{ borderRadius: '$small' }} />
+              <Box>{t('options.ignorePrefixExplanation')}</Box>
+            </ExplainerModal>
+
+            <Switch
+              data-testid="prefixStylesWithThemeName"
+              id="prefixStylesWithThemeName"
+              checked={!!rulesPrefixStylesWithThemeName}
+              defaultChecked={rulesPrefixStylesWithThemeName}
+              onCheckedChange={handlePrefixWithThemeNameChange}
+            />
+            <Label css={{ fontWeight: '$sansRegular' }} htmlFor="prefixStylesWithThemeName">{t('options.prefixStyles')}</Label>
+            <ExplainerModal title={t('options.prefixStyles')}>
+              <Box as="img" src={prefixStylesImage} css={{ borderRadius: '$small' }} />
+              <Box>{t('options.prefixStylesExplanation')}</Box>
+            </ExplainerModal>
+
+            <Switch
+              data-testid="createStylesWithVariableReferences"
+              id="createStylesWithVariableReferences"
+              checked={!!rulesCreateStylesWithVariableReferences}
+              defaultChecked={rulesCreateStylesWithVariableReferences}
+              onCheckedChange={handleCreateStylesWithVariableReferencesChange}
+            />
+            <Label css={{ fontWeight: '$sansRegular' }} htmlFor="createStylesWithVariableReferences">{t('options.createStylesWithVariableReferences')}</Label>
+            <ExplainerModal title={t('options.createStylesWithVariableReferences')}>
+              <Box>{t('options.createStylesWithVariableReferencesExplanation')}</Box>
+            </ExplainerModal>
+          </Box>
         </form>
       </Stack>
     </Modal>

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/useExportSetsTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/useExportSetsTab.tsx
@@ -1,42 +1,11 @@
-import { FileDirectoryIcon } from '@primer/octicons-react';
-import {
-  Tabs, Stack, Heading, Button, Link,
-} from '@tokens-studio/ui';
-import React, { useMemo } from 'react';
-import { useDispatch, useSelector, useStore } from 'react-redux';
-import { useForm, Controller } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
+import React from 'react';
+import { useSelector } from 'react-redux';
 
-import Modal from '../Modal';
-import { TokenSetTreeContent } from '../TokenSetTree/TokenSetTreeContent';
-import { StyledCard } from './StyledCard';
-
-import { ExplainerModal } from '../ExplainerModal';
-import OnboardingExplainer from '../OnboardingExplainer';
-import { Dispatch } from '../../store';
-
-import { allTokenSetsSelector, usedTokenSetSelector } from '@/selectors';
-import { docsLinks } from './docsLinks';
-import { RootState } from '@/app/store';
-import { tokenSetListToTree, TreeItem } from '@/utils/tokenset';
-import { TokenSetThemeItem } from '../ManageThemesModal/TokenSetThemeItem';
-import { FormValues } from '../ManageThemesModal/CreateOrEditThemeForm';
+import { allTokenSetsSelector } from '@/selectors';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { ExportTokenSet } from '@/types/ExportTokenSet';
 
 export default function useExportSetsTab() {
-  const dispatch = useDispatch<Dispatch>();
-  const closeOnboarding = React.useCallback(() => {
-    dispatch.uiState.setOnboardingExplainerExportSets(false);
-  }, [dispatch]);
-  const onboardingExplainerExportSets = useSelector((state: RootState) => state.uiState.onboardingExplainerExportSets);
-
-  const { t } = useTranslation(['manageStylesAndVariables']);
-
-  const store = useStore<RootState>();
-
-  const [showChangeSets, setShowChangeSets] = React.useState(false);
-
   const allSets = useSelector(allTokenSetsSelector);
   const [selectedSets, setSelectedSets] = React.useState<ExportTokenSet[]>(allSets.map((set) => {
     const tokenSet = {
@@ -46,119 +15,8 @@ export default function useExportSetsTab() {
     return tokenSet;
   }));
 
-  const selectedTokenSets = React.useMemo(() => (
-    usedTokenSetSelector(store.getState())
-  ), [store]);
-
-  const availableTokenSets = useSelector(allTokenSetsSelector);
-
-  const setsTree = React.useMemo(() => tokenSetListToTree(availableTokenSets), [availableTokenSets]);
-
-  const handleCancelChangeSets = React.useCallback(() => {
-    // DO NOT SAVE THE SET CHANGES
-    setShowChangeSets(false);
-  }, []);
-
-  const handleShowChangeSets = React.useCallback(() => {
-    setShowChangeSets(true);
-  }, []);
-
-  const { control, getValues } = useForm<FormValues>({
-    defaultValues: {
-      tokenSets: { ...selectedTokenSets },
-    },
-  });
-
-  const TokenSetThemeItemInput = React.useCallback((props: React.PropsWithChildren<{ item: TreeItem }>) => (
-    <Controller
-      name="tokenSets"
-      control={control}
-      // this is the only way to do this
-      // eslint-disable-next-line
-      render={({ field }) => (
-        <TokenSetThemeItem
-          {...props}
-          value={field.value}
-          onChange={field.onChange}
-        />
-      )}
-    />
-  ), [control]);
-
-  const selectedEnabledSets = useMemo(() => selectedSets.filter((set) => set.status === TokenSetStatus.ENABLED), [selectedSets]);
-
-  React.useEffect(() => {
-    if (!showChangeSets) {
-      const currentSelectedSets = getValues();
-      const selectedTokenSets: ExportTokenSet[] = Object.keys(currentSelectedSets.tokenSets).reduce((acc: ExportTokenSet[], curr: string) => {
-        if (currentSelectedSets.tokenSets[curr] !== TokenSetStatus.DISABLED) {
-          const tokenSet = {
-            set: curr,
-            status: currentSelectedSets.tokenSets[curr],
-          } as ExportTokenSet;
-          acc.push(tokenSet);
-        }
-        return acc;
-      }, [] as ExportTokenSet[]);
-      setSelectedSets([...selectedTokenSets]);
-    }
-  }, [showChangeSets, getValues]);
-
-  const ExportSetsTab = () => (
-    <Tabs.Content value="useSets">
-      <StyledCard>
-        <Stack direction="column" align="start" gap={6}>
-          <Stack direction="column" align="start" gap={4}>
-            {!onboardingExplainerExportSets && (
-              <Stack direction="row" align="center" gap={2}>
-                <Heading>{t('exportSetsTab.confirmSets')}</Heading>
-                <ExplainerModal title={t('exportSetsTab.confirmSets')}>
-                  {t('exportSetsTab.intro')}
-                  <Link target="_blank" href={docsLinks.stylesAndVariables}>{`${t('generic.learnMore')} – ${t('docs.stylesAndVariables')}`}</Link>
-                </ExplainerModal>
-              </Stack>
-            )}
-            {onboardingExplainerExportSets && (
-            <OnboardingExplainer
-              data={{
-                text: t('exportSetsTab.intro'),
-                title: t('exportSetsTab.confirmSets'),
-                url: docsLinks.stylesAndVariables,
-              }}
-              closeOnboarding={closeOnboarding}
-            />
-            )}
-          </Stack>
-          <Stack direction="row" align="start" gap={2}>
-            <FileDirectoryIcon size="small" />
-            <span>
-              {selectedEnabledSets.length}
-              {' of '}
-              {allSets.length}
-              {' '}
-              {t('exportSetsTab.setsSelectedForExport')}
-            </span>
-          </Stack>
-          <Button variant="secondary" size="small" onClick={handleShowChangeSets}>{t('actions.changeSets')}</Button>
-        </Stack>
-      </StyledCard>
-      <Modal size="fullscreen" full compact isOpen={showChangeSets} close={handleCancelChangeSets} backArrow title="Styles and Variables / Export Sets">
-        <Heading>{t('exportSetsTab.changeSetsHeading')}</Heading>
-        <Link target="_blank" href={docsLinks.sets}>{`${t('generic.learnMore')} – ${t('docs.referenceOnlyMode')}`}</Link>
-        <Stack
-          direction="column"
-          gap={2}
-          css={{
-            marginBlockStart: '$4',
-          }}
-        >
-          <TokenSetTreeContent items={setsTree} renderItemContent={TokenSetThemeItemInput} keyPosition="end" />
-        </Stack>
-      </Modal>
-    </Tabs.Content>
-  );
   return {
-    ExportSetsTab,
     selectedSets,
+    setSelectedSets,
   };
 }

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/useExportThemesTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/useExportThemesTab.tsx
@@ -1,149 +1,18 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import {
-  Button, Heading, Tabs, Link, Box, Stack, Checkbox, Label,
-} from '@tokens-studio/ui';
-import { styled } from '@stitches/react';
 import { useTranslation } from 'react-i18next';
-import { StyledCard } from './StyledCard';
 import {
   themesListSelector,
 } from '@/selectors';
-import { StyledProBadge } from '../ProBadge';
-import { useIsProUser } from '@/app/hooks/useIsProUser';
-import { ThemeObject } from '@/types';
-import { ExportThemeRow } from './ExportThemeRow';
-import { docsLinks } from './docsLinks';
-import { LabelledCheckbox } from './LabelledCheckbox';
-
-const ProButton = styled(Button, {
-  ':first-child': {
-    flexDirection: 'row-reverse',
-  },
-});
 
 export default function useExportThemesTab() {
   const { t } = useTranslation(['manageStylesAndVariables']);
   const themes = useSelector(themesListSelector);
-  const isPro = useIsProUser();
 
-  const ThemeGroups = React.useMemo(() => {
-    const uniqueGroups: string[] = themes.reduce((unique: string[], theme) => {
-      if (theme.group && !unique.includes(theme.group)) {
-        unique.push(theme.group);
-      }
-      return unique;
-    }, []);
-    return uniqueGroups;
-  }, [themes]);
-
-  const ungroupedThemes = React.useMemo(() => themes.filter((theme) => !theme.group), [themes]);
-
-  // TODO: Remeber selected themes in document storage
-  // Reloading the plugin shouldn't forget the selected themes
   const [selectedThemes, setSelectedThemes] = React.useState<string[]>(themes.map((theme) => theme.id));
 
-  const handleSelectTheme = React.useCallback((themeId: string) => {
-    if (selectedThemes.includes(themeId)) {
-      setSelectedThemes(selectedThemes.filter((id) => id !== themeId));
-    } else {
-      setSelectedThemes([...selectedThemes, themeId]);
-    }
-  }, [selectedThemes]);
-
-  const handleSelectAllThemes = React.useCallback(() => {
-    if (selectedThemes.length === themes.length) {
-      setSelectedThemes([]);
-    } else {
-      setSelectedThemes(themes.map((theme) => theme.id));
-    }
-  }, [themes, selectedThemes]);
-
-  const handleGetPro = React.useCallback(() => {
-    window.open('https://tokens.studio/#pricing-1', '_blank');
-  }, []);
-
-  function createThemeRow(theme: ThemeObject) {
-    return (
-      <ExportThemeRow
-        key={theme.id}
-      >
-        {/* eslint-disable-next-line react/jsx-no-bind */}
-        <LabelledCheckbox id={theme.id} checked={selectedThemes.includes(theme.id)} onChange={() => handleSelectTheme(theme.id)} label={theme.name} />
-        {/* TODO: Add theme details */}
-        {/* <ThemeDetails /> */}
-        {/* <IconButton variant="invisible" size="small" tooltip="Details" icon={<ChevronRightIcon />} /> */}
-      </ExportThemeRow>
-    );
-  }
-
-  const ExportThemesTab = () => (
-    <Tabs.Content value="useThemes">
-      {themes.length === 0 ? (
-        <StyledCard>
-          <Stack direction="column" align="start" gap={4}>
-            {isPro ? (
-              <>
-                <Heading size="medium">{t('exportThemesTab.headingPro')}</Heading>
-                <p>{t('exportThemesTab.introPro')}</p>
-                <Link target="_blank" href={docsLinks.themes}>
-                  {' '}
-                  {t('generic.learnMore')}
-                  {' – '}
-                  {t('generic.themes')}
-                </Link>
-              </>
-            ) : (
-              <>
-                <Heading size="medium">{t('exportThemesTab.headingBasic')}</Heading>
-                <p>{t('exportThemesTab.introBasic')}</p>
-                <Link target="_blank" href={docsLinks.themes}>
-                  {t('generic.learnMore')}
-                  {' – '}
-                  {t('generic.themes')}
-                </Link>
-                <Box css={{
-                  alignSelf: 'flex-end',
-                }}
-                >
-                  <Button variant="secondary" size="small">{t('actions.getPRO')}</Button>
-                </Box>
-              </>
-            )}
-          </Stack>
-
-        </StyledCard>
-      ) : (
-        <StyledCard>
-          <Stack direction="column" align="start" gap={4}>
-            <Heading>{t('exportThemesTab.confirmThemes')}</Heading>
-            <p>{t('exportThemesTab.combinationsOfSetsMakeThemes')}</p>
-            <Stack direction="column" width="full" gap={4}>
-              <Stack direction="row" gap={3} align="center">
-                <Checkbox id="check-all-themes" checked={selectedThemes.length === themes.length} onCheckedChange={handleSelectAllThemes} />
-                <Label htmlFor="check-all-themes">{t('generic.selectAll')}</Label>
-              </Stack>
-              {ThemeGroups.map((group) => (
-                <Stack direction="column" gap={2}>
-                  <Heading size="small">{group}</Heading>
-                  {themes.filter((theme) => theme.group === group).map((theme) => createThemeRow(theme))}
-                </Stack>
-              ))}
-              {ungroupedThemes.length ? (
-                <Stack direction="column" gap={2}>
-                  <Heading size="small">{t('generic.noGroup')}</Heading>
-                  {ungroupedThemes.map((theme) => createThemeRow(theme))}
-                </Stack>
-              ) : null}
-            </Stack>
-          </Stack>
-
-        </StyledCard>
-      )}
-    </Tabs.Content>
-  );
   return {
-    ExportThemesTab,
     selectedThemes,
+    setSelectedThemes,
   };
 }

--- a/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
+++ b/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
@@ -1,7 +1,7 @@
 {
 "modalTitle": "Export to Figma",
 "buttonLabel": "Styles and Variables",
-"optionsModalTitle": "Export to Figma Options",
+"optionsModalTitle": "Export to Figma: Options",
 "actions": {
   "export": "Export to Figma",
   "import": "Import from Figma",
@@ -14,7 +14,7 @@
   "changeSets": "Change Sets"
 },
 "docs": {
-  "exportToFigmaOptions": "Export to Figma Options",
+  "exportToFigmaOptions": "Export to Figma: Options",
   "stylesAndVariables": "Styles and Variables",
   "referenceOnlyMode": "Enabled versus Reference Only Mode"
 },
@@ -30,8 +30,9 @@
 },
 "options": {
   "title": "Options",
-  "whichVariablesShouldBeCreatedAndUpdated": "Which variables should be created and updated?",
-  "whichStylesShouldBeCreatedAndUpdated": "Which styles should be created and updated?",
+  "intro": "Create styles or variables based on your themes or token sets. First, choose what types of tokens should be created as either styles or variables.",
+  "whichVariablesShouldBeCreatedAndUpdated": "Create or update variables",
+  "whichStylesShouldBeCreatedAndUpdated": "Create or update styles",
   "tokensExportedToFigmaShould": "Tokens exported to Figma should:",
   "ignorePrefix": "Ignore first part of token name for styles",
   "ignorePrefixExplanation": "Useful if you want to ignore 'colors' in a token called 'colors.blue.500' for your styles",
@@ -56,18 +57,18 @@
   "effects": "Effects"
 },
 "exportThemesTab": {
-  "headingPro": "Create Themes to get Started",
-  "headingBasic": "Creating Themes is a pro Feature",
-  "introPro": "Combinations of token sets create themes. Use Themes to create multiple collections of variables or styles for easy switching between design concepts like light or dark color modes, multiple brands, products or platforms. Or switch to Sets to export without using Themes",
-  "introBasic": "Combinations of token sets create themes. Use Themes to create multiple collections of variables or styles for easy switching between design concepts like light or dark color modes, multiple brands, products or platforms.",
-  "confirmThemes": "Confirm Themes",
-  "combinationsOfSetsMakeThemes": "Combinations of token sets create themes"
+  "headingPro": "Create themes to get started",
+  "headingBasic": "Creating themes is a pro Feature",
+  "introPro": "Combinations of token sets create themes. Use themes to create multiple collections of variables or styles for easy switching between design concepts like light or dark color modes, multiple brands, products or platforms. Or switch to Sets to export without using Themes",
+  "introBasic": "Combinations of token sets create themes. Use themes to create multiple collections of variables or styles for easy switching between design concepts like light or dark color modes, multiple brands, products or platforms.",
+  "confirmThemes": "Create styles or variables based on themes",
+  "combinationsOfSetsMakeThemes": "Choose which themes should be created or updated."
 
 },
 "exportSetsTab": {
   "changeSetsHeading": "Enabled sets will export to Figma",
-  "confirmSets": "Confirm Sets",
-  "intro": "You can use token sets to manage your styles, and variables. Use Themes (Pro) to create multiple collections of variables or styles for easy switching between design concepts.",
+  "confirmSets": "Create styles or variables based on token sets",
+  "intro": "You can use token sets to manage your styles, and variables. Use themes (Pro) to create multiple collections of variables or styles for easy switching between design concepts.",
   "setsSelectedForExport": "Sets selected for export"
 }
 }


### PR DESCRIPTION
### Why does this PR exist?

The export tab for variables / styles had a re-render that was caused by the dialog coming from a hook. this fixes this.

### What does this pull request do?

In addition to the re-render, optimizes styling of the `Options` dialog to not use as much vertical space.

The changes in this PR seem large, but it's really just moving the render part of the hook out to its own files, and then add some styling.

The other change this introduces is to treat "color" as a toggle. We dont want users to create both styles and variables for colors at the same time, this is always unintended. I now changed it so it is a toggle, if color is set true, the other will be set to false.

### Testing this change

Interact with the manage styles and variables modal

### Additional Notes (if any)

Before:

https://github.com/tokens-studio/figma-plugin/assets/4548309/bbc48686-9677-45ab-9a76-aa630b3c2691


After:

https://github.com/tokens-studio/figma-plugin/assets/4548309/4735501d-e59e-4738-9312-79a3e1689157

