### PR TITLE
fix: border token and box shadow input form color swatch to update on references

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/BorderTokenDownShiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BorderTokenDownShiftInput.tsx
@@ -5,14 +5,7 @@ import DownshiftInput from './DownshiftInput';
 import { getLabelForProperty } from '@/utils/getLabelForProperty';
 import { styled } from '@/stitches.config';
 import { getAliasValue } from '@/utils/alias';
-
-const StyledButton = styled('button', {
-  display: 'block',
-  width: '1.5rem',
-  height: '1.5rem',
-  borderRadius: '$small',
-  cursor: 'pointer',
-});
+import { ColorPickerTrigger } from './ColorPickerTrigger';
 
 export default function BorderTokenDownShiftInput({
   name,
@@ -70,13 +63,7 @@ export default function BorderTokenDownShiftInput({
       placeholder={mapTypeToPlaceHolder[name as keyof typeof mapTypeToPlaceHolder] as unknown as string}
       prefix={
         name === 'color' && (
-          <StyledButton
-            type="button"
-            style={{ background: resolvedColor ?? '#000000', fontSize: 0 }}
-            onClick={handleToggleInputHelper}
-          >
-            {value}
-          </StyledButton>
+          <ColorPickerTrigger onClick={handleToggleInputHelper} background={resolvedColor} />
         )
       }
       suffix

--- a/packages/tokens-studio-for-figma/src/app/components/BorderTokenDownShiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BorderTokenDownShiftInput.tsx
@@ -4,6 +4,7 @@ import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 import DownshiftInput from './DownshiftInput';
 import { getLabelForProperty } from '@/utils/getLabelForProperty';
 import { styled } from '@/stitches.config';
+import { getAliasValue } from '@/utils/alias';
 
 const StyledButton = styled('button', {
   display: 'block',
@@ -23,16 +24,30 @@ export default function BorderTokenDownShiftInput({
   handleToggleInputHelper,
   onSubmit,
 }: {
-  name: string,
+  name: string;
   value: string;
   type: string;
   resolvedTokens: ResolveTokenValuesResult[];
   handleChange: (property: string, value: string) => void;
   setInputValue: (newInputValue: string, property: string) => void;
   handleToggleInputHelper?: () => void;
-  onSubmit: () => void
+  onSubmit: () => void;
 }) {
-  const handleBorderDownShiftInputChange = React.useCallback((newInputValue: string) => setInputValue(newInputValue, name), [name, setInputValue]);
+  const [resolvedColor, setResolvedColor] = React.useState<string>(value ? String(value) : '');
+
+  React.useEffect(() => {
+    if (name === 'color' && value && value.startsWith('{')) {
+      const aliasValue = getAliasValue(value, resolvedTokens);
+      setResolvedColor(aliasValue ? String(aliasValue) : '');
+    } else {
+      setResolvedColor(typeof value === 'string' ? value : '');
+    }
+  }, [value, resolvedTokens, name]);
+
+  const handleBorderDownShiftInputChange = React.useCallback(
+    (newInputValue: string) => setInputValue(newInputValue, name),
+    [name, setInputValue],
+  );
   const getIconComponent = React.useMemo(() => getLabelForProperty(name), [name]);
 
   const { t } = useTranslation(['tokens']);
@@ -57,7 +72,7 @@ export default function BorderTokenDownShiftInput({
         name === 'color' && (
           <StyledButton
             type="button"
-            style={{ background: value ?? '#000000', fontSize: 0 }}
+            style={{ background: resolvedColor ?? '#000000', fontSize: 0 }}
             onClick={handleToggleInputHelper}
           >
             {value}

--- a/packages/tokens-studio-for-figma/src/app/components/SingleBoxShadowDownShiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SingleBoxShadowDownShiftInput.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 import DownshiftInput from './DownshiftInput';
 import { ColorPickerTrigger } from './ColorPickerTrigger';
+import { getAliasValue } from '@/utils/alias';
 
 export default function SingleBoxShadowDownShiftInput({
   name,
@@ -14,17 +15,31 @@ export default function SingleBoxShadowDownShiftInput({
   handleToggleInputHelper,
   onSubmit,
 }: {
-  name: string,
+  name: string;
   value: string;
   type: string;
   resolvedTokens: ResolveTokenValuesResult[];
   handleChange: (property: string, value: string) => void;
   setInputValue: (newInputValue: string, property: string) => void;
   handleToggleInputHelper?: () => void;
-  onSubmit: () => void
+  onSubmit: () => void;
 }) {
   const { t } = useTranslation(['tokens']);
-  const handleBoxshadowDownShiftInputChange = React.useCallback((newInputValue: string) => setInputValue(newInputValue, name), [name, setInputValue]);
+  const [resolvedColor, setResolvedColor] = React.useState<string>(value ? String(value) : '');
+
+  React.useEffect(() => {
+    if (name === 'color' && value && value.startsWith('{')) {
+      const aliasValue = getAliasValue(value, resolvedTokens);
+      setResolvedColor(aliasValue ? String(aliasValue) : '');
+    } else {
+      setResolvedColor(typeof value === 'string' ? value : '');
+    }
+  }, [value, resolvedTokens, name]);
+
+  const handleBoxshadowDownShiftInputChange = React.useCallback(
+    (newInputValue: string) => setInputValue(newInputValue, name),
+    [name, setInputValue],
+  );
   return (
     <DownshiftInput
       name={name}
@@ -37,11 +52,9 @@ export default function SingleBoxShadowDownShiftInput({
       setInputValue={handleBoxshadowDownShiftInputChange}
       placeholder={name === 'color' ? t('colorOrAlias') : t('valueOrAlias')}
       prefix={
-        name === 'color' && value && (
-          <ColorPickerTrigger
-            background={value}
-            onClick={handleToggleInputHelper}
-          >
+        name === 'color' &&
+        resolvedColor && (
+          <ColorPickerTrigger background={resolvedColor} onClick={handleToggleInputHelper}>
             {value}
           </ColorPickerTrigger>
         )


### PR DESCRIPTION
Addresses #1928 

- when a user selects a color(via a reference token) in the border token form, the swatch shall now update dynamically.
- fixes #1928 