### PR TITLE
fix: avoid hidden names & values in search dropdowns

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
@@ -278,8 +278,16 @@ export const DownshiftInput: React.FunctionComponent<React.PropsWithChildren<Rea
                                 <StyledItemColor style={{ backgroundColor: token.value.toString() }} />
                               </StyledItemColorDiv>
                               )}
-                              <StyledItemName>{getHighlightedText(token.name, searchInput || '')}</StyledItemName>
-                              <StyledItemValue>{getResolvedText(token)}</StyledItemValue>
+                              <StyledItemName truncate>
+                                <Tooltip label={getHighlightedText(token.name, searchInput) || ''} side="bottom">
+                                  {getHighlightedText(token.name, searchInput || '')}
+                                </Tooltip>
+                              </StyledItemName>
+                              <StyledItemValue truncate>
+                                <Tooltip label={getResolvedText(token)} side="bottom">
+                                  <span>{getResolvedText(token)}</span>
+                                </Tooltip>
+                              </StyledItemValue>
                             </StyledItem>
                           );
                         }}
@@ -301,7 +309,11 @@ export const DownshiftInput: React.FunctionComponent<React.PropsWithChildren<Rea
                                   // eslint-disable-next-line react/jsx-no-bind
                                   onMouseDown={() => handleSelect(filteredValue)}
                                 >
-                                  <StyledItemName>{getHighlightedText(filteredValue, searchInput || '')}</StyledItemName>
+                                  <StyledItemName truncate>
+                                    <Tooltip label={getHighlightedText(filteredValue, searchInput)} side="bottom">
+                                      {getHighlightedText(filteredValue, searchInput || '')}
+                                    </Tooltip>
+                                  </StyledItemName>
                                 </StyledItem>
                               );
                             }}

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import Mentions from 'rc-mentions';
 import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 import { isDocumentationType } from '@/utils/is/isDocumentationType';
@@ -8,7 +9,7 @@ import { TokenTypes } from '@/constants/TokenTypes';
 import { useReferenceTokenType } from '@/app/hooks/useReferenceTokenType';
 import './mentions.css';
 import {
-  StyledItem, StyledItemColor, StyledItemColorDiv, StyledItemName, StyledItemValue, StyledPart,
+  StyledItem, StyledItemColor, StyledItemName, StyledItemValue, StyledPart, StyledItemInfo, StyledItemInfoLabel,
 } from './StyledDownshiftInput';
 import getResolvedTextValue from '@/utils/getResolvedTextValue';
 
