### PR TITLE
2.0 Polish modal size

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Modal/Modal.tsx
@@ -49,7 +49,7 @@ const StyledDialogContent = styled(Dialog.Content, {
     size: {
       large: {
         width: 'calc(100vw - $7)',
-        maxWidth: 'calc(100vw -$7)',
+        maxWidth: '480px',
         padding: 0,
         boxShadow: '$contextMenu',
         borderColor: '$borderSubtle',

--- a/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
@@ -58,8 +58,8 @@ function PullDialog() {
     }
     case 'loading': {
       return (
-        <Modal size="large" isOpen close={onCancel} title={`Pull from ${transformProviderName(storageType.provider)}`}>
-          <Stack direction="column" gap={4} justify="center" align="center">
+        <Modal isOpen close={onCancel}>
+          <Stack direction="column" gap={4} justify="center" align="center" css={{ padding: '$4 0' }}>
             <Spinner />
             <Heading size="medium">{t('pullFrom', { provider: transformProviderName(storageType.provider) })}</Heading>
           </Stack>

--- a/packages/tokens-studio-for-figma/src/app/components/PushDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/PushDialog.tsx
@@ -115,7 +115,6 @@ function PushDialog() {
           full
           title={t('pushTo', { provider: transformProviderName(storageType.provider) })}
           showClose
-          size="large"
           isOpen
           close={onCancel}
           stickyFooter
@@ -180,8 +179,8 @@ function PushDialog() {
     }
     case 'loading': {
       return (
-        <Modal size="large" isOpen close={onCancel}>
-          <Stack direction="column" gap={4} justify="center" align="center">
+        <Modal isOpen close={onCancel}>
+          <Stack direction="column" gap={4} justify="center" align="center" css={{ padding: '$4 0' }}>
             <Spinner />
             <Heading size="medium">
               {t('pushingTo')}
@@ -197,8 +196,8 @@ function PushDialog() {
     }
     case 'success': {
       return (
-        <Modal size="large" isOpen close={onCancel}>
-          <Stack direction="column" align="center" gap={6} css={{ textAlign: 'center' }}>
+        <Modal isOpen close={onCancel}>
+          <Stack direction="column" align="center" gap={6} css={{ textAlign: 'center', padding: '$4 0' }}>
             <Stack direction="column" gap={4}>
               <Heading data-testid="push-dialog-success-heading" size="medium">
                 All done!

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -177,7 +177,7 @@ export default function useTokens() {
 
   const pullVariables = useCallback(async () => {
     const userDecision = await confirm({
-      text: 'Import variables',
+      text: 'Import Variables',
       description: 'Sets will be created for each variable mode.',
       choices: [
         { key: 'useDimensions', label: 'Convert numbers to dimensions', enabled: false },


### PR DESCRIPTION
Closes #2909

Modals in 2.0 are overall too big - they span the full window size.

### What does this pull request do?

Introduce a max width for our modals so that they don't go as wide.

### Before

![image](https://github.com/tokens-studio/figma-plugin/assets/4548309/46c0d2fa-e4dd-4b99-b7b5-184799535213)

### After

<img width="979" alt="CleanShot 2024-06-24 at 08 37 09@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/19054141-c660-4979-a486-885ccb0e9d82">
