### PR TITLE
2.0: Fix order of keys when pushed to remote

### DIFF
--- a/packages/tokens-studio-for-figma/src/utils/convertTokensToObject.ts
+++ b/packages/tokens-studio-for-figma/src/utils/convertTokensToObject.ts
@@ -18,8 +18,7 @@ export default function convertTokensToObject(tokens: Record<string, AnyTokenLis
       // Directly work with tokenWithoutName to preserve order
       if (tokenWithoutName.inheritTypeLevel) {
         // If inheritTypeLevel exists, handle it specifically
-        const { inheritTypeLevel } = tokenWithoutName;
-        delete tokenWithoutName.inheritTypeLevel; // Remove it to avoid altering the order
+        const { inheritTypeLevel, ...tokenWithoutTypeLevel } = tokenWithoutName;
 
         // Set type of group level without altering the order of tokenWithoutName
         set(tokenGroupObj, getGroupTypeName(name, inheritTypeLevel), tokenWithoutName.type);
@@ -27,7 +26,7 @@ export default function convertTokensToObject(tokens: Record<string, AnyTokenLis
         // Add value and description keys directly to preserve order
         tokenWithoutName[TokenFormat.tokenValueKey] = tokenWithoutName.value;
         tokenWithoutName[TokenFormat.tokenDescriptionKey] = tokenWithoutName.description;
-        set(tokenGroupObj, name, tokenWithoutName, { merge: true });
+        set(tokenGroupObj, name, tokenWithoutTypeLevel, { merge: true });
       } else {
         // For tokens without inheritTypeLevel, directly add type, value, and description to preserve order
         tokenWithoutName[TokenFormat.tokenTypeKey] = tokenWithoutName.type;


### PR DESCRIPTION
Closes #2907

With 2.0 we seem to have introduced a regression when it comes to the order of token keys. We made it so that `type` always comes first, then `value`, and so on. This is bad because we need to respect users key ordering.

With this PR we're now respecting the order and keeping it the same by not destructuring the object.

### Before

<img width="692" alt="CleanShot 2024-06-24 at 08 39 54@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/cf8b56df-bb2f-49d2-b2f7-81877413dda8">

As you can see in this screenshot we reordered keys, even though the user didnt specify that.

### After

<img width="710" alt="CleanShot 2024-06-24 at 08 40 55@2x" src="https://github.com/tokens-studio/figma-plugin/assets/4548309/e407ea8c-148f-44a1-be54-da11eca1d12e">

Here's me after the change just adding a modifier - note how it preserves the order of `value` first.