### PR TITLE
fix: sync provider "Read more" links now open in browser

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/ADOForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/ADOForm.tsx
@@ -60,7 +60,7 @@ export default function ADOForm({
         <Text muted>
           {t('providers.ado.description')}
           {' '}
-          <Link href="https://docs.tokens.studio/sync/ado?ref=addprovider">{t('readMore')}</Link>
+          <Link href="https://docs.tokens.studio/sync/ado?ref=addprovider" target="_blank" rel="noreferrer">{t('readMore')}</Link>
         </Text>
         <FormField>
           <Label htmlFor="baseUrl">{t('providers.ado.orgUrl')}</Label>

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/GenericVersioned.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/GenericVersioned.tsx
@@ -125,7 +125,7 @@ export default function GenericVersionedForm({
         <Text muted>
           {t('providers.generic.description')}
           {' '}
-          <Link href="https://docs.tokens.studio/sync/generic-storage?ref=addprovider" target="_blank">{t('readMore')}</Link>
+          <Link href="https://docs.tokens.studio/sync/generic-storage?ref=addprovider" target="_blank" rel="noreferrer">{t('readMore')}</Link>
         </Text>
         <FormField>
           <Label htmlFor="name">{t('providers.generic.name')}</Label>

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/GitForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/GitForm.tsx
@@ -65,7 +65,7 @@ export default function GitForm({
         <Text muted>
           {t('gitExplained')}
           {' '}
-          <Link href={`https://docs.tokens.studio/sync/${values.provider}?ref=addprovider`} target="_blank">{t('readMore')}</Link>
+          <Link href={`https://docs.tokens.studio/sync/${values.provider}?ref=addprovider`} target="_blank" rel="noreferrer">{t('readMore')}</Link>
         </Text>
         <FormField>
           <Label htmlFor="name">{t('name')}</Label>

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/JSONBinForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/JSONBinForm.tsx
@@ -59,7 +59,7 @@ export default function JSONBinForm({
         <Text muted>
           {t('providers.jsonbin.description')}
           {' '}
-          <Link href="https://docs.tokens.studio/sync/jsonbin?ref=addprovider">{t('readMore')}</Link>
+          <Link href="https://docs.tokens.studio/sync/jsonbin?ref=addprovider" target="_blank" rel="noreferrer">{t('readMore')}</Link>
         </Text>
         <FormField>
           <Label htmlFor="name">{t('name')}</Label>

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/SupernovaForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/SupernovaForm.tsx
@@ -67,7 +67,7 @@ export default function SupernovaForm({
         <Text muted>
           {t('providers.supernova.description')}
           {' '}
-          <Link href="https://learn.supernova.io/" target="_blank">{t('readMore', { ns: 'general' })}</Link>
+          <Link href="https://learn.supernova.io/" target="_blank" rel="noreferrer">{t('readMore', { ns: 'general' })}</Link>
         </Text>
         <FormField>
           <Label htmlFor="name">{t('name')}</Label>

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/URLForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/URLForm.tsx
@@ -59,7 +59,7 @@ export default function URLForm({
         <Text muted>
           {t('providers.url.description')}
           {' '}
-          <Link href="https://docs.tokens.studio/sync/url?ref=addprovider">{t('readMore')}</Link>
+          <Link href="https://docs.tokens.studio/sync/url?ref=addprovider" target="_blank" rel="noreferrer">{t('readMore')}</Link>
         </Text>
         <FormField>
           <Label htmlFor="name">{t('name')}</Label>


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2847](https://github.com/tokens-studio/figma-plugin/issues/2847#issue-2349030882)

"Read more" links to explain more about sync providers were opening in the plugin. They now open in a browser window.

### What does this pull request do?
* Adds `target="_blank" rel="noreferrer"` (extra safe) to all links on all applicable sync provider forms

### Testing this change
* Go to settings
* Click on any new sync provider to add
* Click on "Read more"

https://github.com/tokens-studio/figma-plugin/assets/114073780/500de519-6ab9-40bc-9de7-57006298418d

