### PR TITLE
feat: Enhance base font size display in settings tab

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
@@ -101,24 +101,24 @@ const RemConfiguration = () => {
                 display: 'flex',
                 alignItems: 'center',
                 backgroundColor: isBrokenLink ? '$dangerBg' : '$accentBg',
-                padding: '2px',
+                padding: '$2',
               }}
             >
-              <Label css={{ fontSize: '12px', color: isBrokenLink ? '$dangerFg' : '$accentDefault' }}>
+              <Label css={{ fontSize: '$small', color: isBrokenLink ? '$dangerFg' : '$accentDefault' }}>
                 {aliasBaseFontSize}
               </Label>
               {isBrokenLink && (
                 <IconBrokenLink
-                  style={{ color: '#e03e1a', width: '24px', height: '24px', marginLeft: '3px', fontWeight: 'bold' }}
+                  style={{ color: 'var(--colors-dangerFg)', width: 'var(--sizes-6)', height: 'var(--sizes-6)', marginLeft: '3px' }}
                 />
               )}
             </Box>
           )}
           <Label
             css={{
-              fontSize: '12px',
+              fontSize: '$small',
               color: '$fgSubtle',
-              marginLeft: aliasBaseFontSize.startsWith('{') ? '8px' : '0px',
+              marginLeft: aliasBaseFontSize.startsWith('{') ? '$3' : '',
             }}
           >
             {displayBaseFontValue}

--- a/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
@@ -101,7 +101,7 @@ const RemConfiguration = () => {
                 display: 'flex',
                 alignItems: 'center',
                 backgroundColor: isBrokenLink ? '$dangerBg' : '$accentBg',
-                padding: '4px',
+                padding: '2px',
               }}
             >
               <Label css={{ fontSize: '12px', color: isBrokenLink ? '$dangerFg' : '$accentDefault' }}>

--- a/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Box, Button, Label, Stack, Text } from '@tokens-studio/ui';
 import remConfigurationImage from '@/app/assets/hints/remConfiguration.png';
+import IconBrokenLink from '@/icons/brokenlink.svg';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { mergeTokenGroups } from '@/utils/tokenHelpers';
@@ -23,6 +24,7 @@ const RemConfiguration = () => {
   const dispatch = useDispatch<Dispatch>();
   const { t } = useTranslation(['settings']);
   const [modalVisible, setModalVisible] = React.useState(false);
+  const [isBrokenLink, setIsBrokenLink] = React.useState<boolean>(false);
 
   const toggleModalVisible = React.useCallback(() => setModalVisible((prev) => !prev), []);
 
@@ -37,20 +39,27 @@ const RemConfiguration = () => {
     [tokens, usedTokenSet, activeTokenSet],
   );
 
+  const resolvedAliasBaseFontSizes = getAliasValue(aliasBaseFontSize, resolvedTokens);
+
   const displayBaseFontValue = React.useMemo(() => {
     const resolvedAliasBaseFontSize = getAliasValue(aliasBaseFontSize, resolvedTokens);
-
+    let formattedpxValue = 16;
+    console.log(resolvedAliasBaseFontSize);
     if (typeof resolvedAliasBaseFontSize === 'string' || typeof resolvedAliasBaseFontSize === 'number') {
       const resolvedAliasBaseFontSizeValue =
         typeof resolvedAliasBaseFontSize === 'number'
           ? resolvedAliasBaseFontSize
           : parseFloat(resolvedAliasBaseFontSize);
-      const formattedpxValue = isNaN(resolvedAliasBaseFontSizeValue)
-        ? 16
-        : Number(resolvedAliasBaseFontSizeValue.toFixed(2));
-      return `${t('baseFont')} (1rem = ${formattedpxValue}px)`;
+      if (isNaN(resolvedAliasBaseFontSizeValue)) {
+        formattedpxValue = 16;
+        setIsBrokenLink(true);
+      } else {
+        formattedpxValue = Number(resolvedAliasBaseFontSizeValue.toFixed(2));
+        setIsBrokenLink(false);
+      }
+      return `1rem = ${formattedpxValue}px`;
     }
-    return `${t('baseFont')} (1rem = 16px)`;
+    return `1rem = 16px`;
   }, [aliasBaseFontSize, resolvedTokens]);
 
   const handleBaseFontSizeChange = React.useCallback(
@@ -77,12 +86,44 @@ const RemConfiguration = () => {
 
   return (
     <Stack direction="row" align="center" justify="between" css={{ width: '100%' }}>
-      <Stack direction="row" align="center" gap={1}>
-        <Label>{displayBaseFontValue}</Label>
-        <ExplainerModal title={displayBaseFontValue}>
-          <Box as="img" src={remConfigurationImage} css={{ borderRadius: '$small' }} />
-          <Box>{t('baseFontExplanation')}</Box>
-        </ExplainerModal>
+      <Stack direction="column" align="start" gap={1}>
+        <Stack direction="row" align="center" gap={1}>
+          <Label>{t('baseFont')}</Label>
+          <ExplainerModal title={displayBaseFontValue}>
+            <Box as="img" src={remConfigurationImage} css={{ borderRadius: '$small' }} />
+            <Box>{t('baseFontExplanation')}</Box>
+          </ExplainerModal>
+        </Stack>
+        <Stack direction="row" align="center" gap={1}>
+          {aliasBaseFontSize.startsWith('{') && (
+            <Box
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                backgroundColor: isBrokenLink ? '$dangerBg' : '$accentBg',
+                padding: '4px',
+              }}
+            >
+              <Label css={{ fontSize: '12px', color: isBrokenLink ? '$dangerFg' : '$accentDefault' }}>
+                {aliasBaseFontSize}
+              </Label>
+              {isBrokenLink && (
+                <IconBrokenLink
+                  style={{ color: '#e03e1a', width: '24px', height: '24px', marginLeft: '3px', fontWeight: 'bold' }}
+                />
+              )}
+            </Box>
+          )}
+          <Label
+            css={{
+              fontSize: '12px',
+              color: '$fgSubtle',
+              marginLeft: aliasBaseFontSize.startsWith('{') ? '8px' : '0px',
+            }}
+          >
+            {displayBaseFontValue}
+          </Label>
+        </Stack>
       </Stack>
 
       <Button onClick={toggleModalVisible} variant="secondary">


### PR DESCRIPTION
- Now base font size's reference will be displayed directly outside in the settings tab
- when the referenced token is deleted or invalid, it shall display the broken link in red
- Resolves #2875 
<img width="534" alt="Screenshot 2024-06-20 at 00 36 13" src="https://github.com/tokens-studio/figma-plugin/assets/9948167/6b57dd41-9192-49e9-8074-6bf1839c06ee">
<img width="532" alt="Screenshot 2024-06-20 at 00 36 44" src="https://github.com/tokens-studio/figma-plugin/assets/9948167/8e6fc947-022f-404d-9e67-87dd06d0de3c">

In dark mode:

<img width="552" alt="Screenshot 2024-06-20 at 11 46 09" src="https://github.com/tokens-studio/figma-plugin/assets/9948167/76fb6c26-77bc-4380-8e29-c3939a042020">

<img width="535" alt="Screenshot 2024-06-20 at 11 46 41" src="https://github.com/tokens-studio/figma-plugin/assets/9948167/b6f96f49-1266-454f-ba59-e3f702acdbda">
