### PR TITLE
[885] Add support for TS dynamic sets

### DIFF
--- a/packages/tokens-studio-for-figma/jest.config.ts
+++ b/packages/tokens-studio-for-figma/jest.config.ts
@@ -185,7 +185,7 @@ export default {
   //     "^.+\\.js$": "babel-jest",
   // },
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: ['/node_modules/(?!(@figma-plugin|react-dnd|react-colorful|dnd-core|react-dnd-html5-backend|@react-dnd)/)', '\\.pnp\\.[^\\/]+$'],
+  transformIgnorePatterns: ['/node_modules/(?!(@figma-plugin|react-dnd|@react-dnd|react-colorful|dnd-core|react-dnd-html5-backend|culori|dot-prop)/)', '\\.pnp\\.[^\\/]+$'],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -32,9 +32,6 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@tokens-studio/ui": "0.5.5",
-    "@tokens-studio/tokens": "0.1.1",
-    "@tokens-studio/sdk": "1.1.4",
     "@figma-plugin/helpers": "^0.15.2",
     "@gitbeaker/rest": "^39.21.2",
     "@monaco-editor/react": "^4.5.1",
@@ -58,6 +55,10 @@
     "@supabase/storage-js": "^2.0.0",
     "@supabase/supabase-js": "^2.0.5",
     "@supernovaio/supernova-sdk": "^1.9.3",
+    "@tokens-studio/graph-engine": "^0.17.5",
+    "@tokens-studio/sdk": "1.1.5",
+    "@tokens-studio/tokens": "0.1.1",
+    "@tokens-studio/ui": "0.5.5",
     "@types/chroma-js": "^2.1.4",
     "@types/color": "^3.0.3",
     "@types/file-saver": "^2.0.5",
@@ -137,7 +138,6 @@
     "zod": "^3.22.3"
   },
   "devDependencies": {
-    "0x": "^5.6.0",
     "@babel/core": "^7.12.16",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/plugin-transform-export-namespace-from": "^7.24.1",
@@ -178,6 +178,7 @@
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
+    "0x": "^5.6.0",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "changeset": "^0.2.6",

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/dynamicSets/externalLoader.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/dynamicSets/externalLoader.ts
@@ -1,0 +1,27 @@
+import { ExternalLoadOptions } from '@tokens-studio/graph-engine';
+import { Graphql, TokenSetQuery } from '@tokens-studio/sdk';
+import { GET_TOKEN_SET_QUERY } from '../graphql';
+import { tokensStudioToToken } from '../utils';
+
+export const externalLoader = async (opts: ExternalLoadOptions) => {
+  try {
+    const data = await Graphql.exec<TokenSetQuery>(
+      Graphql.op(GET_TOKEN_SET_QUERY, {
+        urn: opts.data.urn,
+      }),
+    );
+
+    const responseTokens = data.data?.tokenSet?.tokens;
+
+    if (!responseTokens) {
+      return { tokens: [] };
+    }
+
+    const tokens = responseTokens.map((token) => tokensStudioToToken(token));
+
+    return { tokens };
+  } catch (error) {
+    console.error(error);
+    return { tokens: [] };
+  }
+};

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/dynamicSets/fetchDynamicTokenSetData.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/dynamicSets/fetchDynamicTokenSetData.ts
@@ -1,0 +1,40 @@
+import { GeneratorQuery, Graphql, RawToken } from '@tokens-studio/sdk';
+import { GET_GENERATOR_QUERY } from '../graphql';
+import { FlowGraph, execute, minimizeFlowGraph, nodes } from '@tokens-studio/graph-engine';
+import { externalLoader } from './externalLoader';
+
+export const fetchDynamicTokenSetData = async (generatorUrn: string) => {
+  try {
+    const responseData = await Graphql.exec<GeneratorQuery>(
+      Graphql.op(GET_GENERATOR_QUERY, {
+        urn: generatorUrn,
+      }),
+    );
+
+    if (!responseData.data?.generator?.graph) {
+      return null;
+    }
+
+    const graph = JSON.parse(responseData.data.generator.graph) as FlowGraph;
+
+    const output = (await execute({
+      graph: minimizeFlowGraph(graph),
+      inputValues: {},
+      nodes,
+      externalLoader,
+    })) as { tokens: Array<RawToken> };
+
+    const tokensArray = Object.values(output).reduce((acc, curr) => {
+      if (Array.isArray(curr)) {
+        return [...acc, ...curr];
+      }
+      return acc;
+    }, []);
+
+    return tokensArray;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return null;
+};

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/dynamicSets/index.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/dynamicSets/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchDynamicTokenSetData';
+export * from './externalLoader';

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/createTokenMutation.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/createTokenMutation.ts
@@ -1,26 +1,9 @@
+import { TOKEN_FRAGMENT } from './tokenFragment';
+
 export const CREATE_TOKEN_MUTATION = `
     mutation CreateToken($set: String!, $input: TokenInput!) {
         createToken(set: $set, input: $input) {
-        description
-        name
-        urn
-        extensions
-        setUrn
-        type
-        value {
-            ... on Raw_Token_scalar {
-            value
-            }
-            ... on Raw_Token_typography {
-            value
-            }
-            ... on Raw_Token_border {
-            value
-            }
-            ... on Raw_Token_boxShadow {
-            value
-            }
-        }
+            ${TOKEN_FRAGMENT}
         }
     }
 `;

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/deleteTokenMutation.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/deleteTokenMutation.ts
@@ -1,26 +1,9 @@
+import { TOKEN_FRAGMENT } from './tokenFragment';
+
 export const DELETE_TOKEN_MUTATION = `
 mutation DeleteToken($urn: String!) {
     deleteToken(urn: $urn) {
-        description
-        name
-        urn
-        extensions
-        setUrn
-        type
-        value {
-            ... on Raw_Token_scalar {
-                value
-            }
-            ... on Raw_Token_typography {
-                value
-            }
-            ... on Raw_Token_border {
-                value
-            }
-            ... on Raw_Token_boxShadow {
-                value
-            }
-        }
+        ${TOKEN_FRAGMENT}
     }
 }
 `;

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getGeneratorQuery.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getGeneratorQuery.ts
@@ -1,0 +1,12 @@
+export const GET_GENERATOR_QUERY = `
+query Generator($urn: String!) {
+    generator(urn: $urn) {
+        urn
+        name
+        description
+        createdAt
+        updatedAt
+        graph
+    }
+}
+`;

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getProjectDataQuery.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getProjectDataQuery.ts
@@ -1,3 +1,5 @@
+import { TOKEN_FRAGMENT } from './tokenFragment';
+
 export const GET_PROJECT_DATA_QUERY = `
 query Project($urn: String!) {
   project(urn: $urn) {
@@ -6,52 +8,10 @@ query Project($urn: String!) {
       name
       type
       projectUrn
+      generatorUrn
       orderIndex
       tokens(limit: 400) {
-        description
-        name
-        urn
-        extensions
-        setUrn
-        type
-        value {
-          ... on Raw_Token_scalar {
-            value
-          }
-          ... on Raw_Token_typography {
-            value
-            typography {
-              textDecoration
-              textCase
-              lineHeight
-              letterSpacing
-              fontSize
-              fontFamily
-              fontWeight
-              paragraphIndent
-              paragraphSpacing
-            }
-          }
-          ... on Raw_Token_border {
-            value
-            border {
-              width
-              style
-              color
-            }
-          }
-          ... on Raw_Token_boxShadow {
-            value
-            boxShadow {
-              x
-              y
-              blur
-              spread
-              color
-              type
-            }
-          }
-        }
+        ${TOKEN_FRAGMENT}
       }
     }
     themeGroups {

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getTokenSetQuery.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getTokenSetQuery.ts
@@ -1,0 +1,21 @@
+import { TOKEN_FRAGMENT } from './tokenFragment';
+
+export const GET_TOKEN_SET_QUERY = `
+query TokenSet($urn: String!) {
+    tokenSet(urn: $urn) {
+        urn
+        metadata {
+            createdAt
+        }
+        name
+        projectUrn
+        type
+        generatorUrn
+        orderIndex
+        createdAt
+        tokens {
+            ${TOKEN_FRAGMENT}
+        }
+    }
+}
+`;

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/index.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/index.ts
@@ -9,3 +9,5 @@ export { UPDATE_TOKEN_SET_ORDER_MUTATION } from './updateTokenSetOrderMutation';
 export { CREATE_THEME_GROUP_MUTATION } from './createThemeGroupMutation';
 export { UPDATE_THEME_GROUP_MUTATION } from './updateThemeGroupMutation';
 export { DELETE_THEME_GROUP_MUTATION } from './deleteThemeGroupMutation';
+export { GET_GENERATOR_QUERY } from './getGeneratorQuery';
+export { GET_TOKEN_SET_QUERY } from './getTokenSetQuery';

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/tokenFragment.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/tokenFragment.ts
@@ -1,0 +1,43 @@
+export const TOKEN_FRAGMENT = `
+    description
+    name
+    urn
+    extensions
+    setUrn
+    type
+    value {
+        ... on Raw_Token_scalar {
+            value
+        }
+        ... on Raw_Token_typography {
+            typography {
+                textDecoration
+                textCase
+                lineHeight
+                letterSpacing
+                fontSize
+                fontFamily
+                fontWeight
+                paragraphIndent
+                paragraphSpacing
+            }
+        }
+        ... on Raw_Token_border {
+            border {
+                width
+                style
+                color
+            }
+        }
+        ... on Raw_Token_boxShadow {
+            boxShadow {
+                x
+                y
+                blur
+                spread
+                color
+                type
+            }
+        }
+    }
+`;

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/updateTokenMutation.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/updateTokenMutation.ts
@@ -1,24 +1,8 @@
-export const UPDATE_TOKEN_MUTATION = `mutation UpdateToken($urn: String!, $input: TokenUpdateInput!) {
+import { TOKEN_FRAGMENT } from './tokenFragment';
+
+export const UPDATE_TOKEN_MUTATION = `
+mutation UpdateToken($urn: String!, $input: TokenUpdateInput!) {
     updateToken(urn: $urn, input: $input) {
-      description
-      name
-      urn
-      extensions
-      setUrn
-      type
-      value {
-        ... on Raw_Token_scalar {
-          value
-        }
-        ... on Raw_Token_typography {
-          value
-        }
-        ... on Raw_Token_border {
-          value
-        }
-        ... on Raw_Token_boxShadow {
-          value
-        }
-      }
+      ${TOKEN_FRAGMENT}
     }
-  }`;
+}`;

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/utils/index.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './tokensStudioToToken';

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/utils/tokensStudioToToken.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/utils/tokensStudioToToken.ts
@@ -1,0 +1,78 @@
+import { RawToken, TokenType } from '@tokens-studio/sdk';
+import { deepmerge } from 'deepmerge-ts';
+import { SingleToken } from '@/types/tokens';
+
+interface Token {
+  name?: string | null;
+  description?: string | null;
+  type?: string | null;
+  value: any;
+  $extensions?: SingleToken['$extensions'];
+}
+
+const removeNulls = (obj: any) => Object.fromEntries(Object.entries(obj).filter(([key, v]) => v !== null));
+
+const parseValue = (value: string | undefined | null) => {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return value;
+  }
+};
+
+// We need to convert the raw token data from the GraphQL API into a format that the plugin will understand,
+// as there's some differences between the two. Ideally, we could just pass in a "request format"
+// into the query, but that's not possible so far.
+export const tokensStudioToToken = (raw: RawToken) => {
+  let combined: Token = {
+    name: raw.name,
+    type: raw.type,
+    value: null,
+  };
+
+  if (raw.urn) {
+    combined = {
+      ...combined,
+      $extensions: {
+        'studio.tokens': {
+          urn: raw.urn,
+        },
+      },
+    };
+  }
+
+  if (raw.description) {
+    combined.description = raw.description;
+  }
+
+  if (raw.extensions) {
+    combined.$extensions = deepmerge(JSON.parse(raw.extensions), combined.$extensions);
+  }
+
+  // @ts-ignore
+  if (raw.value.typography) {
+    // @ts-ignore typography exists for typography tokens
+    combined.value = removeNulls((raw as RawToken).value!.typography!);
+    // @ts-ignore
+  } else if (raw.value.border) {
+    // @ts-ignore border exists for border tokens
+    combined.value = removeNulls((raw as unknown as Raw_Token_border).value!.border!);
+    // @ts-ignore
+  } else if (raw.value.boxShadow) {
+    // @ts-ignore
+    combined.value = (raw as Raw_Token_boxShadow).value!.boxShadow;
+  } else if (raw.type === TokenType.composition) {
+    combined.value = raw.value?.value && JSON.parse(raw.value.value);
+  } else if (raw.value?.value) {
+    combined.value = parseValue(raw.value.value);
+  } else {
+    // tokens from dynamic sets have a different structure
+    combined.value = parseValue(raw.value as unknown as string) || raw.value;
+  }
+
+  return combined;
+};


### PR DESCRIPTION
Add support for dynamic sets.

When querying the tokens from TS we take all dynamic sets and execute the graphs so we can show tokens in the plugin.

+ fix for non color tokens that were not parsed correctly


### Why does this PR exist?

Closes https://github.com/tokens-studio/studio-app/issues/885
Closes https://github.com/tokens-studio/studio-app/issues/884

### Testing this change

https://github.com/tokens-studio/figma-plugin/assets/19837930/df7cd525-5836-4963-a340-26f40cfbedd0


