### PR TITLE
872 disable features for studio sync

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/JSONEditor.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/JSONEditor.tsx
@@ -3,9 +3,10 @@ import { useSelector } from 'react-redux';
 import Editor, { useMonaco } from '@monaco-editor/react';
 import Box from './Box';
 import { useShortcut } from '@/hooks/useShortcut';
-import { activeTokenSetReadOnlySelector, editProhibitedSelector } from '@/selectors';
+import { activeApiProviderSelector, activeTokenSetReadOnlySelector, editProhibitedSelector } from '@/selectors';
 import useTokens from '../store/useTokens';
 import { useFigmaTheme } from '@/hooks/useFigmaTheme';
+import { StorageProviderType } from '@/constants/StorageProviderType';
 
 type Props = {
   stringTokens: string;
@@ -18,6 +19,9 @@ function JSONEditor({
 }: Props) {
   const editProhibited = useSelector(editProhibitedSelector);
   const activeTokenSetReadOnly = useSelector(activeTokenSetReadOnlySelector);
+  const activeApiProvider = useSelector(activeApiProviderSelector);
+  const isTokensStudioProvider = activeApiProvider === StorageProviderType.TOKENS_STUDIO;
+
   const { handleJSONUpdate } = useTokens();
   const { isDarkTheme } = useFigmaTheme();
   const monaco = useMonaco();
@@ -65,7 +69,7 @@ function JSONEditor({
           fontSize: 11,
           wordWrap: 'on',
           contextmenu: false,
-          readOnly: editProhibited || activeTokenSetReadOnly,
+          readOnly: editProhibited || activeTokenSetReadOnly || isTokensStudioProvider,
         }}
       />
     </Box>

--- a/packages/tokens-studio-for-figma/src/app/components/TokenGroup/TokenGroupHeading.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenGroup/TokenGroupHeading.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tokens-studio/ui';
 import Stack from '../Stack';
 import useManageTokens from '../../store/useManageTokens';
-import { activeTokenSetReadOnlySelector, editProhibitedSelector } from '@/selectors';
+import { activeApiProviderSelector, activeTokenSetReadOnlySelector, editProhibitedSelector } from '@/selectors';
 import { IconCollapseArrow, IconExpandArrow, IconAdd } from '@/icons';
 import { StyledTokenGroupHeading, StyledTokenGroupAddIcon, StyledTokenGroupHeadingCollapsable } from './StyledTokenGroupHeading';
 import { Dispatch } from '../../store';
@@ -16,6 +16,7 @@ import { ShowNewFormOptions } from '@/types';
 import useTokens from '../../store/useTokens';
 import RenameTokenGroupModal from '../modals/RenameTokenGroupModal';
 import DuplicateTokenGroupModal from '../modals/DuplicateTokenGroupModal';
+import { StorageProviderType } from '@/constants/StorageProviderType';
 
 export type Props = {
   id: string
@@ -31,6 +32,7 @@ export function TokenGroupHeading({
   const { t } = useTranslation(['tokens']);
   const editProhibited = useSelector(editProhibitedSelector);
   const activeTokenSetReadOnly = useSelector(activeTokenSetReadOnlySelector);
+  const activeApiProvider = useSelector(activeApiProviderSelector);
   const [newTokenGroupName, setNewTokenGroupName] = React.useState<string>(path);
   const [showRenameTokenGroupModal, setShowRenameTokenGroupModal] = React.useState<boolean>(false);
   const [showDuplicateTokenGroupModal, setShowDuplicateTokenGroupModal] = React.useState<boolean>(false);
@@ -38,8 +40,9 @@ export function TokenGroupHeading({
   const dispatch = useDispatch<Dispatch>();
   const collapsed = useSelector(collapsedTokensSelector);
   const { remapTokensInGroup, remapTokensWithOtherReference } = useTokens();
+  const isTokensStudioProvider = activeApiProvider === StorageProviderType.TOKENS_STUDIO;
 
-  const canEdit = !editProhibited && !activeTokenSetReadOnly;
+  const canEdit = !editProhibited && !activeTokenSetReadOnly && !isTokensStudioProvider;
 
   const handleDelete = React.useCallback(() => {
     deleteGroup(path, type);

--- a/packages/tokens-studio-for-figma/src/app/components/TokenSetTreeItemContent.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenSetTreeItemContent.tsx
@@ -4,12 +4,14 @@ import React, {
 import { useDispatch, useSelector } from 'react-redux';
 import { TokenSetItem } from './TokenSetItem';
 import {
+  activeApiProviderSelector,
   activeTokenSetSelector,
   editProhibitedSelector,
   tokenSetMetadataSelector,
 } from '@/selectors';
 import { TreeItem } from '@/utils/tokenset';
 import { DragControlsContext } from '@/context';
+import { StorageProviderType } from '@/constants/StorageProviderType';
 
 type ExtendedTreeItem = TreeItem & {
   tokenSets: string[];
@@ -35,6 +37,9 @@ export function TokenSetTreeItemContent({
   const activeTokenSet = useSelector(activeTokenSetSelector);
   const editProhibited = useSelector(editProhibitedSelector);
   const tokenSetMetadata = useSelector(tokenSetMetadataSelector);
+  const activeApiProvider = useSelector(activeApiProviderSelector);
+
+  const isTokensStudioProvider = activeApiProvider === StorageProviderType.TOKENS_STUDIO;
 
   const handleClick = useCallback((set: TreeItem) => {
     if (set.isLeaf) {
@@ -69,7 +74,7 @@ export function TokenSetTreeItemContent({
       item={item}
       onCheck={handleCheckedChange}
       canEdit={!editProhibited}
-      canDuplicate={!tokenSetMetadata[item.path]?.isDynamic}
+      canDuplicate={!isTokensStudioProvider && !tokenSetMetadata[item.path]?.isDynamic}
       canReorder={!editProhibited}
       canDelete={item.canDelete}
       extraBefore={children}

--- a/packages/tokens-studio-for-figma/src/selectors/activeApiProviderSelector.ts
+++ b/packages/tokens-studio-for-figma/src/selectors/activeApiProviderSelector.ts
@@ -1,0 +1,4 @@
+import { createSelector } from 'reselect';
+import { uiStateSelector } from './uiStateSelector';
+
+export const activeApiProviderSelector = createSelector(uiStateSelector, (state) => state.api.provider);

--- a/packages/tokens-studio-for-figma/src/selectors/activeApiProviderSelector.ts
+++ b/packages/tokens-studio-for-figma/src/selectors/activeApiProviderSelector.ts
@@ -1,4 +1,4 @@
 import { createSelector } from 'reselect';
 import { uiStateSelector } from './uiStateSelector';
 
-export const activeApiProviderSelector = createSelector(uiStateSelector, (state) => state.api.provider);
+export const activeApiProviderSelector = createSelector(uiStateSelector, (state) => state.api?.provider);

--- a/packages/tokens-studio-for-figma/src/selectors/index.ts
+++ b/packages/tokens-studio-for-figma/src/selectors/index.ts
@@ -15,6 +15,7 @@ export * from './mainNodeSelectionValuesSelector';
 export * from './storageTypeSelector';
 export * from './ignoreFirstPartForStylesSelector';
 export * from './apiProvidersSelector';
+export * from './activeApiProviderSelector';
 export * from './hasUnsavedChangesSelector';
 export * from './activeTabSelector';
 export * from './changelogSelector';

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/updateThemeGroupsInTokensStudio/deleteTheme.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/updateThemeGroupsInTokensStudio/deleteTheme.ts
@@ -8,7 +8,9 @@ type Props = {
   groupIdsMap: Record<string, string>;
 };
 
-export const deleteTheme = ({ action, themes, prevThemes, groupIdsMap }: Props) => {
+export const deleteTheme = ({
+  action, themes, prevThemes, groupIdsMap,
+}: Props) => {
   const { payload: themeUrn } = action;
 
   let themeGroupsToUpdate: Record<string, ThemeObjectsList> = {};

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/updateThemeGroupsInTokensStudio/saveTheme.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/updateThemeGroupsInTokensStudio/saveTheme.ts
@@ -8,7 +8,9 @@ type Props = {
   groupIdsMap: Record<string, string>;
 };
 
-export const saveTheme = ({ action, themes, prevThemes, groupIdsMap }: Props) => {
+export const saveTheme = ({
+  action, themes, prevThemes, groupIdsMap,
+}: Props) => {
   const {
     payload: { id, name, group },
   } = action;


### PR DESCRIPTION
### Why does this PR exist?

Closes https://github.com/tokens-studio/studio-app/issues/872
Closes https://github.com/tokens-studio/studio-app/issues/875

### What does this pull request do?

- fixes complex tokens: composition, typography, border and boxShadow
- disabled features for users using Tokens Studio sync (features not available in the platform): operations on token groups, duplicate token set, JSON edit
