### PR TITLE
#2720: fix left missing padding in draggable items

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/MoreButton/MoreButton.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/MoreButton/MoreButton.tsx
@@ -166,15 +166,15 @@ export const MoreButton: React.FC<React.PropsWithChildren<React.PropsWithChildre
                 </ContextMenu.SubContent>
               </ContextMenu.Portal>
             </ContextMenu.Sub>
-            ) : (
-              <MoreButtonProperty
-                key={property.name}
-                value={token.name}
-                property={property}
-                onClick={handleClick}
-                disabled={property.disabled}
-              />
-            )))}
+          ) : (
+            <MoreButtonProperty
+              key={property.name}
+              value={token.name}
+              property={property}
+              onClick={handleClick}
+              disabled={property.disabled}
+            />
+          )))}
           <ContextMenu.Sub>
             <ContextMenu.SubTrigger>
               Documentation Tokens

--- a/packages/tokens-studio-for-figma/src/app/components/MoreButton/MoreButton.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/MoreButton/MoreButton.tsx
@@ -6,9 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { ChevronRightIcon } from '@radix-ui/react-icons';
 import copy from 'copy-to-clipboard';
 
-import {
-  ContextMenu,
-} from '@tokens-studio/ui';
+import { ContextMenu } from '@tokens-studio/ui';
 import { styled } from '@/stitches.config';
 import { activeTokenSetReadOnlySelector, activeTokenSetSelector, editProhibitedSelector } from '@/selectors';
 import { PropertyObject } from '@/types/properties';
@@ -142,14 +140,13 @@ export const MoreButton: React.FC<React.PropsWithChildren<React.PropsWithChildre
 
   return (
     <ContextMenu>
-
       <ContextMenu.Trigger id={`${token.name}-button}`}>
         <TokenButtonContent type={type} active={active} onClick={handleTokenClick} token={token} />
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content alignOffset={5} collisionPadding={30}>
           {visibleProperties.map((property) => (property.childProperties ? (
-            <ContextMenu.Sub>
+            <ContextMenu.Sub key={property.label}>
               <ContextMenu.SubTrigger>
                 {property.label}
                 <RightSlot>
@@ -169,15 +166,15 @@ export const MoreButton: React.FC<React.PropsWithChildren<React.PropsWithChildre
                 </ContextMenu.SubContent>
               </ContextMenu.Portal>
             </ContextMenu.Sub>
-          ) : (
-            <MoreButtonProperty
-              key={property.name}
-              value={token.name}
-              property={property}
-              onClick={handleClick}
-              disabled={property.disabled}
-            />
-          )))}
+            ) : (
+              <MoreButtonProperty
+                key={property.name}
+                value={token.name}
+                property={property}
+                onClick={handleClick}
+                disabled={property.disabled}
+              />
+            )))}
           <ContextMenu.Sub>
             <ContextMenu.SubTrigger>
               Documentation Tokens
@@ -187,7 +184,14 @@ export const MoreButton: React.FC<React.PropsWithChildren<React.PropsWithChildre
             </ContextMenu.SubTrigger>
             <ContextMenu.Portal>
               <ContextMenu.SubContent alignOffset={-5} collisionPadding={30}>
-                {DocumentationProperties.map((property) => <MoreButtonProperty key={property.name} value={token.name} property={property} onClick={handleClick} />)}
+                {DocumentationProperties.map((property) => (
+                  <MoreButtonProperty
+                    key={property.name}
+                    value={token.name}
+                    property={property}
+                    onClick={handleClick}
+                  />
+                ))}
               </ContextMenu.SubContent>
             </ContextMenu.Portal>
           </ContextMenu.Sub>

--- a/packages/tokens-studio-for-figma/src/app/components/StyledDragger/DragGrabber.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StyledDragger/DragGrabber.tsx
@@ -9,22 +9,19 @@ export type Props<T> = {
   onDragStart?: (event: React.PointerEvent<HTMLDivElement>, item: T) => void;
 };
 
-export function DragGrabber<T>({
-  item,
-  canReorder = false,
-  onDragStart,
-}: Props<T>) {
-  const handleGrabberPointerDown = useCallback<React.PointerEventHandler<HTMLDivElement>>((event) => {
-    if (onDragStart) onDragStart(event, item);
-  }, [item, onDragStart]);
+export function DragGrabber<T>({ item, canReorder = false, onDragStart }: Props<T>) {
+  const handleGrabberPointerDown = useCallback<React.PointerEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (onDragStart) onDragStart(event, item);
+    },
+    [item, onDragStart],
+  );
 
   return (
     <StyledBeforeFlex>
-      {canReorder ? (
-        <StyledGrabber onPointerDown={handleGrabberPointerDown}>
-          <IconGrabber />
-        </StyledGrabber>
-      ) : null}
+      <StyledGrabber onPointerDown={handleGrabberPointerDown} canReorder={canReorder}>
+        <IconGrabber />
+      </StyledGrabber>
     </StyledBeforeFlex>
   );
 }

