### PR TITLE
2.0: fix startup

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/AddLicenseKey/AddLicenseKey.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/AddLicenseKey/AddLicenseKey.test.tsx
@@ -15,6 +15,7 @@ import {
 import { AddLicenseSource } from '@/app/store/models/userState';
 import ConfirmDialog from '../ConfirmDialog';
 import * as notifiers from '@/plugin/notifiers';
+import { addLicenseKey } from '@/utils/addLicenseKey';
 
 // Hide log calls unless they are expected. This is mainly related to react-modal
 jest.spyOn(console, 'error').mockImplementation(() => { });
@@ -159,9 +160,11 @@ describe('Add license key', () => {
       </Provider>,
     );
 
-    await mockStore.dispatch.userState.addLicenseKey({
+    await addLicenseKey(mockStore.dispatch, {
       key: LICENSE_FOR_VALID_RESPONSE,
       source: AddLicenseSource.UI,
+    }, {
+      userId: '123',
     });
 
     const removeKeyButton = await result.findByRole('button', {
@@ -185,9 +188,11 @@ describe('Add license key', () => {
       </Provider>,
     );
 
-    await mockStore.dispatch.userState.addLicenseKey({
+    await addLicenseKey(mockStore.dispatch, {
       key: LICENSE_FOR_VALID_RESPONSE,
       source: AddLicenseSource.UI,
+    }, {
+      userId: '123',
     });
 
     const removeKeyButton = await result.findByRole('button', {
@@ -220,9 +225,11 @@ describe('Add license key', () => {
       </Provider>,
     );
 
-    await mockStore.dispatch.userState.addLicenseKey({
+    await addLicenseKey(mockStore.dispatch, {
       key: LICENSE_FOR_DETACH_ERROR_RESPONSE,
       source: AddLicenseSource.UI,
+    }, {
+      userId: '123',
     });
 
     const removeKeyButton = await result.getByRole('button', {
@@ -252,9 +259,11 @@ describe('Add license key', () => {
       </Provider>,
     );
 
-    await mockStore.dispatch.userState.addLicenseKey({
+    await addLicenseKey(mockStore.dispatch, {
       key: LICENSE_FOR_ERROR_RESPONSE,
       source: AddLicenseSource.UI,
+    }, {
+      userId: '123',
     });
 
     await act(async () => {

--- a/packages/tokens-studio-for-figma/src/app/components/AddLicenseKey/AddLicenseKey.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/AddLicenseKey/AddLicenseKey.tsx
@@ -20,6 +20,7 @@ import { userIdSelector } from '@/selectors/userIdSelector';
 import { licenseDetailsSelector } from '@/selectors';
 import { ldUserFactory } from '@/utils/ldUserFactory';
 import { ErrorMessage } from '../ErrorMessage';
+import { addLicenseKey } from '@/utils/addLicenseKey';
 
 export default function AddLicenseKey() {
   const inputEl = useRef<HTMLInputElement | null>(null);
@@ -40,9 +41,11 @@ export default function AddLicenseKey() {
 
   const addKey = useCallback(async () => {
     if (newKey) {
-      await dispatch.userState.addLicenseKey({ key: newKey, source: AddLicenseSource.UI });
+      await addLicenseKey(dispatch, { key: newKey, source: AddLicenseSource.UI }, {
+        userId,
+      });
     }
-  }, [newKey, dispatch]);
+  }, [newKey, dispatch, userId]);
 
   const removeAccessToFeatures = useCallback(() => {
     if (userId) {

--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/addLicenseFactory.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/addLicenseFactory.test.ts
@@ -4,6 +4,7 @@ import { addLicenseFactory } from '../addLicenseFactory';
 import { AddLicenseSource } from '@/app/store/models/userState';
 import * as getLicenseKeyModule from '@/utils/getLicenseKey';
 import { LicenseStatus } from '@/constants/LicenseStatus';
+import * as addLicenseKey from '@/utils/addLicenseKey';
 
 describe('addLicenseFactory', () => {
   const getLicenseKeySpy = jest.spyOn(getLicenseKeyModule, 'default');
@@ -15,16 +16,18 @@ describe('addLicenseFactory', () => {
       licenseKey: 'FIGMA-TOKENS',
     } as unknown as StartupMessage;
 
-    const addLicenseKeySpy = jest.spyOn(mockStore.dispatch.userState, 'addLicenseKey');
+    const addLicenseKeySpy = jest.spyOn(addLicenseKey, 'addLicenseKey');
     addLicenseKeySpy.mockResolvedValueOnce();
 
     const fn = addLicenseFactory(mockStore.dispatch, mockParams);
     await fn();
 
     expect(addLicenseKeySpy).toBeCalledTimes(1);
-    expect(addLicenseKeySpy).toBeCalledWith({
+    expect(addLicenseKeySpy).toBeCalledWith(mockStore.dispatch, {
       key: 'FIGMA-TOKENS',
       source: AddLicenseSource.INITAL_LOAD,
+    }, {
+      userId: 'figma:1234',
     });
     expect(getLicenseKeySpy).not.toBeCalled();
   });
@@ -35,7 +38,7 @@ describe('addLicenseFactory', () => {
       user: { figmaId: 'figma:1234' },
     } as unknown as StartupMessage;
 
-    const addLicenseKeySpy = jest.spyOn(mockStore.dispatch.userState, 'addLicenseKey');
+    const addLicenseKeySpy = jest.spyOn(addLicenseKey, 'addLicenseKey');
     getLicenseKeySpy.mockResolvedValueOnce({
       error: 'No license found',
     });
@@ -53,7 +56,7 @@ describe('addLicenseFactory', () => {
       user: { figmaId: 'figma:1234' },
     } as unknown as StartupMessage;
 
-    const addLicenseKeySpy = jest.spyOn(mockStore.dispatch.userState, 'addLicenseKey');
+    const addLicenseKeySpy = jest.spyOn(addLicenseKey, 'addLicenseKey');
     getLicenseKeySpy.mockResolvedValueOnce({
       key: 'FIGMA-TOKENS',
     });

--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/addLicenseFactory.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/addLicenseFactory.ts
@@ -2,6 +2,7 @@ import type { Dispatch } from '@/app/store';
 import { AddLicenseSource } from '@/app/store/models/userState';
 import { LicenseStatus } from '@/constants/LicenseStatus';
 import type { StartupMessage } from '@/types/AsyncMessages';
+import { addLicenseKey } from '@/utils/addLicenseKey';
 import getLicenseKey from '@/utils/getLicenseKey';
 
 export function addLicenseFactory(dispatch: Dispatch, params: StartupMessage) {
@@ -18,9 +19,12 @@ export function addLicenseFactory(dispatch: Dispatch, params: StartupMessage) {
     }
 
     if (licenseKey) {
-      await dispatch.userState.addLicenseKey({
+      await addLicenseKey(dispatch, {
         key: licenseKey,
         source: AddLicenseSource.INITAL_LOAD,
+      }, {
+        userId: user!.figmaId,
+        userName: user!.name,
       });
     } else {
       dispatch.userState.setLicenseStatus(LicenseStatus.NO_LICENSE);

--- a/packages/tokens-studio-for-figma/src/app/store/models/userState.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/userState.ts
@@ -96,44 +96,6 @@ export const userState = createModel<RootModel>()({
     ...userStateReducers,
   },
   effects: (dispatch) => ({
-    addLicenseKey: async (payload: { key: string; source: AddLicenseSource }, rootState) => {
-      dispatch.userState.setLicenseStatus(LicenseStatus.VERIFYING);
-
-      const { userId, userName } = rootState.userState;
-      const { key, source } = payload;
-
-      const {
-        error, plan, email: clientEmail, entitlements,
-      } = await validateLicense(key, userId, userName);
-
-      if (error) {
-        dispatch.userState.setLicenseStatus(LicenseStatus.ERROR);
-        dispatch.userState.setLicenseError(error);
-        if (source === AddLicenseSource.INITAL_LOAD) {
-          notifyToUI('License key invalid, please check your Settings', { error: true });
-        }
-      } else {
-        // clear errors when license validation is succesfull
-        dispatch.userState.setLicenseError(undefined);
-        dispatch.userState.setLicenseDetails({
-          plan,
-          clientEmail,
-          entitlements: [...new Set(entitlements)],
-        });
-        dispatch.userState.setLicenseStatus(LicenseStatus.VERIFIED);
-
-        if (source === AddLicenseSource.UI) {
-          notifyToUI('License added succesfully!');
-          dispatch.userState.setLicenseKey(key);
-        }
-
-        AsyncMessageChannel.ReactInstance.message({
-          type: AsyncMessageTypes.SET_LICENSE_KEY,
-          licenseKey: key,
-        });
-      }
-      dispatch.userState.setLicenseKey(key);
-    },
     removeLicenseKey: async (payload, rootState) => {
       const { licenseKey, userId, licenseError } = rootState.userState;
 

--- a/packages/tokens-studio-for-figma/src/utils/addLicenseKey.ts
+++ b/packages/tokens-studio-for-figma/src/utils/addLicenseKey.ts
@@ -1,0 +1,49 @@
+import { Dispatch } from '@/app/store';
+import { AddLicenseSource } from '@/app/store/models/userState';
+import { LicenseStatus } from '@/constants/LicenseStatus';
+import validateLicense from './validateLicense';
+import { notifyToUI } from '@/plugin/notifiers';
+import { AsyncMessageChannel } from '@/AsyncMessageChannel';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+
+export async function addLicenseKey(dispatch: Dispatch, payload: { key: string; source: AddLicenseSource }, user: {
+  userId: string | null;
+  userName?: string;
+}) {
+  dispatch.userState.setLicenseStatus(LicenseStatus.VERIFYING);
+
+  const { userId, userName } = user;
+  const { key, source } = payload;
+
+  const {
+    error, plan, email: clientEmail, entitlements,
+  } = await validateLicense(key, userId, userName);
+
+  if (error) {
+    dispatch.userState.setLicenseStatus(LicenseStatus.ERROR);
+    dispatch.userState.setLicenseError(error);
+    if (source === AddLicenseSource.INITAL_LOAD) {
+      notifyToUI('License key invalid, please check your Settings', { error: true });
+    }
+  } else {
+    // clear errors when license validation is succesfull
+    dispatch.userState.setLicenseError(undefined);
+    dispatch.userState.setLicenseDetails({
+      plan,
+      clientEmail,
+      entitlements: [...new Set(entitlements)],
+    });
+    dispatch.userState.setLicenseStatus(LicenseStatus.VERIFIED);
+
+    if (source === AddLicenseSource.UI) {
+      notifyToUI('License added succesfully!');
+      dispatch.userState.setLicenseKey(key);
+    }
+
+    AsyncMessageChannel.ReactInstance.message({
+      type: AsyncMessageTypes.SET_LICENSE_KEY,
+      licenseKey: key,
+    });
+  }
+  dispatch.userState.setLicenseKey(key);
+}


### PR DESCRIPTION
### Why does this PR exist?

Fixes https://github.com/tokens-studio/figma-plugin/issues/2719

### What does this pull request do?

Previously `addLicenseKey` was a side-effect in state. This caused us to not await the response of this, something in the upgrade to 2.0 must've caused this to become apparent.

I now changed it so that addLicenseKey is a dedicated function that we properly await. Doing so the plugin now awaits license key response before we move on to other parts of the startup, also fixing our launch darkly issues.

### Before
https://github.com/tokens-studio/figma-plugin/assets/4548309/b7722b8a-2e2b-47ba-9b6f-b5b6c955eadd

### After
https://github.com/tokens-studio/figma-plugin/assets/4548309/cec4d03f-051e-40f4-a149-ea26b731bbc6
