### PR TITLE
chore: dropdown menu item indicator updates

### DIFF
--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -58,7 +58,7 @@
     "@tokens-studio/graph-engine": "^0.17.5",
     "@tokens-studio/sdk": "1.1.5",
     "@tokens-studio/tokens": "0.1.4",
-    "@tokens-studio/ui": "0.6.6",
+    "@tokens-studio/ui": "0.6.7",
     "@types/chroma-js": "^2.1.4",
     "@types/color": "^3.0.3",
     "@types/file-saver": "^2.0.5",

--- a/packages/tokens-studio-for-figma/src/app/components/BranchSwitchMenuRadioElement.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BranchSwitchMenuRadioElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CheckIcon } from '@radix-ui/react-icons';
+import { Check } from 'iconoir-react';
 import { DropdownMenu } from '@tokens-studio/ui';
 
 type Props = {
@@ -24,7 +24,7 @@ export const BranchSwitchMenuRadioElement: React.FC<React.PropsWithChildren<Reac
       css={{ position: 'relative' }}
     >
       <DropdownMenu.ItemIndicator>
-        <CheckIcon data-testid="branch-switch-menu-check-icon" />
+        <Check data-testid="branch-switch-menu-check-icon" />
       </DropdownMenu.ItemIndicator>
       {branch}
     </DropdownMenu.RadioItem>

--- a/packages/tokens-studio-for-figma/src/app/components/InspectSearchOptionDropdown.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/InspectSearchOptionDropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { CheckIcon } from '@radix-ui/react-icons';
+import { Check } from 'iconoir-react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DropdownMenu, IconButton } from '@tokens-studio/ui';
 import { inspectStateSelector } from '@/selectors';
@@ -36,7 +36,7 @@ export default function InspectSearchOptionDropdown() {
             onCheckedChange={handleIsShowBrokenReferences}
           >
             <DropdownMenu.ItemIndicator>
-              <CheckIcon />
+              <Check />
             </DropdownMenu.ItemIndicator>
             {t('showBrokenReferences')}
           </DropdownMenu.CheckboxItem>
@@ -46,7 +46,7 @@ export default function InspectSearchOptionDropdown() {
             onCheckedChange={handleIsShowResolvedReferences}
           >
             <DropdownMenu.ItemIndicator>
-              <CheckIcon />
+              <Check />
             </DropdownMenu.ItemIndicator>
             {t('showResolvedReferences')}
           </DropdownMenu.CheckboxItem>

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeGroupDropDownMenu.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeGroupDropDownMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { CheckIcon } from '@radix-ui/react-icons';
+import { Check } from 'iconoir-react';
 import { DropdownMenu } from '@tokens-studio/ui';
 import { useTranslation } from 'react-i18next';
 import Box from '../Box';
@@ -30,7 +30,7 @@ export const ThemeGroupDropDownMenu: React.FC<React.PropsWithChildren<React.Prop
         onSelect={handleSelect}
       >
         <DropdownMenu.ItemIndicator>
-          <CheckIcon />
+          <Check />
         </DropdownMenu.ItemIndicator>
         <Box>
           {groupName}

--- a/packages/tokens-studio-for-figma/src/app/components/MultiSelectCheckboxItem.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/MultiSelectCheckboxItem.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  CheckIcon,
-} from '@radix-ui/react-icons';
+import { Check } from 'iconoir-react';
 import { DropdownMenu } from '@tokens-studio/ui';
 import Box from './Box';
 
@@ -28,7 +26,7 @@ export const MultiSelectCheckboxItem: React.FunctionComponent<React.PropsWithChi
     >
       <Box css={{ width: '$5' }}>
         <DropdownMenu.ItemIndicator css={{ position: 'inherit' }}>
-          <CheckIcon />
+          <Check />
         </DropdownMenu.ItemIndicator>
       </Box>
       <Box>

--- a/packages/tokens-studio-for-figma/src/app/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ThemeSelector/ThemeSelector.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { CheckIcon } from '@radix-ui/react-icons';
+import { Check, NavArrowRight } from 'iconoir-react';
 import { useTranslation } from 'react-i18next';
 import { DropdownMenu, Button } from '@tokens-studio/ui';
-import { NavArrowRight } from 'iconoir-react';
 import { activeThemeSelector, themeOptionsSelector } from '@/selectors';
 import Text from '../Text';
 import { Dispatch } from '@/app/store';
@@ -75,7 +74,7 @@ export const ThemeSelector: React.FC<React.PropsWithChildren<React.PropsWithChil
         onSelect={handleSelect}
       >
         <DropdownMenu.ItemIndicator>
-          <CheckIcon />
+          <Check />
         </DropdownMenu.ItemIndicator>
         {label}
       </DropdownMenu.RadioItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6116,10 +6116,10 @@
   resolved "https://registry.yarnpkg.com/@tokens-studio/types/-/types-0.3.0.tgz#ac0579df362b6b9e47c8893e3ca110d3831f7f26"
   integrity sha512-MgGe1HFH2R/advBxpETgB1VGnCmh3j08igsPmc/1xvm/m2A5fYPmnzqjX6SFlHiajIJ5DEwYbHDzUAO4POn0tw==
 
-"@tokens-studio/ui@0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@tokens-studio/ui/-/ui-0.6.6.tgz#46e16183610c44e8443cd3cff98620905e8849cc"
-  integrity sha512-v48Jj/AQzMhIjh7Iy/J+C/v8xeSfHmR5XzKJjwJFznnxpa9BDlf9LtN23LS8p8vjMOs0K4c9VOrjc3ADr8XgLg==
+"@tokens-studio/ui@0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@tokens-studio/ui/-/ui-0.6.7.tgz#26a8ecf20a9d54c4cdd7b9a39b22ea328f1b9309"
+  integrity sha512-h8W22uSuv2z3taN8lVnBRa15YW7/qsirePZhVIWQjyHNCBhchaHdPHrjA7q976ALCe7soD1b51VneSKlZwucvA==
   dependencies:
     "@iconicicons/react" "^1.5.1"
     "@radix-ui/react-accordion" "^1.1.2"


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2851](https://github.com/tokens-studio/figma-plugin/issues/2851)

### What does this pull request do?
* Bumps the DS UI package version to 0.6.7 - following up from [this release](https://github.com/orgs/tokens-studio/projects/34/views/3)
* Updates all items using the radix `CheckIcon` component to instead make use of the `Check` component from **iconoir**

### Testing this change
Run the plugin, and observe any dropdowns with ✔️ markers look the same.

#### Examples
<img width="222" alt="Screenshot 2024-06-17 at 16 35 45" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/dfa19085-d392-4ffe-841e-d07ac1d4a427">
<img width="275" alt="Screenshot 2024-06-17 at 16 35 57" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/d3bfcf43-ae67-4d37-bf3e-18be9f34c588">
<img width="224" alt="Screenshot 2024-06-17 at 16 36 06" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/38150d78-95c6-44a5-ad65-3dd8e50168a3">



