### PR TITLE
Composition UI cleanup for long token names (choose property button)

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/SingleCompositionTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SingleCompositionTokenForm.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUIDSeed } from 'react-uid';
-import { Select, Box, IconButton } from '@tokens-studio/ui';
+import {
+  Select, Box, IconButton, Stack,
+} from '@tokens-studio/ui';
 import IconMinus from '@/icons/minus.svg';
 import { Properties } from '@/constants/Properties';
 import { CompositionTokenProperty } from '@/types/CompositionTokenProperty';
@@ -85,31 +87,41 @@ export default function SingleCompositionTokenForm({
       },
     }}
     >
-      <Select value={property || t('chooseAProperty')} onValueChange={onPropertySelected}>
-        <Select.Trigger
-          value={property || t('chooseAProperty')}
-          data-testid="composition-token-dropdown"
-        />
-        <Select.Content>
-          {properties.length > 0
-                && properties.map((prop, idx) => <Select.Item data-testid={`item-dropdown-menu-element-${prop}`} key={`property-${seed(idx)}`} value={prop}>{prop}</Select.Item>)}
-        </Select.Content>
-      </Select>
-      <Box css={{ flexGrow: 1 }}>
-        <DownshiftInput
-          value={propertyValue}
-          type={propertyType}
-          resolvedTokens={resolvedTokens}
-          handleChange={onPropertyValueChanged}
-          setInputValue={handleDownShiftInputChange}
-          placeholder={
-            propertyType === 'color' ? t('colorOrAlias') : t('valueOrAlias')
-          }
-          suffix
-          onSubmit={onSubmit}
-        />
-      </Box>
-      <Box css={{ width: '$5', marginRight: '$3' }}>
+      <Stack direction="row" css={{ flex: 1, alignItems: 'center' }}>
+        <Select value={property || t('chooseAProperty')} onValueChange={onPropertySelected}>
+          <Select.Trigger
+            value={property || t('chooseAProperty')}
+            css={{
+              borderTopRightRadius: '$0',
+              borderBottomRightRadius: '$0',
+              height: 'auto',
+              alignSelf: 'stretch',
+              marginTop: '3px', // Hack to compensate for textarea autosize height
+              marginBottom: '1px', // Hack to compensate for textarea autosize height
+            }}
+            data-testid="composition-token-dropdown"
+          />
+          <Select.Content>
+            {properties.length > 0
+                  && properties.map((prop, idx) => <Select.Item data-testid={`item-dropdown-menu-element-${prop}`} key={`property-${seed(idx)}`} value={prop}>{prop}</Select.Item>)}
+          </Select.Content>
+        </Select>
+        <Box css={{ flexGrow: 1 }}>
+          <DownshiftInput
+            value={propertyValue}
+            type={propertyType}
+            resolvedTokens={resolvedTokens}
+            handleChange={onPropertyValueChanged}
+            setInputValue={handleDownShiftInputChange}
+            placeholder={
+              propertyType === 'color' ? t('colorOrAlias') : t('valueOrAlias')
+            }
+            suffix
+            onSubmit={onSubmit}
+          />
+        </Box>
+      </Stack>
+      <Box css={{ width: '$5', marginRight: '$4' }}>
         <IconButton
           tooltip={t('removeThisStyle')}
           data-testid="button-style-remove-multiple"


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Cleans up the composition form UI for long token names #2721 

Follow up PR to clean up the choose a property button having bad alignment/spacing with long token names.

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

- [x] Fix/clean-up the `composition-token-dropdown` Choose a Property button dropdown by joining it to the text input as a leading button (full height and no border radius on the right)
- [x] Fix alignment of `Add another style` (`+`) and `Remove this style` (`–`) icon buttons

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

Create a composition token with some long token names, e.g.

```json
{
/* ... */
"test1": {
    "$type": "composition",
    "$value": {
      "sizing": "12",
      "borderColor": "{hello-world-theme.a-very-long-color-name.try-to-break.square-cta}",
      "horizontalPadding": "8",
      "maxWidth": "4"
    }
  }
/* .... */
}
```

### Additional Notes (if any)

| Before   | After |
|----------|------:|
| ![before](https://github.com/tokens-studio/figma-plugin/assets/6757532/a6f99d7d-df15-426c-83ea-37d187021f59) | ![after](https://github.com/tokens-studio/figma-plugin/assets/6757532/81bf4ba8-735a-4bcd-9b67-9a6fbe8aed2b) |



<!--
  Add any other context or screenshots about the pull request
-->
