### PR TITLE
fix: horizontal token display for all dropdown lists (search input & mentions)

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -124,17 +124,16 @@ export default function MentionsInput({
                 {getHighlightedText(resolvedToken?.name ?? '', value || '')}
               </StyledItemName>
               {resolvedToken && (
-              <StyledItemValue css={{ color: '$tooltipFgMuted' }}>
-                <span>{getResolvedTextValue(resolvedToken)}</span>
-              </StyledItemValue>
+                <StyledItemValue css={{ color: '$tooltipFgMuted' }}>
+                  <span>
+                    {getResolvedTextValue(resolvedToken)}
+                  </span>
+                </StyledItemValue>
               )}
             </Stack>
-)}
+          )}
         >
-          <StyledItem
-            className="dropdown-item"
-          >
-
+          <StyledItem className="dropdown-item">
             {type === 'color' && <StyledItemColorDiv><StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} /></StyledItemColorDiv>}
             <StyledItemName truncate>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
             {resolvedToken && <StyledItemValue truncate>{getResolvedTextValue(resolvedToken)}</StyledItemValue>}

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -1,16 +1,26 @@
 import React, { useMemo } from 'react';
 import Mentions from 'rc-mentions';
+import {
+  Stack,
+  Tooltip,
+} from '@tokens-studio/ui';
+import { SingleToken } from '@/types/tokens';
+import { useReferenceTokenType } from '@/app/hooks/useReferenceTokenType';
+
+// Styles
+import {
+  StyledItem, StyledItemColor, StyledItemColorDiv, StyledItemName, StyledItemValue, StyledPart,
+} from './StyledDownshiftInput';
+import './mentions.css';
+
+// Utils
 import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 import { isDocumentationType } from '@/utils/is/isDocumentationType';
-import { Properties } from '@/constants/Properties';
-import { SingleToken } from '@/types/tokens';
-import { TokenTypes } from '@/constants/TokenTypes';
-import { useReferenceTokenType } from '@/app/hooks/useReferenceTokenType';
-import './mentions.css';
-import {
-  StyledItem, StyledItemColor, StyledItemColorDiv, StyledItemName, StyledItemValue, StyledPart, StyledItemInfo,
-} from './StyledDownshiftInput';
 import getResolvedTextValue from '@/utils/getResolvedTextValue';
