### PR TITLE
fix: improves dropdown search experience

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
@@ -264,23 +264,41 @@ export const DownshiftInput: React.FunctionComponent<React.PropsWithChildren<Rea
                         {({ index, style }) => {
                           const token = filteredTokenItems[index];
                           return (
-                            <StyledItem
-                              data-testid="downshift-input-item"
-                              className="dropdown-item"
-                              {...getItemProps({ key: token.name, index, item: token.name })}
-                              isFocused={highlightedIndex === index}
-                              style={style}
-                              // eslint-disable-next-line react/jsx-no-bind
-                              onMouseDown={() => handleSelect(token.name)}
-                            >
-                              {type === 'color' && (
-                              <StyledItemColorDiv>
-                                <StyledItemColor style={{ backgroundColor: token.value.toString() }} />
-                              </StyledItemColorDiv>
+                            <Tooltip
+                              side="bottom"
+                              label={(
+                                <Stack direction="column" align="start" gap={1} css={{ wordBreak: 'break-word' }}>
+                                  <StyledItemName css={{ color: '$tooltipFg' }}>
+                                    {getHighlightedText(token.name, searchInput || '')}
+                                  </StyledItemName>
+                                  <StyledItemValue css={{ color: '$tooltipFgMuted' }}>
+                                    <span>{getResolvedText(token)}</span>
+                                  </StyledItemValue>
+                                </Stack>
                               )}
-                              <StyledItemName>{getHighlightedText(token.name, searchInput || '')}</StyledItemName>
-                              <StyledItemValue>{getResolvedText(token)}</StyledItemValue>
-                            </StyledItem>
+                            >
+                              <StyledItem
+                                data-testid="downshift-input-item"
+                                className="dropdown-item"
+                                {...getItemProps({ key: token.name, index, item: token.name })}
+                                isFocused={highlightedIndex === index}
+                                style={style}
+                              // eslint-disable-next-line react/jsx-no-bind
+                                onMouseDown={() => handleSelect(token.name)}
+                              >
+                                {type === 'color' && (
+                                <StyledItemColorDiv>
+                                  <StyledItemColor style={{ backgroundColor: token.value.toString() }} />
+                                </StyledItemColorDiv>
+                                )}
+                                <StyledItemName truncate>
+                                  {getHighlightedText(token.name, searchInput || '')}
+                                </StyledItemName>
+                                <StyledItemValue truncate>
+                                  <span>{getResolvedText(token)}</span>
+                                </StyledItemValue>
+                              </StyledItem>
+                            </Tooltip>
                           );
                         }}
                       </StyledList>
@@ -292,17 +310,30 @@ export const DownshiftInput: React.FunctionComponent<React.PropsWithChildren<Rea
                             {({ index, style }) => {
                               const filteredValue = filteredValues[index];
                               return (
-                                <StyledItem
-                                  data-testid="downshift-input-item"
-                                  className="dropdown-item"
-                                  {...getItemProps({ key: value, index, item: value })}
-                                  isFocused={highlightedIndex === index}
-                                  style={style}
-                                  // eslint-disable-next-line react/jsx-no-bind
-                                  onMouseDown={() => handleSelect(filteredValue)}
+                                <Tooltip
+                                  side="bottom"
+                                  label={(
+                                    <Stack direction="column" align="start" gap={1} css={{ wordBreak: 'break-word' }}>
+                                      <StyledItemValue css={{ color: '$tooltipFg' }}>
+                                        {getHighlightedText(filteredValue, searchInput || '')}
+                                      </StyledItemValue>
+                                    </Stack>
+                              )}
                                 >
-                                  <StyledItemName>{getHighlightedText(filteredValue, searchInput || '')}</StyledItemName>
-                                </StyledItem>
+                                  <StyledItem
+                                    data-testid="downshift-input-item"
+                                    className="dropdown-item"
+                                    {...getItemProps({ key: value, index, item: value })}
+                                    isFocused={highlightedIndex === index}
+                                    style={style}
+                                  // eslint-disable-next-line react/jsx-no-bind
+                                    onMouseDown={() => handleSelect(filteredValue)}
+                                  >
+                                    <StyledItemName truncate>
+                                      {getHighlightedText(filteredValue, searchInput || '')}
+                                    </StyledItemName>
+                                  </StyledItem>
+                                </Tooltip>
                               );
                             }}
                         </StyledList>

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -8,7 +8,7 @@ import { TokenTypes } from '@/constants/TokenTypes';
 import { useReferenceTokenType } from '@/app/hooks/useReferenceTokenType';
 import './mentions.css';
 import {
-  StyledItem, StyledItemColor, StyledItemColorDiv, StyledItemName, StyledItemValue, StyledPart,
+  StyledItem, StyledItemColor, StyledItemColorDiv, StyledItemName, StyledItemValue, StyledPart, StyledItemInfo,
 } from './StyledDownshiftInput';
 import getResolvedTextValue from '@/utils/getResolvedTextValue';
 
@@ -107,16 +107,19 @@ export default function MentionsInput({
         className="mentions-item"
       >
         <StyledItem
+          css={{ display: 'block' }}
           className="dropdown-item"
         >
-          {type === 'color' && (
-          <StyledItemColorDiv>
-            <StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} />
-          </StyledItemColorDiv>
-          )}
-          <StyledItemName css={{ flexGrow: '1' }}>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
+          <StyledItemInfo>
+            <StyledItemName>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
+          </StyledItemInfo>
           {
-            resolvedToken && <StyledItemValue>{getResolvedTextValue(resolvedToken)}</StyledItemValue>
+            resolvedToken && (
+            <StyledItemInfo>
+              {type === 'color' && (<StyledItemColorDiv><StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} /></StyledItemColorDiv>)}
+              <StyledItemValue>{getResolvedTextValue(resolvedToken)}</StyledItemValue>
+            </StyledItemInfo>
+            )
           }
         </StyledItem>
       </Option>

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
@@ -28,6 +28,7 @@ export const StyledDropdown = styled('div', {
   backgroundColor: '$bgDefault',
   cursor: 'pointer',
   boxShadow: '$contextMenu',
+  padding: '$3',
 });
 
 export const StyledList = styled(List as ComponentType<any>, {
@@ -40,24 +41,32 @@ export const StyledList = styled(List as ComponentType<any>, {
 });
 
 export const StyledItemValue = styled('div', {
-  color: '$fgMuted',
-  fontWeight: '$sansBold',
-  textAlign: 'right',
-  maxWidth: '300px',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
+  fontSize: '$xsmall',
+  color: '$fgDefault',
+  fontWeight: '$normal',
+  variants: {
+    truncate: {
+      true: {
+        maxWidth: '50%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        textWrap: 'nowrap',
+      },
+    },
+  },
 });
 
 export const StyledItem = styled('div', {
   display: 'flex',
   alignItems: 'center',
-  gap: '$2',
-  padding: '$2 $3',
-  borderRadius: '$small',
+  justifyContent: 'space-between',
+  padding: '$3',
   fontSize: '$xxsmall',
+  borderBottom: '1px solid $bgSubtle',
   variants: {
     isFocused: {
       true: {
+        borderRadius: '0 !important',
         backgroundColor: '$bgSubtle',
       },
     },
@@ -66,20 +75,39 @@ export const StyledItem = styled('div', {
 
 export const StyledItemColorDiv = styled('div', {
   flexShrink: 0,
+  marginRight: '$2',
 });
 
 export const StyledItemColor = styled('div', {
-  width: '16px',
-  height: '16px',
-  borderRadius: '$small',
-  border: '1px solid',
-  borderColor: '$borderSubtle',
+  width: '20px',
+  height: '20px',
+  borderRadius: '$medium',
+  border: '1px solid $borderMuted',
 });
 
 export const StyledItemName = styled('div', {
-  flexGrow: 1,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
+  fontSize: '$xsmall',
+  color: '$fgDefault',
+  fontWeight: '$sansBold',
+  lineHeight: '1.4',
+  wordBreak: 'break-word',
+  marginRight: '$2',
+  variants: {
+    truncate: {
+      true: {
+        maxWidth: '50%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        textWrap: 'nowrap',
+      },
+    },
+  },
+});
+
+export const StyledItemInfo = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  marginBottom: '$2',
 });
 
 export const StyledPart = styled('span', {

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
@@ -57,8 +57,8 @@
 }
 
 .rc-mentions-dropdown-menu {
-  width: 70vw;
-  max-width: 450px;
+  min-width: 200px;
+  max-width: 60vw;
   margin: 0;
   padding: 0;
   max-height: 250px;
@@ -78,7 +78,6 @@
 
 .rc-mentions-dropdown-menu-item {
   width: 100%;
-  min-width: 150px;
   position: relative;
   border-radius: var(--radii-small);
   color: var(--colors-fgDefault);

--- a/packages/tokens-studio-for-figma/src/app/components/TokenListing.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenListing.tsx
@@ -94,7 +94,6 @@ const TokenListing: React.FC<React.PropsWithChildren<React.PropsWithChildren<Pro
             data-testid={`tokenlisting-${tokenKey}-content`}
             css={{
               padding: '$4',
-              paddingTop: 0,
               display: collapsedTokenTypeObj[tokenKey as TokenTypes] ? 'none' : 'block',
             }}
           >


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2147](https://github.com/tokens-studio/figma-plugin/issues/2147#issue-1839939066) (+ reopens old PR https://github.com/tokens-studio/figma-plugin/pull/2753)

Fixes UI issues around the search functionality when editing tokens, from an overflowing dropdown portal component to hidden names and values due to ellipsis when long.

#### ⚠️ Caveats ⚠️ 
 - Needs design review before merging
 - Several less-than-ideal styling overrides to be addressed in following improvement sprints

### What does this pull request do?

For very complex token naming hierarchies, the UI breaks at various places. To set up, ensure you have a variety of tokens with long names (i.e. `very-long-square.wrapping-text-behaviour-token-name.white-background-label-action.ghost-variant.large-cta-just-for-testing-purposes.try-and-break-this-search-box`) or values.

<video src='https://github.com/tokens-studio/figma-plugin/assets/114073780/91bbc8b5-06db-4e7c-ae6c-e4fcab16a55f' width=400></video>

#### 1. Prevents long values from being hidden when searching

* Adapts components inside `DownshiftInput` to stack and wrap values
* Wraps components in `MentionsInput` with a tooltip

##### Before / After

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/83de7f26-d0f5-4096-889a-1a4599b35693" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/f0a5efcd-e290-4873-8f41-5c05cc19edeb" width=200 />

<br/>

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/5bbebcfb-c38e-4a57-ac4a-baa4f407166c" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/47e7a53c-d0c9-46ba-a5f0-a2ff26e8ab53" width=200 />

<br/>

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/f0460d6e-d135-44e3-b47f-a26b5e13f871" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/8ae8085a-8082-443f-a574-c22ad04eed19" width=200 />

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/1106f7ae-d28b-4a3a-a677-b130b2d709f4" width=200 />

##### Steps to test
1. Open the plugin in the tokens tab
2. Typography as **reference only**
 - Create a typography token
 - Search for an alias OR click on the dropdown
 - Name and value should be stacked OR ellipsis + tooltip showing full value
4. Colors
   - Reference a color token with a very long name
   -  Name, value and color view should be stacked

#### 2. Prevents dropdown results overflowing the plugin container

* Adapts width styling in `mentions.css` to prevent overflowing the parent container

##### Before / After
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/e0fffffc-cad7-487f-80cf-0bfca8051bbf" width=200 />
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/ce4504b9-9d7d-486c-8271-81df46c48585" width=200 />

##### Steps to test
1. Open the plugin in the tokens tab
7. Edit / create any existing composition token
8. Search for an alias (Type: `{`) to display any long token name references
9. Dropdown portal should not overflow the plugin area

#### 3. Adds spacing between the token header and values

* Allows top padding in `TokenListing.tsx`

##### Before / After
<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/c0953131-a30c-4560-abbd-f202ca76d8d6" width=200 />

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/c0953131-a30c-4560-abbd-f202ca76d8d6" width=200 />

##### Steps to test
1. Go to the the 'Tokens' tab in the plugin
10. Hover over any non-empty token type group, without nested tokens
11. See the space between the heading and token values