### PR TITLE
fix: display full styling / variable info on theme management

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeStyleManagementCategoryStyleEntry.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeStyleManagementCategoryStyleEntry.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { ArrowRightIcon, LinkBreak1Icon, LinkBreak2Icon } from '@radix-ui/react-icons';
-import { Box, IconButton } from '@tokens-studio/ui';
+import { Box, IconButton, Tooltip } from '@tokens-studio/ui';
 import { Flex } from '../Flex';
 import Text from '../Text';
 import ResolvingLoader from '../ResolvingLoader';
@@ -60,27 +60,44 @@ export const ThemeStyleManagementCategoryStyleEntry: React.FC<React.PropsWithChi
           justifyContent: 'flex-start',
           alignItems: 'center',
           width: '100%',
+          minWidth: 0,
         }}
       >
-        <Box css={{
-          flexGrow: 1, display: 'flex', alignItems: 'center', gap: '$3', overflow: 'hidden',
-        }}
-        >
-          <Text size="small">{token}</Text>
-          <ArrowRightIcon />
-          {(!styleInfo.name && !styleInfo.failedToResolve) && (
-            <ResolvingLoader />
+        <Tooltip
+          side="bottom"
+          label={(
+            <Stack direction="column" align="start" gap={1} css={{ wordBreak: 'break-word' }}>
+              <Text css={{ color: '$tooltipFg' }}>
+                {token}
+              </Text>
+              <Text css={{ color: '$tooltipFgMuted' }}>
+                {styleInfo.name}
+              </Text>
+            </Stack>
           )}
-          {(!styleInfo.name && styleInfo.failedToResolve) && (
+        >
+          <Box css={{
+            flexGrow: 1, display: 'flex', alignItems: 'center', gap: '$3', overflow: 'hidden',
+          }}
+          >
+            <Text css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} size="small">{token}</Text>
+            <Box css={{ flexShrink: 0 }}>
+              <ArrowRightIcon />
+            </Box>
+            {(!styleInfo.name && !styleInfo.failedToResolve) && (
+            <ResolvingLoader />
+            )}
+            {(!styleInfo.name && styleInfo.failedToResolve) && (
             <Stack direction="row" gap={1} css={{ color: '$dangerFg' }}>
               <LinkBreak1Icon />
               Reference not found
             </Stack>
-          )}
-          {styleInfo.name && (
+            )}
+            {styleInfo.name && (
             <Text bold size="small" title={styleInfo.name} css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{styleInfo.name}</Text>
-          )}
-        </Box>
+            )}
+          </Box>
+        </Tooltip>
         <IconButton size="small" variant="invisible" tooltip="Detach style" icon={<LinkBreak2Icon />} data-testid="themestylemanagementcategorystyleentry-unlink" onClick={handleDisconnectStyle} />
       </Flex>
     </Flex>

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeVariableManagementEntry.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeVariableManagementEntry.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { ArrowRightIcon, LinkBreak1Icon, LinkBreak2Icon } from '@radix-ui/react-icons';
-import { Box, IconButton } from '@tokens-studio/ui';
+import { Box, IconButton, Tooltip } from '@tokens-studio/ui';
 import { Flex } from '../Flex';
 import Text from '../Text';
 import ResolvingLoader from '../ResolvingLoader';
@@ -57,27 +57,44 @@ export const ThemeVariableManagementEntry: React.FC<React.PropsWithChildren<Reac
           justifyContent: 'flex-start',
           alignItems: 'center',
           width: '100%',
+          minWidth: 0,
         }}
       >
-        <Box css={{
-          flexGrow: 1, display: 'flex', alignItems: 'center', gap: '$3', overflow: 'hidden',
-        }}
-        >
-          <Text size="small">{token}</Text>
-          <ArrowRightIcon />
-          {(!variableInfo.name && !variableInfo.isResolved) && (
-            <ResolvingLoader />
+        <Tooltip
+          side="bottom"
+          label={(
+            <Stack direction="column" align="start" gap={1} css={{ wordBreak: 'break-word' }}>
+              <Text css={{ color: '$tooltipFg' }}>
+                {token}
+              </Text>
+              <Text css={{ color: '$tooltipFgMuted' }}>
+                {variableInfo.name}
+              </Text>
+            </Stack>
           )}
-          {(!variableInfo.name && variableInfo.isResolved) && (
+        >
+          <Box css={{
+            flexGrow: 0, display: 'flex', alignItems: 'center', gap: '$3', overflow: 'hidden',
+          }}
+          >
+            <Text css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} size="small">{token}</Text>
+            <Box css={{ flexShrink: 0 }}>
+              <ArrowRightIcon />
+            </Box>
+            {(!variableInfo.name && !variableInfo.isResolved) && (
+            <ResolvingLoader />
+            )}
+            {(!variableInfo.name && variableInfo.isResolved) && (
             <Stack direction="row" gap={1} css={{ color: '$dangerFg' }}>
               <LinkBreak1Icon />
               Reference not found
             </Stack>
-          )}
-          {variableInfo.name && (
+            )}
+            {variableInfo.name && (
             <Text bold size="small" title={variableInfo.name} css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{variableInfo.name}</Text>
-          )}
-        </Box>
+            )}
+          </Box>
+        </Tooltip>
         <IconButton tooltip="Detach variable" icon={<LinkBreak2Icon />} variant="invisible" data-testid="ThemeVariableManagementEntry-unlink" onClick={handleDisconnectVariable} />
       </Flex>
     </Flex>


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2153](https://github.com/tokens-studio/figma-plugin/issues/2153#issue-1844490330)

### What does this pull request do?

Managing "Styles & Variables" within the theme editing modal would not display the full necessary info to attach or detach these. We now ensure the items don't overflow its parent container and add a tooltip on hover to provide all the details

### Testing this change

* Create a style or variables with long names and / or value
* Click on the 'Theme' dropdown ---> 'Manage Themes'
* Edit any theme ---> 'Styles & Variables' tab
* Note how the name, value and detach | attach option are well contained + tooltip appears on hover

#### Before / after

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/6b664d93-6ba3-4a35-b333-356ef6e38b41" width=300 />

<img src="https://github.com/tokens-studio/figma-plugin/assets/114073780/77c90c0a-679c-4cfb-8946-6394397db0dd" width=300 />
