### PR TITLE
apply fallback variable if no connected variable

### DIFF
--- a/.changeset/lemon-drinks-sort.md
+++ b/.changeset/lemon-drinks-sort.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+When you apply a token to a layer, and that token isnt connected to a variable, we will now try to apply the token's reference as a variable. This enables you to apply component tokens and have their semantic variable applied as long as it's a pure reference and that component token has no variable connected.

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -49,12 +49,14 @@ export class TokenValueRetriever {
 
   public async getVariableReference(tokenName: string) {
     let variable;
+    const storedToken = this.tokens.get(tokenName);
+    const isUsingReference = storedToken?.rawValue?.startsWith('{') && storedToken?.rawValue?.endsWith('}');
     const hasCachedVariable = this.cachedVariableReferences.has(tokenName);
     if (hasCachedVariable) {
       variable = this.cachedVariableReferences.get(tokenName);
       return variable;
     }
-    const variableMapped = this.variableReferences.get(tokenName);
+    const variableMapped = this.variableReferences.get(tokenName) || (isUsingReference ? this.variableReferences.get(storedToken.rawValue.slice(1, -1)) : null);
     if (!variableMapped) return false;
     if (!hasCachedVariable && typeof variableMapped === 'string') {
       try {


### PR DESCRIPTION
Closes #2794

### Why does this PR exist?

When a token is not connected to a variable, but the value of the token is a pure reference to a token that is connected to a variable, apply that variable, instead of what we do today, which is apply the raw hex value.

This enables users to have their semantic variables applied when their component tokens are applied - as long as they dont create component token variables.

### What does this pull request do?

Adds a check to where we fetch the variableReference if there's a fallback variable we could use

### Testing this change

- Create a token called `red` in a set called `Core`, create a theme group for it and enable just that set here
- Create another token called `danger` and use `{red}` as the value, in another set called `Semantic` (no theme group required)
- Create variables
- Apply the token for `danger` and see that `red` variable is applied