### PR TITLE
Revert Manage Themes dialog group/theme name input change

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
@@ -100,13 +100,12 @@ export const CreateOrEditThemeForm: React.FC<React.PropsWithChildren<React.Props
             onClick={onCancel}
           />
           <Stack
-            direction="column"
-            align="start"
+            direction="row"
+            align="center"
             gap={1}
             css={{
               width: '100%',
-              paddingBlock: '$2',
-              minHeight: 'calc( (2 * $controlMedium) + $2 )',
+              paddingBlock: '$4',
               justifyContent: 'space-evenly',
             }}
           >
@@ -118,6 +117,7 @@ export const CreateOrEditThemeForm: React.FC<React.PropsWithChildren<React.Props
                 autofocus
                 data-testid="create-or-edit-theme-form--group--name"
                 {...register('group')}
+                placeholder="Add group"
                 css={{
                   display: 'flex',
                 }}
@@ -142,7 +142,7 @@ export const CreateOrEditThemeForm: React.FC<React.PropsWithChildren<React.Props
                   ) : (
                     <Button
                       data-testid="button-manage-themes-modal-new-group"
-                      variant="invisible"
+                      variant="secondary"
                       icon={<IconPlus />}
                       onClick={handleAddGroup}
                       size="small"
@@ -155,13 +155,16 @@ export const CreateOrEditThemeForm: React.FC<React.PropsWithChildren<React.Props
               </Box>
             )
           }
-              <Box>/</Box>
+              <Box css={{ margin: '0 $3' }}>/</Box>
             </Stack>
-            <Input
-              full
-              data-testid="create-or-edit-theme-form--input--name"
-              {...register('name', { required: true })}
-            />
+            <Stack direction="row" gap={1} align="center" css={{ flexGrow: 1 }}>
+              <Input
+                full
+                data-testid="create-or-edit-theme-form--input--name"
+                {...register('name', { required: true })}
+                placeholder="Theme name"
+              />
+            </Stack>
           </Stack>
 
         </StyledCreateOrEditThemeFormHeaderFlex>
@@ -175,7 +178,7 @@ export const CreateOrEditThemeForm: React.FC<React.PropsWithChildren<React.Props
       )}
       <Stack direction="column" gap={1}>
         {activeTab === ThemeFormTabs.SETS && (
-        <Stack direction="column" gap={1} css={{ padding: '0 $4 $3' }}>
+        <Stack direction="column" gap={1} css={{ padding: '$3 $4 $3' }}>
           <TokenSetTreeContent
             items={treeOrListItems}
             renderItemContent={TokenSetThemeItemInput}

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeGroupDropDownMenu.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeGroupDropDownMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { Check } from 'iconoir-react';
-import { DropdownMenu } from '@tokens-studio/ui';
+import { Button, DropdownMenu } from '@tokens-studio/ui';
 import { useTranslation } from 'react-i18next';
 import Box from '../Box';
 import { IconPlus } from '@/icons';
@@ -41,14 +41,24 @@ export const ThemeGroupDropDownMenu: React.FC<React.PropsWithChildren<React.Prop
 
   return (
     <DropdownMenu>
-      <DropdownMenu.Trigger>
+      <DropdownMenu.Trigger asChild>
         {
           selectedGroup ? (
-            <span>{selectedGroup}</span>
+            <Button variant="secondary" asDropdown>
+              <span>{selectedGroup}</span>
+            </Button>
           ) : (
             <Box css={{ display: 'flex', alignItems: 'center', gap: '$2' }}>
-              <IconPlus />
-              Add&nbsp;group
+              <Button
+                data-testid="button-manage-themes-modal-group-dropdown"
+                variant="secondary"
+                icon={<IconPlus />}
+                size="small"
+                css={{ display: 'flex', alignItems: 'center', height: '28px' }}
+                asDropdown
+              >
+                Add&nbsp;group
+              </Button>
             </Box>
           )
         }

--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeListGroupHeader.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/ThemeListGroupHeader.tsx
@@ -3,7 +3,6 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { IconButton } from '@tokens-studio/ui';
-import { styled } from '@stitches/react';
 import { editProhibitedSelector } from '@/selectors';
 import { DragControlsContext } from '@/context';
 import { StyledDragButton } from '../StyledDragger/StyledDragButton';
@@ -13,6 +12,7 @@ import Box from '../Box';
 import Input from '../Input';
 import IconPencil from '@/icons/pencil.svg';
 import { Dispatch } from '@/app/store';
+import { INTERNAL_THEMES_NO_GROUP } from '@/constants/InternalTokenGroup';
 
 type Props = React.PropsWithChildren<{
   groupName: string
@@ -28,7 +28,7 @@ export function ThemeListGroupHeader({
   const dispatch = useDispatch<Dispatch>();
   const dragContext = useContext(DragControlsContext);
   const editProhibited = useSelector(editProhibitedSelector);
-  const [currentGroupName, setCurrentGroupName] = useState(label);
+  const [currentGroupName, setCurrentGroupName] = useState<string>(groupName === INTERNAL_THEMES_NO_GROUP ? '' : groupName);
   const [isEditing, setIsEditing] = useState(false);
   const handleDragStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     dragContext.controls?.start(event);


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes #2880  <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

1. Go to the Manage Themes modal by clicking `Theme: None` or `Theme: {theme_name_here}`
2. Click `Manage Themes`
3. Click the `+ New Theme` button
4. Check visually that the new UI is being used
5. Try entering a group name and theme name

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

- Also fixes a bug around empty group name populating the input when renaming the group name
- Added text input placeholders for `Add group` and `Theme name`

| **Before** | **After** |
|--------|--------|
| <img width="477" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/3d820ec3-cae1-4985-910a-c2a21fc9c06d"> | <img width="491" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/1a2ff199-3c6f-47c7-8967-3a51ceb8a695"> |
| <img width="481" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/4a36837e-d80b-4537-9c82-4564c46e91ca"> | <img width="478" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/4dd8771c-6478-4270-a138-2cc070bbb0a2"> | 
| <img width="477" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/3d820ec3-cae1-4985-910a-c2a21fc9c06d"> | <img width="483" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/17e5e85f-d5a8-4a0c-ab67-b9a8d54bba76"> | 
| <img width="480" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/bd2e55bc-2760-4b4b-a14a-fe682afd08a7"> | <img width="486" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/ca7739ad-0134-47ec-9edf-335d7a970b2b"> | 
| <img width="466" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/2eb9af3f-5243-4f9f-8cfb-99670ac44a39"> | <img width="473" alt="image" src="https://github.com/tokens-studio/figma-plugin/assets/6757532/02fdd231-279b-4929-ad20-145aff6a35b5"> | 






<!--
  Add any other context or screenshots about the pull request
-->
