### PR TITLE
2.0: Fix variable references when references aren't coming from any active themes

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
@@ -61,12 +61,14 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
       }
       updatedVariableCollections.push(collection);
     }));
-    const existingVariables = await mergeVariableReferencesWithLocalVariables(selectedThemeObjects);
+    // Gather references that we should use. Merge current theme references with the ones from all themes as well as local variables
+    const existingVariables = await mergeVariableReferencesWithLocalVariables(selectedThemeObjects, themeInfo.themes);
 
+    // Update variables to use references instead of raw values
     updatedVariables = await updateVariablesToReference(existingVariables, referenceVariableCandidates);
   }
 
-  figmaVariablesAfterCreate += figma.variables.getLocalVariables()?.length;
+  figmaVariablesAfterCreate += figma.variables.getLocalVariables()?.length ?? 0;
   const figmaVariableCollectionsAfterCreate = figma.variables.getLocalVariableCollections()?.length;
 
   if (figmaVariablesAfterCreate === figmaVariablesBeforeCreate) {

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
@@ -41,8 +41,8 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
             [curr.set]: curr.status,
           },
           id: curr.set,
-          name: curr.set
-        })
+          name: curr.set,
+        });
       }
       return acc;
     }, [] as ThemeObject[]);
@@ -67,7 +67,7 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
       if (set.status === TokenSetStatus.ENABLED) {
         const setTokens: Record<string, AnyTokenList> = {
           ...sourceTokenSets,
-          [set.set]: tokens[set.set]
+          [set.set]: tokens[set.set],
         };
         const { collection, modeId } = findCollectionAndModeIdForTheme(set.set, set.set, collections);
 
@@ -92,7 +92,7 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
     updatedVariables = await updateVariablesToReference(existingVariables, referenceVariableCandidates);
   }
 
-  figmaVariablesAfterCreate += figma.variables.getLocalVariables()?.length;
+  figmaVariablesAfterCreate += figma.variables.getLocalVariables()?.length ?? 0;
   const figmaVariableCollectionsAfterCreate = figma.variables.getLocalVariableCollections()?.length;
 
   if (figmaVariablesAfterCreate === figmaVariablesBeforeCreate) {

--- a/packages/tokens-studio-for-figma/src/plugin/mergeVariableReferences.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/mergeVariableReferences.ts
@@ -1,10 +1,23 @@
 import { ThemeObject } from '@/types';
 
-export async function mergeVariableReferencesWithLocalVariables(themes: ThemeObject[] = []): Promise<Map<string, string>> {
+// Gather references that we should use. Merge current theme references with the ones from all themes as well as local variables
+// Note that this is a bit naive. As the active theme does not have the themes set as active that it should use as a reference, it will not be able to find the correct reference.
+// This is why we also pass in allThemes and merge them together. This is naive because it might be that the reference required is not the "first to detect".
+// We need to refactor this probably. Themes should be able to strictly specify which other theme the references are coming from, like we do for token sets.
+export async function mergeVariableReferencesWithLocalVariables(themes: ThemeObject[] = [], allThemes: ThemeObject[] = []): Promise<Map<string, string>> {
   const localVariables = await figma.variables.getLocalVariablesAsync();
 
   const variables = new Map();
   themes.forEach((theme) => {
+    if (!theme.$figmaVariableReferences) return;
+    Object.entries(theme.$figmaVariableReferences).forEach(([tokenName, variableId]) => {
+      // For each variable reference we add one to the global Map - ONLY if it is not already set.
+      // Meaning, users will run into problems if they have a token defined in multiple theme groups
+      if (variables.has(tokenName)) return;
+      variables.set(tokenName, variableId);
+    });
+  });
+  allThemes.forEach((theme) => {
     if (!theme.$figmaVariableReferences) return;
     Object.entries(theme.$figmaVariableReferences).forEach(([tokenName, variableId]) => {
       // For each variable reference we add one to the global Map - ONLY if it is not already set.


### PR DESCRIPTION
Closes https://github.com/tokens-studio/figma-plugin/issues/2906

When we're creating variables, we currently use themes that are active to inform what variables should be used as references. However, if those theme groups aren't active, we won't know what variable references to use for tokens and will fall back to raw hex values inside variables. Especially in multi-file setup users sometimes only enable one theme group, meaning they won't have the necessary references available.

### What does this pull request do?

Changes the logic to add another set of themes to the merge function, so that the references from the current theme group have preference, but after that we'll take into account other themes. 

Note that this is kind of flawed as we will pick the first available variable reference that we find. However, I'd say it's OK enough, given:
- We should educate users that they should keep tokens only to one theme group
- Eventually we should refactor themes so that users can directly specify what theme group a variable reference should be coming from

**Before:**
<img width="643" alt="CleanShot 2024-06-24 at 08 32 53@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/fe767a42-192a-45cb-8c71-d9906bfb6dda">

**After:** 
<img width="644" alt="CleanShot 2024-06-24 at 08 32 33@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/0c5ea766-15dc-4c1b-9f3b-f9a60b3e4bb3">


### Testing this change

- Create multiple theme groups
- One theme group should reference token from another
- Create a multi-file setup (you need to push to git to do that)
- Create and Publish variables from the first theme group in file A
- Go to file B, activate the library from file A via Figma
- Create variables from the second theme group (that's using tokens from the first one) in file B

With this change, the references correctly map. Before, they used hex values.