### PR TITLE
2.0: fix bitbucket sync basic auth

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/PushDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/PushDialog.tsx
@@ -136,7 +136,7 @@ function PushDialog() {
           )}
         >
           <Stack direction="column" align="start">
-            <ToggleGroup type="single" value={activeTab} onValueChange={setActiveTab}>
+            <ToggleGroup type="single" value={activeTab} onValueChange={setActiveTab} css={{ marginLeft: '$3', marginTop: '$3' }}>
               <ToggleGroup.Item iconOnly={false} value="commit">
                 {t('commit')}
               </ToggleGroup.Item>

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/BitbucketForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/BitbucketForm.tsx
@@ -38,6 +38,7 @@ export default function BitbucketForm({
       const zodSchema = zod.object({
         provider: zod.string(),
         name: zod.string(),
+        username: zod.string(),
         id: zod.string(),
         branch: zod.string(),
         filePath: zod.string(),
@@ -63,6 +64,12 @@ export default function BitbucketForm({
         <FormField>
           <Label htmlFor="name">{t('name')}</Label>
           <TextInput value={values.name || ''} onChange={onChange} type="text" name="name" id="name" required />
+        </FormField>
+        <FormField>
+          <Label htmlFor="name">
+            {t('providers.bitbucket.username')}
+          </Label>
+          <TextInput value={values.username || ''} onChange={onChange} type="text" name="username" id="username" required />
         </FormField>
         <FormField>
           <Label htmlFor="secret">{t('providers.bitbucket.appPassword')}</Label>
@@ -113,17 +120,6 @@ export default function BitbucketForm({
             required
           />
           <Text muted size="xsmall">{t('filePathCaption')}</Text>
-        </FormField>
-        <FormField>
-          <Label htmlFor="name">{t('providers.bitbucket.projectName')}</Label>
-          <TextInput
-            value={values.baseUrl || ''}
-            placeholder="https://api.bitbucket.com/v2"
-            onChange={onChange}
-            type="text"
-            name="baseUrl"
-            id="baseUrl"
-          />
         </FormField>
 
         <Stack direction="row" justify="end" gap={4}>

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -18,7 +18,6 @@ import { StorageProviderType } from '@/constants/StorageProviderType';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { ErrorMessages } from '@/constants/ErrorMessages';
 import { RemoteResponseData } from '@/types/RemoteResponseData';
-import { useChangedState } from '@/hooks/useChangedState';
 import { PushOverrides } from '../../remoteTokens';
 
 type BitbucketCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.BITBUCKET }>;
@@ -45,6 +44,7 @@ export function useBitbucket() {
         owner ?? splitContextId[0],
         repo ?? splitContextId[1],
         context.baseUrl ?? '',
+        context.username,
       );
       if (context.filePath) storageClient.changePath(context.filePath);
       if (context.branch) storageClient.selectBranch(context.branch);

--- a/packages/tokens-studio-for-figma/src/i18n/lang/en/settings.json
+++ b/packages/tokens-studio-for-figma/src/i18n/lang/en/settings.json
@@ -19,7 +19,7 @@
   "forMoreInformationPleaseSeeOur": "For more information, please see our",
   "privacyPolicy": "Privacy Policy",
   "debugging": "Debugging",
-  "enableSessionRecording": "Enable session recording",
+  "enableSessionRecording": "Grant permission to record session for bugfixing",
   "secondScreenExplainer": "Empower your design workflow, allowing you to manage your design tokens in a second screen.",
   "liveSync": "Live Sync",
   "signInToContinue": "Sign in to continue",

--- a/packages/tokens-studio-for-figma/src/i18n/lang/en/storage.json
+++ b/packages/tokens-studio-for-figma/src/i18n/lang/en/storage.json
@@ -57,6 +57,7 @@
       "projectName": "Project Name (optional)"
     },
     "bitbucket": {
+      "username": "Bitbucket username",
       "appPassword": "App Password",
       "projectName": "Project Name (optional)",
       "repository": "Repository (workspace/repo)"

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -121,11 +121,11 @@ export class BitbucketTokenStorage extends GitTokenStorage {
   }
 
   /**
-   * Fetches the current user and stores it on the object.
+   * Fetches the current user's username.
    *
-   * @returns A promise that resolves to the current user object.
+   * @returns A promise that resolves to the current username.
    */
-  public async fetchCurrentUser(): Promise<any> {
+  public async fetchCurrentUser(): Promise<string> {
     try {
       const currentUser = await this.bitbucketClient.users.getAuthedUser({});
       return currentUser.data.username;

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -125,7 +125,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
    *
    * @returns A promise that resolves to the current username.
    */
-  public async fetchCurrentUser(): Promise<string> {
+  public async fetchCurrentUser(): Promise<string | null> {
     try {
       const currentUser = await this.bitbucketClient.users.getAuthedUser({});
       return currentUser.data.username;

--- a/packages/tokens-studio-for-figma/src/storage/GitTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/GitTokenStorage.ts
@@ -44,17 +44,21 @@ export abstract class GitTokenStorage extends RemoteTokenStorage<GitStorageSaveO
     multiFileEnabled: false,
   };
 
+  protected username: string | undefined = undefined;
+
   constructor(
     secret: string,
     owner: string,
     repository: string,
     baseUrl?: string,
+    username?: string,
   ) {
     super();
     this.secret = secret;
     this.owner = owner;
     this.repository = repository;
     this.baseUrl = baseUrl;
+    this.username = username;
   }
 
   public selectBranch(branch: string) {

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
@@ -58,7 +58,7 @@ describe('BitbucketTokenStorage', () => {
 
   beforeEach(() => {
     // Reset the Bitbucket mock and create a new instance of BitbucketTokenStorage
-    storageProvider = new BitbucketTokenStorage('mock-secret', 'MattOliver', 'figma-tokens-testing');
+    storageProvider = new BitbucketTokenStorage('mock-secret', 'MattOliver', 'figma-tokens-testing', '', 'myusername');
     storageProvider.selectBranch('main');
     jest.clearAllMocks();
     storageProvider.selectBranch('main');
@@ -149,7 +149,7 @@ describe('BitbucketTokenStorage', () => {
       `https://api.bitbucket.org/2.0/repositories/${storageProvider.owner}/${storageProvider.repository}/src/${storageProvider.branch}/`,
       {
         headers: {
-          Authorization: `Basic ${btoa('MattOliver:mock-secret')}`,
+          Authorization: `Basic ${btoa('myusername:mock-secret')}`,
         },
       },
     );

--- a/packages/tokens-studio-for-figma/src/types/StorageType.ts
+++ b/packages/tokens-studio-for-figma/src/types/StorageType.ts
@@ -63,8 +63,9 @@ StorageProviderType.GITLAB,
 export type BitbucketStorageType = GenericStorageType<
 StorageProviderType.BITBUCKET,
 {
-  name: string; // this is only for refrence
+  name: string; // this is only for reference
   id: string; // this should be the repository identifier; eg {workspace}/{repo_slug}
+  username: string; // this is the bitbucket user, required for app password interaction
   branch: string; // this is the base branch
   filePath: string; // this is the path to the token file or files (depends on multifile support)
   baseUrl?: string; // this is the base API url. This is important for self hosted environments


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2672

- Adds a new `username` field to bitbucket storage provider which is required for App passwords
- Authenticates using that username

![Image](https://github.com/tokens-studio/figma-plugin/assets/4548309/50492fb4-c73c-4a41-a706-9e22bf524cfb)

<img width="492" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/1df6611c-f503-4af1-97f9-52acd5149443">
