### PR TITLE
2.0: style polish on dropdowns

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
@@ -41,7 +41,7 @@ export const StyledList = styled(List as ComponentType<any>, {
 });
 
 export const StyledItemValue = styled('div', {
-  fontSize: '$xsmall',
+  fontSize: '$xxsmall',
   color: '$fgDefault',
   fontWeight: '$normal',
   variants: {
@@ -60,9 +60,8 @@ export const StyledItem = styled('div', {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  padding: '$3',
+  padding: '$2',
   fontSize: '$xxsmall',
-  borderBottom: '1px solid $bgSubtle',
   variants: {
     isFocused: {
       true: {
@@ -89,13 +88,13 @@ export const StyledItemName = styled('div', {
   fontSize: '$xsmall',
   color: '$fgDefault',
   fontWeight: '$sansBold',
+  flexGrow: 1,
   lineHeight: '1.4',
   wordBreak: 'break-word',
   marginRight: '$2',
   variants: {
     truncate: {
       true: {
-        maxWidth: '50%',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         textWrap: 'nowrap',
@@ -107,7 +106,6 @@ export const StyledItemName = styled('div', {
 export const StyledItemInfo = styled('div', {
   display: 'flex',
   alignItems: 'center',
-  marginBottom: '$2',
 });
 
 export const StyledPart = styled('span', {

--- a/packages/tokens-studio-for-figma/src/app/components/TokenListing.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenListing.tsx
@@ -95,6 +95,7 @@ const TokenListing: React.FC<React.PropsWithChildren<React.PropsWithChildren<Pro
             css={{
               padding: '$4',
               display: collapsedTokenTypeObj[tokenKey as TokenTypes] ? 'none' : 'block',
+              paddingTop: '$1',
             }}
           >
             <TokenGroup


### PR DESCRIPTION
Fixes some polish issues on the dropdowns / mentions that we introduced. Basically we were using too much space + the suggestions were centered

| Before | After |
|--------|-------|
| ![CleanShot 2024-05-17 at 08 48 47@2x](https://github.com/tokens-studio/figma-plugin/assets/4548309/1372d599-c0d5-480d-bfda-ed05ca17ef72) | ![CleanShot 2024-05-17 at 08 48 11@2x](https://github.com/tokens-studio/figma-plugin/assets/4548309/911a1350-ff9a-4555-93ed-edbd6ae211fa) |
| ![CleanShot 2024-05-17 at 08 48 52@2x](https://github.com/tokens-studio/figma-plugin/assets/4548309/fb1038b9-3543-44b5-a302-d27050b83dea) | ![CleanShot 2024-05-17 at 08 48 18@2x](https://github.com/tokens-studio/figma-plugin/assets/4548309/6898cbf2-88d9-41f1-97ca-0c73b3090105) |

