### PR TITLE
fix: show grabber on item hover

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeListGroupHeader.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeListGroupHeader.tsx
@@ -57,6 +57,7 @@ export function ThemeListGroupHeader({
   return (
     <StyledDragButton
       type="button"
+      canReorder={!editProhibited}
       css={{
         backgroundColor: '$bgDefault',
         display: 'grid',

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeListItemContent.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeListItemContent.tsx
@@ -37,6 +37,7 @@ export function ThemeListItemContent({
   return (
     <StyledDragButton
       type="button"
+      canReorder={!editProhibited}
       css={{
         padding: 0, width: '100%', display: 'inherit', cursor: 'inherit',
       }}

--- a/packages/tokens-studio-for-figma/src/app/components/StyledDragger/StyledDragButton.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StyledDragger/StyledDragButton.tsx
@@ -31,6 +31,15 @@ export const StyledDragButton = styled('button', {
         },
       },
     },
+    canReorder: {
+      true: {
+        '&:hover, &:focus': {
+          [`${StyledGrabber}`]: {
+            opacity: 1,
+          },
+        },
+      },
+    },
     itemType: {
       folder: {
         cursor: 'default',

--- a/packages/tokens-studio-for-figma/src/app/components/TokenSetItem/TokenSetItem.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenSetItem/TokenSetItem.tsx
@@ -121,6 +121,7 @@ export function TokenSetItem({
                 paddingLeft: `${5 * item.level}px`,
               }}
               isActive={isActive}
+              canReorder={canReorder}
               onClick={handleClick}
             >
               <DragGrabber item={item} canReorder={canReorder} onDragStart={handleGrabberPointerDown} />
@@ -137,6 +138,7 @@ export function TokenSetItem({
               }}
               data-testid={`tokensetitem-${item.path}`}
               isActive={isActive}
+              canReorder={canReorder}
               onClick={handleClick}
             >
               <DragGrabber item={item} canReorder={canReorder} onDragStart={handleGrabberPointerDown} />


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2783](https://github.com/tokens-studio/figma-plugin/issues/2783) 

Draggable items only showed the dragger when the _icon_ was hovered on, instead of hovering **anywhere** on the item. This adds a styling variant to force the dragger to show when contained within a reorderable item.

### What does this pull request do?

* Adds a `canReorder` variant to `StyledDragButton` which shows the any grabber contained, on hover
* Passes the `canReorder` prop to all draggable items that need it

### Testing this change

* Open the plugin
* To see draggable items:
   * Have multiple layered sets in the **Tokens** tab
   * Have multiple **Themes** in the themes management modal

#### Draggers for **Pro** users 

https://github.com/tokens-studio/figma-plugin/assets/114073780/6af2b79f-ddbf-4b24-8022-21bbc653f40d

#### No draggers for non  **Pro** users 

https://github.com/tokens-studio/figma-plugin/assets/114073780/fdbfc8ed-a4e9-4187-acd4-1ab363c35876





