### PR TITLE
fix: clicking a select when editing a color token now keeps the modal open

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenFormModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenFormModal.tsx
@@ -26,6 +26,16 @@ const EditTokenFormModal: React.FC<React.PropsWithChildren<React.PropsWithChildr
     }
   }, [dispatch, showAutoSuggest]);
 
+  const handleEditTokenModalClose = React.useCallback(() => {
+    /**
+     * Temporary fix - Radix UI leaves `pointer-events: none` on body when dialog is closed
+     * Future fix - upgrade the Dialog in our DS (https://github.com/tokens-studio/ds/issues/219)
+     * */
+    setTimeout(() => {
+      document.body.style.pointerEvents = 'auto';
+    }, 1000);
+  }, []);
+
   if (!editToken) {
     return null;
   }
@@ -35,8 +45,8 @@ const EditTokenFormModal: React.FC<React.PropsWithChildren<React.PropsWithChildr
       compact
       size="large"
       isOpen
-      modal={false}
       close={handleReset}
+      onCloseCallback={handleEditTokenModalClose}
       // eslint-disable-next-line no-nested-ternary
       title={editToken.status === EditTokenFormStatus.CREATE ? t('newToken')
         : editToken.status === EditTokenFormStatus.DUPLICATE ? t('duplicateToken') : editToken.initialName}

--- a/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
@@ -20,6 +20,7 @@ export type ModalProps = {
   showClose?: boolean;
   backArrow?: boolean
   close: () => void;
+  onCloseCallback?: () => void;
   modal?: boolean;
   onInteractOutside?: (event: Event) => void;
 };
@@ -89,6 +90,7 @@ export function Modal({
   modal = true,
   backArrow = false,
   onInteractOutside,
+  onCloseCallback,
 }: ModalProps) {
   const handleClose = React.useCallback(() => {
     close();
@@ -97,6 +99,9 @@ export function Modal({
   const handleOnOpenChange = React.useCallback(
     (open) => {
       if (!open) {
+        if (onCloseCallback) {
+          onCloseCallback();
+        }
         close();
       }
     },


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2885](https://github.com/tokens-studio/figma-plugin/issues/2885)

When editing a color token, specifically the **Modify** operations, when clicking outside either of the `Select` components - still within the `Dialog` - it would close the whole modal!

<img width="200" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/f82c6d95-28c0-4d61-9302-d26a5056459f">

### What does this pull request do?
* Sets the `EditTokenFormModal` to be a true **Dialog** by [reverting this line](https://github.com/tokens-studio/figma-plugin/commit/d1f242ee7bd62aba35ac501a3f8ed63fa0e121d2#diff-673288265fffd7be7744be899e7164982415b80ad754639cb7c14efa6e537f0bR38) (now `modal={true}` as per [Radix's Dialog default prop](https://www.radix-ui.com/primitives/docs/components/dialog#root))
* Fixes when both components are closed (`Select` contained in a `Dialog`) seems to dees the underlying layer unresponsive due to `pointer-events: none` remaining in the `<body>` = Radix bug! This mitigates it as a temporary fix on the `EditTokenFormModal.tsx`. Some thoughts: 
    * 🧐 Could be related to the mismatching dependencies as discussed [here](https://hyma-team.slack.com/archives/C06RHB9RT2B/p1718884986918469?thread_ts=1718783596.851599&cid=C06RHB9RT2B)
    * 🤕 Some users reported that this was not fixed after upgrading `DropdownMenus` / `Select` & `Dialog` to the latest Radix UI versions - then they went for a temporary fix:
       * 🎁 Fix for now: set `pointer-events` to auto (Community suggestions: https://github.com/radix-ui/primitives/issues/1241#issuecomment-1734547434 & https://github.com/radix-ui/primitives/issues/1241#issuecomment-2048551011)
       * 🔜 Fix for the future: upgrade Radix components safely in the DS (https://github.com/tokens-studio/ds/issues/220, https://github.com/tokens-studio/ds/issues/219)

### Testing this change
1. In the **Tokens** tab, edit or duplicate any color token, and see a Modal appear
2. Add a (`+`) **Modify** to set an _Operation_ or _Space_ (see 2 Select components)
3. Click outside any Select, still **inside** the Modal
4. The Modal now stays open!

| Before | After |
| ------ | ------ |
| <video src='https://github.com/tokens-studio/figma-plugin/assets/114073780/bd6b67b3-91ad-412e-982f-d3e73635e847' /> | <video src='https://github.com/tokens-studio/figma-plugin/assets/114073780/09cb4cfa-d4c4-4ce2-803f-c2a48f1c7259' /> |

