### PR TITLE
fix: variables styles color remember

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
@@ -89,7 +89,7 @@ export const settings = createModel<RootModel>()({
     variablesString: true,
     variablesNumber: true,
     variablesBoolean: true,
-    stylesColor: true,
+    stylesColor: false,
     stylesTypography: true,
     stylesEffect: true,
   } as SettingsState,

--- a/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
@@ -89,7 +89,7 @@ export const settings = createModel<RootModel>()({
     variablesString: true,
     variablesNumber: true,
     variablesBoolean: true,
-    stylesColor: false,
+    stylesColor: true,
     stylesTypography: true,
     stylesEffect: true,
   } as SettingsState,

--- a/packages/tokens-studio-for-figma/src/utils/__tests__/uiSettings.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/__tests__/uiSettings.test.ts
@@ -85,7 +85,7 @@ describe('uiSettings', () => {
       variablesBoolean: true,
       stylesEffect: true,
       stylesTypography: true,
-      stylesColor: true,
+      stylesColor: false,
       createStylesWithVariableReferences: true,
       ignoreFirstPartForStyles: false,
       prefixStylesWithThemeName: false,

--- a/packages/tokens-studio-for-figma/src/utils/uiSettings.ts
+++ b/packages/tokens-studio-for-figma/src/utils/uiSettings.ts
@@ -92,7 +92,7 @@ export async function getUISettings(notify = true): Promise<SavedSettings> {
       variablesBoolean = typeof data.variablesBoolean === 'undefined' ? true : data.variablesBoolean;
       variablesNumber = typeof data.variablesNumber === 'undefined' ? true : data.variablesNumber;
       variablesString = typeof data.variablesString === 'undefined' ? true : data.variablesString;
-      stylesColor = typeof data.stylesColor === 'undefined' ? true : data.stylesColor;
+      stylesColor = typeof data.stylesColor === 'undefined' ? false : data.stylesColor;
       stylesTypography = typeof data.stylesTypography === 'undefined' ? true : data.stylesTypography;
       stylesEffect = typeof data.stylesEffect === 'undefined' ? true : data.stylesEffect;
       ignoreFirstPartForStyles = typeof data.ignoreFirstPartForStyles === 'undefined' ? false : data.ignoreFirstPartForStyles;


### PR DESCRIPTION
Fixes: https://github.com/tokens-studio/figma-plugin/issues/2876

This sets the default for those options when no value is provided correctly, as in if nothing is stored locally, we just set variablesColor to true, not both.