### PR TITLE
fix: prevent errors from appearing while editing JSON

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/Tokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Tokens.tsx
@@ -17,8 +17,6 @@ import JSONEditor from './JSONEditor';
 import Box from './Box';
 import IconListing from '@/icons/listing.svg';
 import useTokens from '../store/useTokens';
-import parseTokenValues from '@/utils/parseTokenValues';
-import parseJson from '@/utils/parseJson';
 import AttentionIcon from '@/icons/attention.svg';
 import { TokensContext } from '@/context';
 import {
@@ -127,12 +125,6 @@ function Tokens({ isActive }: { isActive: boolean }) {
 
   const handleChangeJSON = React.useCallback((val: string) => {
     setError(null);
-    try {
-      const parsedTokens = parseJson(val);
-      parseTokenValues(parsedTokens);
-    } catch (e) {
-      setError(`Unable to read JSON: ${JSON.stringify(e)}`);
-    }
     dispatch.tokenState.setStringTokens(val);
   }, [dispatch.tokenState]);
 
@@ -311,9 +303,7 @@ function Tokens({ isActive }: { isActive: boolean }) {
           </Box>
           {manageThemesModalOpen && <ManageThemesModal />}
         </Box>
-        <TokensBottomBar
-          hasJSONError={!!error}
-        />
+        <TokensBottomBar handleError={setError} />
       </Box>
     </TokensContext.Provider>
   );


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2777](https://github.com/tokens-studio/figma-plugin/issues/2777#issue-2305858396) 

Removes the constant error appearing when editing JSON.

### What does this pull request do?
* Simply sets the JSON editor's value when it changes, without validation (`Tokens.tsx`)
* Moves the validation into `TokensBottomBar.tsx`, which is triggered when user clicks the **Save JSON** CTA

### Testing this change
* Open the plugin
* Go into the JSON tab
* Type in a new token, manually and click on **Save JSON**
   * If valid: it will persist
   * If not valid: it will show an error toast 

| Before | After |
|-----|-----|
| <video height="300" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/b4d31946-eaa3-4d7e-bf33-3b49641eeefc"></video> | <video height="300" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/cf766e4f-e47c-43de-b50a-50e752e68ada"></video> |




