### PR TITLE
fix: correctly format suggestions by mentions when submitted

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -80,7 +80,7 @@ export default function MentionsInput({
   }, [initialName, resolvedTokens, referenceTokenTypes, type]);
 
   const handleMentionInputChange = React.useCallback((newValue: string) => {
-    handleChange(name, newValue.replace(/}(?=\s)[^{}]*}/gi, '}'));
+    handleChange(name, newValue.replace(/}(?=\s)[^{}]*}/gi, '}').trim());
   }, [handleChange, name]);
 
   const handleInputBlur = React.useCallback(() => {


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2902](https://github.com/tokens-studio/figma-plugin/issues/2902)

[A previous fix to prevent trailing whitespace being added](https://github.com/tokens-studio/figma-plugin/pull/2789), had made the [Mentions](https://www.npmjs.com/package/rc-mentions) component misbehave. Inserting extra curly brackets at random spots when searching.

### What does this pull request do?
* Removes the `trim` prop in favour of trimming the raw value

### Testing this change

| Before | After |
| ----- | ----- |
| https://github.com/tokens-studio/figma-plugin/assets/114073780/c1bde474-834c-4b70-b6a7-171d04ebd27c | https://github.com/tokens-studio/figma-plugin/assets/114073780/893fae55-d55c-4add-ace7-56ddb4ceced1 |

### Additional Notes (if any)

✨ 👀 Extra improvement: when typing in a search, ensure that if there is a full match, it is highlighted. Perhaps adding a custom `filterOption` prop to the [Mentions](https://www.npmjs.com/package/rc-mentions) component?

At the moment, even if there is a full match (i.e. `colors.blue.500`), the first one on the list is highlighted and submitted when pressing **Enter**:
<img width="250" alt="Screenshot 2024-06-27 at 17 53 57" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/8d239c4c-6a67-4efd-b06f-9cb5f87d9b6d">
