### PR TITLE
Fix/no space after mentions

### DIFF
--- a/.changeset/many-shrimps-tan.md
+++ b/.changeset/many-shrimps-tan.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Selecting something when typing { will now no longer insert a space after

--- a/packages/tokens-studio-for-figma/src/app/components/AnnotationBuilder.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/AnnotationBuilder.tsx
@@ -5,7 +5,7 @@ import { IconButton } from '@tokens-studio/ui';
 import { uiStateSelector } from '@/selectors';
 import createAnnotation from './createAnnotation';
 import Stack from './Stack';
-import Text from './Text';x
+import Text from './Text';
 import Box from './Box';
 import { isEqual } from '@/utils/isEqual';
 import { Direction } from '@/constants/Direction';

--- a/packages/tokens-studio-for-figma/src/app/components/AnnotationBuilder.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/AnnotationBuilder.tsx
@@ -5,7 +5,7 @@ import { IconButton } from '@tokens-studio/ui';
 import { uiStateSelector } from '@/selectors';
 import createAnnotation from './createAnnotation';
 import Stack from './Stack';
-import Text from './Text';
+import Text from './Text';x
 import Box from './Box';
 import { isEqual } from '@/utils/isEqual';
 import { Direction } from '@/constants/Direction';

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -138,6 +138,7 @@ export default function MentionsInput({
       value={value}
       placeholder={placeholder}
       prefix={['{']}
+      split=""
       placement="bottom"
       autoFocus={autoFocus}
       onChange={handleMentionInputChange}


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

When you use auto-suggestions from rc mentions, it would always add a space.
Turns out it's super simple to change the character we split suggestions with.

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Adds `split=""` to the mentions component 

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

Create a token which references another token.
Use mentions by typing `{` and selecting a suggestion

Notice there is no space after selection the mention now.

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
