### PR TITLE
fix: add save button to export sets modal

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
@@ -35,32 +35,40 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
 
   const store = useStore<RootState>();
 
-  const [showChangeSets, setShowChangeSets] = React.useState(false);
-
-  const allSets = useSelector(allTokenSetsSelector);
-
   const selectedTokenSets = React.useMemo(() => (
     usedTokenSetSelector(store.getState())
   ), [store]);
+
+  const {
+    control, getValues, reset,
+  } = useForm<FormValues>({
+    defaultValues: {
+      tokenSets: { ...selectedTokenSets },
+    },
+  });
+
+  const [showChangeSets, setShowChangeSets] = React.useState(false);
+  const [previousSetSelection, setPreviousSetSelection] = React.useState({});
+
+  const allSets = useSelector(allTokenSetsSelector);
 
   const availableTokenSets = useSelector(allTokenSetsSelector);
 
   const setsTree = React.useMemo(() => tokenSetListToTree(availableTokenSets), [availableTokenSets]);
 
   const handleCancelChangeSets = React.useCallback(() => {
-    // DO NOT SAVE THE SET CHANGES
+    reset(previousSetSelection);
+    setShowChangeSets(false);
+  }, [previousSetSelection, reset]);
+
+  const handleSaveChangeSets = React.useCallback(() => {
     setShowChangeSets(false);
   }, []);
 
   const handleShowChangeSets = React.useCallback(() => {
     setShowChangeSets(true);
-  }, []);
-
-  const { control, getValues } = useForm<FormValues>({
-    defaultValues: {
-      tokenSets: { ...selectedTokenSets },
-    },
-  });
+    setPreviousSetSelection(getValues());
+  }, [getValues]);
 
   const TokenSetThemeItemInput = React.useCallback((props: React.PropsWithChildren<{ item: TreeItem }>) => (
     <Controller
@@ -134,7 +142,25 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
           <Button variant="secondary" size="small" onClick={handleShowChangeSets}>{t('actions.changeSets')}</Button>
         </Stack>
       </StyledCard>
-      <Modal size="fullscreen" full compact isOpen={showChangeSets} close={handleCancelChangeSets} backArrow title="Styles and Variables / Export Sets">
+      <Modal
+        size="fullscreen"
+        full
+        compact
+        isOpen={showChangeSets}
+        close={handleCancelChangeSets}
+        backArrow
+        title="Styles and Variables / Export Sets"
+        footer={(
+          <Stack direction="row" gap={4} justify="between">
+            <Button variant="secondary" onClick={handleCancelChangeSets}>
+              {t('actions.cancel')}
+            </Button>
+            <Button variant="primary" onClick={handleSaveChangeSets}>
+              {t('actions.confirm')}
+            </Button>
+          </Stack>
+          )}
+      >
         <Heading>{t('exportSetsTab.changeSetsHeading')}</Heading>
         <Link target="_blank" href={docsLinks.sets}>{`${t('generic.learnMore')} – ${t('docs.referenceOnlyMode')}`}</Link>
         <Stack


### PR DESCRIPTION
### Why does this PR exist?

Previously, selecting sets to export would always persist the changes. This gives the user to option to save or cancel.

Closes [#2575](https://github.com/tokens-studio/figma-plugin/issues/2575#issue-2230356010) (N.B. screen doesn't contain a search any more)

### What does this pull request do?

* Renders a footer on set selection with **cancel** (destroys the set selection) or **confirm** (persists the set selection)
* Adds a `previousSelectedSets` state to remember the T-1 state and use when the user presses **cancel** (in the footer) or the **back arrow** (in the header)

### Testing this change
* Click on 'Styles & Variables' ---> 'Export styles & variables'
* On the modal, click 'Confirm'
* Click on the 'Token Sets' tab
* Click on 'Change Sets' CTA
* Change set selections as you wish:
   * Clicking on **confirm** will save the changes
   * Clicking on **cancel** will discard the changes

#### Before / After

<img width="250" alt="Screenshot 2024-06-04 at 15 08 33" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/3c7d9afe-3ad5-4a05-a855-0b726050b951">

<img width="250" alt="Screenshot 2024-06-04 at 14 54 12" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/115b91ff-5138-4dfb-a4a3-b7f97c18b5d1">

##### Changes in action 
https://github.com/tokens-studio/figma-plugin/assets/114073780/3c0f5d9b-98f9-4c84-8a7e-d35c0276fba1

