### PR TITLE
fix: debug mode now shows `sessionId`

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/Settings/Settings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Settings/Settings.tsx
@@ -40,6 +40,10 @@ function Settings() {
   const { idStorage } = useFlags();
 
   const toggleDebugMode = React.useCallback(async (checked: CheckedState) => {
+    if (checked && process.env.ENVIRONMENT === 'development') {
+      console.warn('Session recording is disabled in development mode');
+    }
+
     dispatch.settings.setSessionRecording(!!checked);
     if (checked) {
       // Display the info to the user
@@ -155,9 +159,9 @@ function Settings() {
               width: '100%',
             }}
           >
-            <Stack direction="row" justify="between" gap={2} align="center" css={{ width: '100%' }}>
-              <Stack direction="column">
-                <Stack direction="row" align="center" gap={1}>
+            <Stack direction="column" gap={2} css={{ width: '100%' }}>
+              <Stack direction="row" align="center" justify="between" gap={1}>
+                <Stack direction="row" gap={2} align="center">
                   <Label htmlFor="enableDebugging">{t('enableSessionRecording')}</Label>
                   <ExplainerModal title={t('enableSessionRecording')}>
                     <Box css={{
@@ -171,32 +175,34 @@ function Settings() {
                       {' '}
                       {t('forMoreInformationPleaseSeeOur')}
                       {' '}
-                      <Link href="https://tokens.studio/privacy" target="_blank">{t('privacyPolicy')}</Link>
+                      <Link href="https://tokens.studio/privacy" target="_blank" rel="noreferrer">{t('privacyPolicy')}</Link>
                     </Box>
                   </ExplainerModal>
-                  <Box
-                    css={{
-                      color: '$fgMuted',
-                      fontSize: '$xsmall',
-                      lineHeight: 1.5,
-                    }}
-                  >
-                    {debugSession && (
-                    <Text>
-                      {t('yourCurrentSessionIdIs')}
-                      {' '}
-                      <b>{debugSession}</b>
-                    </Text>
-                    )}
-                  </Box>
                 </Stack>
+                <Box css={{ flexShrink: 0 }}>
+                  <Switch
+                    id="enableDebugging"
+                    checked={!!debugMode}
+                    defaultChecked={debugMode}
+                    onCheckedChange={toggleDebugMode}
+                  />
+                </Box>
               </Stack>
-              <Switch
-                id="enableDebugging"
-                checked={!!debugMode}
-                defaultChecked={debugMode}
-                onCheckedChange={toggleDebugMode}
-              />
+              <Box
+                css={{
+                  color: '$fgMuted',
+                  fontSize: '$xsmall',
+                  lineHeight: 1.5,
+                }}
+              >
+                {debugSession && (
+                <Text>
+                  {t('yourCurrentSessionIdIs')}
+                  {' '}
+                  <b>{debugSession}</b>
+                </Text>
+                )}
+              </Box>
             </Stack>
             <Stack direction="row" justify="between" gap={2} align="center" css={{ width: '100%' }}>
               <Label>{t('resetOnboarding')}</Label>

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
@@ -153,7 +153,7 @@ const SyncSettings = () => {
                   <Stack direction="column" gap={4}>
                     {
                     providers.map((provider) => (
-                      <Stack direction="row" justify="between" align="center">
+                      <Stack direction="row" justify="between" align="center" key={provider.text}>
                         <Stack direction="column">
                           <Box css={{
                             color: '$fgDefault', display: 'inline-flex', gap: '$2', alignItems: 'center',


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2772](https://github.com/tokens-studio/figma-plugin/issues/2772)

At the bottom of the plugin **Settings**, a user can toggle the permission to record the session for debugging purposes. This was not showing the `sessionId` when turned ON!

### What does this pull request do?
* Shows a console warning when the user toggles ON session recording won't work (i.e. in the `development` environment) - will work on `production`, `alpha` & `beta`.
* Polishes the UI when the session recording is ON

#### Doubts & further considerations
* 🤔 📈 Not sure if the Session Replay(s) take time to process - as I [could not find them on the dashboard](https://figma-tokens.sentry.io/replays/?project=5220409&statsPeriod=14d)
* Upgrading our `@sentry/react` package. Although for replay to work we are [covering the minimum requirements of the SDK to be >7.27.0](https://figma-tokens.sentry.io/replays/?project=5220409&statsPeriod=14d) (we are on `"@sentry/react": "^7.53.1"`)
* Enriching our replay config: https://docs.sentry.io/platforms/javascript/session-replay/configuration/
* Migrating to the latest Sentry SDK: https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/

### Testing this change
* Run `yarn build`
* Set up the plugin to import through the `manifest.json` - this should have set the environment to `production`
* Open the plugin, go to **Settings**
* Scroll to the bottom & enable the "Grand permission to record..." ---> see a _sessionId_ appear

| Before | After |
| ------| ------| 
| <img width="300" alt="Screenshot 2024-06-18 at 14 07 24" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/81f46839-7f43-49ac-bafa-dd599d204af8"> | <img width="300" alt="Screenshot 2024-06-18 at 11 56 17" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/7d47c858-8d5c-492c-8d18-25f37a409401"> | 


