### PR TITLE
fix bitbucket create branch from having wrong origin

### DIFF
--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -82,7 +82,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
       const sourceBranchName = source || this.branch;
       const sourceBranch = originBranch.data.values.find((branchValue: Schema.Branch) => branchValue.name === sourceBranchName);
 
-      if (!originBranch.data.values || !sourceBranch || !sourceBranch.target) {
+      if (!originBranch.data || !originBranch.data.values || !sourceBranch || !sourceBranch.target || !sourceBranch.target.hash) {
         throw new Error('Could not retrieve origin branch');
       }
 

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
@@ -15,8 +15,15 @@ import {
   mockListBranches,
   mockCreateOrUpdateFiles,
   mockCreateBranch,
-  mockListRefs,
 } from '../../../tests/__mocks__/bitbucketMock';
+
+const mockListRefs = jest.fn(() => {
+  return Promise.resolve({
+    data: {
+      values: [{ name: 'main', target: { hash: 'simpleHash' } }],
+    },
+  });
+});
 
 // Mock FormData
 // createOrUpdateFiles function uses a FormData object to send the data to the createSrcFileCommit method


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2905

Users reported bitbucket sync behaves weirdly when creating a new branch. It takes a different source branch than specified.

### What does this pull request do?

Looked into the code and we naively took the first branch that came back from the list of branches. Changed it so that we use the specified branch name.