### PR TITLE
Fix token value autosize

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
@@ -192,8 +192,10 @@ export const DownshiftInput: React.FunctionComponent<React.PropsWithChildren<Rea
             {error ? <ErrorValidation>{error}</ErrorValidation> : null}
           </Stack>
           <Box css={{ display: 'flex', position: 'relative', width: '100%' }} className="input">
-            {!!inlineLabel && !prefix && <Tooltip label={name}><StyledPrefix isText>{label}</StyledPrefix></Tooltip>}
-            {!!prefix && <StyledPrefix>{prefix}</StyledPrefix>}
+            {!!inlineLabel && !prefix && (
+              <Tooltip label={name}><StyledPrefix isText css={{ height: 'auto' }}>{label}</StyledPrefix></Tooltip>
+            )}
+            {!!prefix && <StyledPrefix css={{ height: 'auto' }}>{prefix}</StyledPrefix>}
             <MentionsInput
               name={name}
               type={type}
@@ -214,7 +216,9 @@ export const DownshiftInput: React.FunctionComponent<React.PropsWithChildren<Rea
                   data-testid="downshift-input-suffix-button"
                   icon={<StyledIconDisclosure />}
                   size="small"
-                  css={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0, boxShadow: 'none' }}
+                  css={{
+                    borderTopLeftRadius: 0, borderBottomLeftRadius: 0, boxShadow: 'none', height: 'auto',
+                  }}
                 />
               </Popover.Trigger>
               {/* Using Anchor to control the width of the popover to match the parent input */}

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
@@ -9,7 +9,7 @@
 .rc-mentions > textarea,
 .rc-mentions-measure {
   width: 100%;
-  height: var(--sizes-controlSmall) !important;
+  min-height: var(--sizes-controlSmall) !important;
   font-style: inherit;
   font-variant: inherit;
   font-stretch: inherit;


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes #2721 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

> If users try to enter something like a long linear-gradient value and the value goes quite wide, the text input currently is not big enough to make sense of anything. Let's find a way where the input grows in height when users enter more.

MentionsInput height CSS is changed to auto; `MentionsInput` already has the `autosize` prop passed to it.

> We need to watch out for the prepending and appending button to the left so that those are still displayed correctly (likely vertical alignment top)

Handled by adding `height: auto` CSS to `<StyledPrefix ... />`. The prefix is automatically vertically aligned to the center.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

1. Open `Tokens` Tab
2. Scroll down to `Typography`
3. Create a Token with a very long name
4. Click `+` (Add New Token)
5. Under the Typography fields, try entering very long values – verify that the input `textarea` expands to multiline
6. Change to `Reference Mode`
7. Click the dropdown button, or mention the very long Typography token by typing `{` to bring up the mention dropdown
8. Verify that the input `textarea` expands to multiline

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

| Before | After |
|--------|-------|
| ![Before – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/4d38b9a5-26c1-4a71-9ded-d7223fdf6524) | ![After – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/b352037e-d8cc-4185-a1e4-2249b2a68fd3) |
| ![Before – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/d9a32d6d-fa5c-441b-bdbd-e22c1e2aafba) | ![After – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/926d7ccb-2b25-4069-adce-1ef61bacfe16) |
| ![Before – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/32ad461c-ef1f-48e2-be10-6da95d9f3aac) | ![After – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/a966911d-41a8-4ffa-ab2d-8691316a977f) |
| ![Before – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/6c2a13e1-dcbd-489e-aa86-0ae5f5950ebb) | ![After – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/a92ca317-437a-42dc-9900-ba266799d675) |
| ![Before – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/5c4f9cd8-be89-41db-b855-34fc53f986e6) | ![After – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/cc7834af-9816-4c7c-86f0-d5fdce4f0a0e) |
| ![Before – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/cde05986-f66b-48da-9b3c-038bec94f00d) | ![After – Tokens / Typography / New Token](https://github.com/tokens-studio/figma-plugin/assets/6757532/ba148018-9db1-4f2c-9034-26ec361a125b) |





<!--
  Add any other context or screenshots about the pull request
-->