@@ -49,6 +50,7 @@ export default function MentionsInput({
   hasPrefix = false,
 }: Props) {
   const referenceTokenTypes = useReferenceTokenType(type as TokenTypes);
+  const { t } = useTranslation(['tokens']);
 
   const mentionData = useMemo<SuggestionDataItem[]>(() => {
     if (isDocumentationType(type as Properties)) {
@@ -107,17 +109,27 @@ export default function MentionsInput({
         className="mentions-item"
       >
         <StyledItem
+          css={{ display: 'block' }}
           className="dropdown-item"
         >
-          {type === 'color' && (
-          <StyledItemColorDiv>
-            <StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} />
-          </StyledItemColorDiv>
-          )}
-          <StyledItemName css={{ flexGrow: '1' }}>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
+          <StyledItemInfo>
+            <StyledItemInfoLabel>{`${t('name')}: `}</StyledItemInfoLabel>
+            <StyledItemName>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
+          </StyledItemInfo>
           {
-            resolvedToken && <StyledItemValue>{getResolvedTextValue(resolvedToken)}</StyledItemValue>
-          }
+            resolvedToken && (
+            <StyledItemInfo>
+              <StyledItemInfoLabel>{`${t('value')}: `}</StyledItemInfoLabel>
+              <StyledItemValue>{getResolvedTextValue(resolvedToken)}</StyledItemValue>
+            </StyledItemInfo>
+            )
+}
+          {type === 'color' && (
+            <StyledItemInfo>
+              <StyledItemInfoLabel>{`${t('types.Color')}: `}</StyledItemInfoLabel>
+              <StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} />
+            </StyledItemInfo>
+          )}
         </StyledItem>
       </Option>
     );

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -113,20 +113,20 @@ export default function MentionsInput({
           className="dropdown-item"
         >
           <StyledItemInfo>
-            <StyledItemInfoLabel>{`${t('name')}: `}</StyledItemInfoLabel>
+            <StyledItemInfoLabel>{`${t('name')} `}</StyledItemInfoLabel>
             <StyledItemName>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
           </StyledItemInfo>
           {
             resolvedToken && (
             <StyledItemInfo>
-              <StyledItemInfoLabel>{`${t('value')}: `}</StyledItemInfoLabel>
+              <StyledItemInfoLabel>{`${t('value')} `}</StyledItemInfoLabel>
               <StyledItemValue>{getResolvedTextValue(resolvedToken)}</StyledItemValue>
             </StyledItemInfo>
             )
 }
           {type === 'color' && (
             <StyledItemInfo>
-              <StyledItemInfoLabel>{`${t('types.Color')}: `}</StyledItemInfoLabel>
+              <StyledItemInfoLabel>{`${t('types.Color')} `}</StyledItemInfoLabel>
               <StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} />
             </StyledItemInfo>
           )}

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
@@ -28,6 +28,7 @@ export const StyledDropdown = styled('div', {
   backgroundColor: '$bgDefault',
   cursor: 'pointer',
   boxShadow: '$contextMenu',
+  padding: '$3',
 });
 
 export const StyledList = styled(List as ComponentType<any>, {
@@ -40,8 +41,9 @@ export const StyledList = styled(List as ComponentType<any>, {
 });
 
 export const StyledItemValue = styled('div', {
-  color: '$fgMuted',
-  fontWeight: '$sansBold',
+  fontSize: '$medium',
+  color: '$fgDefault',
+  fontWeight: '$normal',
   variants: {
     truncate: {
       true: {
@@ -58,8 +60,7 @@ export const StyledItem = styled('div', {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  gap: '$1',
-  padding: '$2 $3',
+  padding: '$3',
   fontSize: '$xxsmall',
   borderBottom: '1px solid $bgSubtle',
   variants: {
@@ -85,7 +86,10 @@ export const StyledItemColor = styled('div', {
 });
 
 export const StyledItemName = styled('div', {
-  fontWeight: '$sansBold',
+  fontSize: '$medium',
+  color: '$fgDefault',
+  fontWeight: '$normal',
+  lineHeight: '1.4',
   variants: {
     truncate: {
       true: {
@@ -101,10 +105,15 @@ export const StyledItemName = styled('div', {
 export const StyledItemInfo = styled('div', {
   display: 'flex',
   alignItems: 'center',
+  marginBottom: '$3',
 });
 
 export const StyledItemInfoLabel = styled('span', {
-  marginRight: '$2',
+  marginRight: '$3',
+  fontSize: '$medium',
+  color: '$fgDefault',
+  fontWeight: '$sansSemibold',
+  lineHeight: '1.4',
 });
 
 export const StyledPart = styled('span', {

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
@@ -42,22 +42,30 @@ export const StyledList = styled(List as ComponentType<any>, {
 export const StyledItemValue = styled('div', {
   color: '$fgMuted',
   fontWeight: '$sansBold',
-  textAlign: 'right',
-  maxWidth: '300px',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
+  variants: {
+    truncate: {
+      true: {
+        maxWidth: '50%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        textWrap: 'nowrap',
+      },
+    },
+  },
 });
 
 export const StyledItem = styled('div', {
   display: 'flex',
   alignItems: 'center',
-  gap: '$2',
+  justifyContent: 'space-between',
+  gap: '$1',
   padding: '$2 $3',
-  borderRadius: '$small',
   fontSize: '$xxsmall',
+  borderBottom: '1px solid $bgSubtle',
   variants: {
     isFocused: {
       true: {
+        borderRadius: '0 !important',
         backgroundColor: '$bgSubtle',
       },
     },
@@ -77,9 +85,26 @@ export const StyledItemColor = styled('div', {
 });
 
 export const StyledItemName = styled('div', {
-  flexGrow: 1,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
+  fontWeight: '$sansBold',
+  variants: {
+    truncate: {
+      true: {
+        maxWidth: '50%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        textWrap: 'nowrap',
+      },
+    },
+  },
+});
+
+export const StyledItemInfo = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+});
+
+export const StyledItemInfoLabel = styled('span', {
+  marginRight: '$2',
 });
 
 export const StyledPart = styled('span', {

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
@@ -57,8 +57,8 @@
 }
 
 .rc-mentions-dropdown-menu {
-  width: 70vw;
-  max-width: 450px;
+  min-width: 200px;
+  max-width: 60vw;
   margin: 0;
   padding: 0;
   max-height: 250px;
@@ -78,7 +78,6 @@
 
 .rc-mentions-dropdown-menu-item {
   width: 100%;
-  min-width: 150px;
   position: relative;
   border-radius: var(--radii-small);
   color: var(--colors-fgDefault);

--- a/packages/tokens-studio-for-figma/src/app/components/TokenListing.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenListing.tsx
@@ -94,7 +94,6 @@ const TokenListing: React.FC<React.PropsWithChildren<React.PropsWithChildren<Pro
             data-testid={`tokenlisting-${tokenKey}-content`}
             css={{
               padding: '$4',
-              paddingTop: 0,
               display: collapsedTokenTypeObj[tokenKey as TokenTypes] ? 'none' : 'block',
             }}
           >


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2147](https://github.com/tokens-studio/figma-plugin/issues/2147#issue-1839939066)

Fixes UI issues around the search functionality when editing tokens, from an overflowing dropdown portal component to hidden names and values due to ellipsis when long.

#### ⚠️ Caveats ⚠️ 
 - Needs design review before merging
 - Several less-than-ideal styling overrides to be addressed in following improvement sprints

### What does this pull request do?

For very complex token naming hierarchies, the UI breaks at various places. To set up, ensure you have a variety of tokens with long names (i.e. `very-long-square.wrapping-text-behaviour-token-name.white-background-label-action.ghost-variant.large-cta-just-for-testing-purposes.try-and-break-this-search-box`) or values.

#### 1. Prevents long values from being hidden when searching

* Adapts components inside `DownshiftInput` to stack and wrap values
* Wraps components in `MentionsInput` with a tooltip

##### Before / After

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/83de7f26-d0f5-4096-889a-1a4599b35693" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/8e2f5bd9-9bad-4509-95ae-552ed745055d" width=200 />

<br/>

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/5bbebcfb-c38e-4a57-ac4a-baa4f407166c" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/fc1c104d-f4c8-4476-9f26-4228fb94857e" width=200 />

<br/>

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/f0460d6e-d135-44e3-b47f-a26b5e13f871" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/1e48b3de-57ab-4184-92fc-9f0d9c13ab43" width=200 />

##### Steps to test
1. Open the plugin in the tokens tab
2. Typography as **reference only**
 - Create a typography token
 - Search for an alias OR click on the dropdown
 - Name and value should be stacked OR ellipsis + tooltip showing full value
4. Colors
   - Reference a color token with a very long name
   -  Name, value and color view should be stacked

#### 2. Prevents dropdown results overflowing the plugin container

* Adapts width styling in `mentions.css` to prevent overflowing the parent container

##### Before / After
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/e0fffffc-cad7-487f-80cf-0bfca8051bbf" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/f2663670-992e-424b-985a-b2765882f95e" width=200 />

##### Steps to test
1. Open the plugin in the tokens tab
7. Edit / create any existing composition token
8. Search for an alias (Type: `{`) to display any long token name references
9. Dropdown portal should not overflow the plugin area

#### 3. Adds spacing between the token header and values

* Allows top padding in `TokenListing.tsx`

##### Before / After
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/c0953131-a30c-4560-abbd-f202ca76d8d6" width=200 />

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/c0953131-a30c-4560-abbd-f202ca76d8d6" width=200 />

##### Steps to test
1. Go to the the 'Tokens' tab in the plugin
10. Hover over any non-empty token type group, without nested tokens
11. See the space between the heading and token values