+
+// Constants
+import { Properties } from '@/constants/Properties';
+import { TokenTypes } from '@/constants/TokenTypes';
 
 export interface SuggestionDataItem {
   id: string;
@@ -106,22 +116,30 @@ export default function MentionsInput({
         value={suggestion.id as string}
         className="mentions-item"
       >
-        <StyledItem
-          css={{ display: 'block' }}
-          className="dropdown-item"
+        <Tooltip
+          side="bottom"
+          label={(
+            <Stack direction="column" align="start" gap={1} css={{ wordBreak: 'break-word' }}>
+              <StyledItemName css={{ color: '$tooltipFg' }}>
+                {getHighlightedText(resolvedToken?.name ?? '', value || '')}
+              </StyledItemName>
+              {resolvedToken && (
+              <StyledItemValue css={{ color: '$tooltipFgMuted' }}>
+                <span>{getResolvedTextValue(resolvedToken)}</span>
+              </StyledItemValue>
+              )}
+            </Stack>
+)}
         >
-          <StyledItemInfo>
-            <StyledItemName>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
-          </StyledItemInfo>
-          {
-            resolvedToken && (
-            <StyledItemInfo>
-              {type === 'color' && (<StyledItemColorDiv><StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} /></StyledItemColorDiv>)}
-              <StyledItemValue>{getResolvedTextValue(resolvedToken)}</StyledItemValue>
-            </StyledItemInfo>
-            )
-          }
-        </StyledItem>
+          <StyledItem
+            className="dropdown-item"
+          >
+
+            {type === 'color' && <StyledItemColorDiv><StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} /></StyledItemColorDiv>}
+            <StyledItemName truncate>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
+            {resolvedToken && <StyledItemValue truncate>{getResolvedTextValue(resolvedToken)}</StyledItemValue>}
+          </StyledItem>
+        </Tooltip>
       </Option>
     );
   }, [resolvedTokens, type, getHighlightedText, referenceTokenTypes, value]);

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
@@ -44,7 +44,8 @@ export const StyledItemValue = styled('div', {
   fontSize: '$xxsmall',
   color: '$fgDefault',
   fontWeight: '$normal',
-  flex: '1 1 50%',
+  textAlign: 'right',
+  flex: '1 0 auto',
   variants: {
     truncate: {
       true: {
@@ -61,7 +62,7 @@ export const StyledItem = styled('div', {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  padding: '$2',
+  padding: '$2 $3',
   fontSize: '$xxsmall',
   variants: {
     isFocused: {
@@ -89,7 +90,7 @@ export const StyledItemName = styled('div', {
   fontSize: '$xsmall',
   color: '$fgDefault',
   fontWeight: '$sansBold',
-  flex: '1 1 50%',
+  flex: '1 1 auto',
   lineHeight: '1.4',
   wordBreak: 'break-word',
   marginRight: '$2',

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/StyledDownshiftInput.tsx
@@ -44,6 +44,7 @@ export const StyledItemValue = styled('div', {
   fontSize: '$xxsmall',
   color: '$fgDefault',
   fontWeight: '$normal',
+  flex: '1 1 50%',
   variants: {
     truncate: {
       true: {
@@ -88,7 +89,7 @@ export const StyledItemName = styled('div', {
   fontSize: '$xsmall',
   color: '$fgDefault',
   fontWeight: '$sansBold',
-  flexGrow: 1,
+  flex: '1 1 50%',
   lineHeight: '1.4',
   wordBreak: 'break-word',
   marginRight: '$2',
@@ -101,11 +102,6 @@ export const StyledItemName = styled('div', {
       },
     },
   },
-});
-
-export const StyledItemInfo = styled('div', {
-  display: 'flex',
-  alignItems: 'center',
 });
 
 export const StyledPart = styled('span', {
@@ -136,7 +132,6 @@ export const StyledDownshiftInput: React.FC<React.PropsWithChildren<React.PropsW
   name,
   value,
   placeholder,
-  suffix,
   inputRef,
   dataCy,
   onChange,

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/mentions.css
@@ -55,7 +55,6 @@
 .rc-mentions-dropdown {
   position: absolute;
   border-radius: var(--radii-medium);
-  z-index: 10;
 }
 
 .rc-mentions-dropdown-menu {
@@ -75,7 +74,6 @@
   box-shadow: var(--shadows-contextMenu);
   background: var(--colors-bgCanvas);
   cursor: pointer;
-  z-index: 10;
 }
 
 .rc-mentions-dropdown-menu-item {


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2878](https://github.com/tokens-studio/figma-plugin/issues/2878#issue-2361535058) <!-- link the related issue -->

The ability to view full token data (specifically names) was a pain point for users, which was solved by stacking these ([PR](https://github.com/tokens-studio/figma-plugin/pull/2759)). Negative feedback means we are reverting this, and aligning both views to horizontally display the data.

### What does this pull request do?
* Adapts `mentions.css` & `Mentions` to have the same look & feel as `DownshiftInput` when displaying an item on the list
* Allows name & resolved value to grow equally, while displaying a tooltip with these full values

### Testing this change
* Run the plugin
* Create a new token with a loooooong name
* Go and create a composition token (for example)
   * Search for the loooooong name = DownshiftInput
   * Start typing `{...` = Mentions


#### Samples of updated UI
| DownShiftInput | Mentions |
| ----- | ----- |
| <img width="250" alt="Screenshot 2024-06-19 at 11 53 02" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/38ef484f-96e4-449f-a4ad-fa0b3e93ecdb"> | <img width="250" alt="Screenshot 2024-06-19 at 11 54 32" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/7d69e207-c728-4939-a4ce-e0e9dc48b6f8"> |
| <img width="250" alt="Screenshot 2024-06-19 at 11 54 52" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/050c1555-968f-4a79-99d2-a3e79ff1cc6d"> | <img width="250" alt="Screenshot 2024-06-19 at 11 55 26" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/12ef10e3-bfde-4957-86b3-6b527176dfb2"> |