--- a/packages/tokens-studio-for-figma/src/app/components/StyledDragger/StyledDragButton.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StyledDragger/StyledDragButton.tsx
@@ -11,9 +11,6 @@ export const StyledDragButton = styled('button', {
     [`+ ${StyledCheckbox}`]: {
       opacity: 1,
     },
-    [`${StyledGrabber}`]: {
-      opacity: 1,
-    },
   },
   variants: {
     isActive: {

--- a/packages/tokens-studio-for-figma/src/app/components/StyledDragger/StyledGrabber.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StyledDragger/StyledGrabber.tsx
@@ -2,14 +2,23 @@ import Box from '../Box';
 import { styled } from '@/stitches.config';
 
 export const StyledGrabber = styled(Box, {
-  cursor: 'grab',
   display: 'flex',
   alignItems: 'center',
   width: '$4',
   height: '100%',
   color: '$fgSubtle',
   opacity: 0,
-  '&:hover': {
-    opacity: 1,
+  variants: {
+    canReorder: {
+      true: {
+        cursor: 'grab',
+        '&:hover': {
+          opacity: 1,
+        },
+      },
+      false: {
+        pointerEvents: 'none',
+      },
+    },
   },
 });


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2720](https://github.com/tokens-studio/figma-plugin/issues/2720)

Draggable items become undraggable when in read-only mode (i.e. user does not have full permissions to edit, reorder, etc), making multiple screens in the plugin look strange due to the missing space on the left hand side. This PR ensures the space for the grabber remains.

### What does this pull request do?
* Adds a `canReorder` variant to `StyledDragger` that shows / hides the grabber icon based on its boolean value
* Cleans up redundant styling in `StyledDragButton`, which was overriding the visibility behaviour of the grabber
* Unrelated: fixes a missing key in children warning coming from `MoreButton`

#### Free account: before & after 

👀 Note the yellow squares highlighting the difference when user is free (i.e. `editProhibited`):
* Grabber icon (three horizontal lines) not appearing on hover
* Dropdown actions (when applicable) **Rename, Duplicate & Delete** are disabled

##### Scenario A: Tokens list view

Affected files: `TokenSetTreeItemContent.tsx`, `TokenSetItem.tsx`

###### Before
<img width="200" alt="free user tokens list with multiple sets" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/ddf85598-0d74-46b9-80ae-2aa1debb9650">

###### After
<img width="200" alt="free user tokens list with multiple sets" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/0ee03d41-0a34-4cb0-be74-8d67b4116514">

##### Scenario B: Theme management modal

Affected files: `ThemeListGroupHeader.tsx`, `ThemeListItemContent.tsx`

###### Before
<img width="200" alt="free user theme management" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/a1f8258a-91d9-470d-bbfb-defd82c78ad1">

###### After
<img width="200" alt="free user theme management" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/b8a364a9-8367-4892-afa1-ef8ba5408041">

##### Scenario C: Composition token creation modal

Affected files: `SingleCompositionTokenContent.tsx`

###### Before
<img width="200" alt="free user composition token creation" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/8d48531f-1afc-40e7-b0f9-73d84aeb0187">

###### After
<img width="200" alt="free user composition token creation" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/d838063e-5527-410b-acbe-ebc35f902157">

### Testing this change

Firstly, ensure you are a **free** user.

#### Scenario A
* Have a sync setup with various token files (See [docs](https://docs.tokens.studio/sync/multi-file)), to ensure that the **tokens tab** view has nested layers on the left hand side
   * You will need to set this one as a **paid** user, then remove the license key 🔑 
   * ⚠️ Restart the plugin to see the user status change
   * 🔨  If the user status _still_ doesn't update, in `Settings` -> `Sync providers` - change from remote to local, this should refresh the user status
* See how the left hand side maintains the spacing, where the reordering drag icon user to be 

#### Scenario B

> ⚠️ This scenario should never be accessible for a free user. When clicking on the "Theme" dropdown, the _"Manage themes"_ option is disabled.

<img width="200" alt="free user disabled theme management" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/1e490938-d8c9-4cdd-abb4-8a4976b66e99">

To test locally, force the `canReorder: false` in `ThemeListGroupHeader.tsx` & `ThemeListItemContent.tsx`.

#### Scenario C

> ⚠️ This scenario should never be accessible for a free user. When scrolling down to the "Composition" tokens area, the option is disabled.

<img width="200" alt="free user disabled composition tokens" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/f0476bcd-9955-4e2c-8cb1-725eecdd386a">

To test locally, force the `canReorder: false` in `SingleCompositionTokenContent.tsx`.