### PR TITLE
fix: 2776 404 style dont apply

### DIFF
--- a/packages/tokens-studio-for-figma/src/utils/__tests__/trySetStyleId.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/__tests__/trySetStyleId.test.ts
@@ -95,7 +95,7 @@ describe('trySetStyleId', () => {
     const node = { effectStyleId: '' } as unknown as RectangleNode;
     expect(await trySetStyleId(node, 'effect', 'S:1234')).toBe(true);
     expect(mockImportStyleByKeyAsync).toBeCalledTimes(0);
-    expect(node.effectStyleId).toEqual('S:1234');
+    expect(node.effectStyleId).toEqual('S:1234,');
   });
 
   it('should not do anything for invalid parameters', async () => {


### PR DESCRIPTION
### Why does this PR exist?

Closes #2776

Previously when a user had deleted styles that were still attached to tokens, we'd try to apply the style, even though it no longer existed.

### What does this pull request do?

Changed the logic to *not* resolve to the stored style id if it's a 404. Instead, return early.

### Testing this change

Create a theme and connect tokens to created styles. On prod, you'd see a bunch of 404s in addition to errors trying to apply the style. With this build, the 404s still exist, but the apply errors are no longer there.

Before (here we're attempting to apply a style resulting in the error)

https://github.com/tokens-studio/figma-plugin/assets/4548309/0982325b-5e99-4148-8f55-73513701c9c9

After (here we're exiting early and wont even try to apply the missing style)

https://github.com/tokens-studio/figma-plugin/assets/4548309/20f2cde5-8498-4914-8653-9d28d0f5bf1c

