### PR TITLE
fix: color swatches to show colors with gradients

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/DownshiftInput.tsx
@@ -25,6 +25,7 @@ import {
 import fuzzySearch from '@/utils/fuzzySearch';
 import MentionsInput from './MentionInput';
 import getResolvedText from '@/utils/getResolvedTextValue';
+import getColorSwatchStyle from '@/utils/color/getColorSwatchStyle';
 
 type SearchField = 'Tokens' | 'Fonts' | 'Weights';
 
@@ -294,7 +295,7 @@ export const DownshiftInput: React.FunctionComponent<React.PropsWithChildren<Rea
                               >
                                 {type === 'color' && (
                                 <StyledItemColorDiv>
-                                  <StyledItemColor style={{ backgroundColor: token.value.toString() }} />
+                                  <StyledItemColor style={getColorSwatchStyle(token.value.toString())} />
                                 </StyledItemColorDiv>
                                 )}
                                 <StyledItemName truncate>

--- a/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DownshiftInput/MentionInput.tsx
@@ -17,6 +17,7 @@ import './mentions.css';
 import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 import { isDocumentationType } from '@/utils/is/isDocumentationType';
 import getResolvedTextValue from '@/utils/getResolvedTextValue';
+import getColorSwatchStyle from '@/utils/color/getColorSwatchStyle';
 
 // Constants
 import { Properties } from '@/constants/Properties';
@@ -134,7 +135,7 @@ export default function MentionsInput({
           )}
         >
           <StyledItem className="dropdown-item">
-            {type === 'color' && <StyledItemColorDiv><StyledItemColor style={{ backgroundColor: resolvedToken?.value.toString() }} /></StyledItemColorDiv>}
+            {type === 'color' && <StyledItemColorDiv><StyledItemColor style={resolvedToken?.value ? getColorSwatchStyle(resolvedToken?.value.toString()) : {}} /></StyledItemColorDiv>}
             <StyledItemName truncate>{getHighlightedText(resolvedToken?.name ?? '', value || '')}</StyledItemName>
             {resolvedToken && <StyledItemValue truncate>{getResolvedTextValue(resolvedToken)}</StyledItemValue>}
           </StyledItem>

--- a/packages/tokens-studio-for-figma/src/utils/color/getColorSwatchStyle.ts
+++ b/packages/tokens-studio-for-figma/src/utils/color/getColorSwatchStyle.ts
@@ -1,5 +1,5 @@
 export default function getColorSwatchStyle(tokenValue: string) {
   return tokenValue.includes(';')
     ? { background: tokenValue.replace(/;/g, '') }
-    : { backgroundColor: tokenValue };
+    : { background: tokenValue };
 }

--- a/packages/tokens-studio-for-figma/src/utils/color/getColorSwatchStyle.ts
+++ b/packages/tokens-studio-for-figma/src/utils/color/getColorSwatchStyle.ts
@@ -1,0 +1,5 @@
+export default function getColorSwatchStyle(tokenValue: string) {
+  return tokenValue.includes(';')
+    ? { background: tokenValue.replace(/;/g, '') }
+    : { backgroundColor: tokenValue };
+}

--- a/packages/tokens-studio-for-figma/src/utils/color/index.ts
+++ b/packages/tokens-studio-for-figma/src/utils/color/index.ts
@@ -1,3 +1,4 @@
 export * from './convertToRgb';
 export * from './isLightOrDark';
 export * from './getReferenceTokensFromGradient';
+export * from './getColorSwatchStyle';


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2951](https://github.com/tokens-studio/figma-plugin/issues/2951#issue-2385828332)

Colors with semicolons were not applying to the color swatches due to an error when the DOM CSS styling was attempting to be applied

### What does this pull request do?
* Adds a small utility that strips a semicolon from a string
* Uses the utility for correct styling in search and mentions

### Testing this change
1. Create a color token as a gradient (i.e. `linear-gradient(to right,#dc573c,#247efc);`)
2. Create or edit another color token - search by name or alias
3. See the gradient showing on the swatch

| Before | After |
| ----- | ----- |
| <img width="200" alt="Screenshot 2024-07-02 at 12 04 03" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/204889ed-733b-4b75-a20f-98c2f1f60c51"> | <img width="200" alt="Screenshot 2024-07-02 at 12 17 05" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/a8769df4-8159-4e0c-8ce6-57073955a4b0"> |
| <img width="200" alt="Screenshot 2024-07-02 at 12 04 14" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/16883cf4-6fd9-4322-a548-fc3f4eb4f46b"> | <img width="200" alt="Screenshot 2024-07-02 at 12 17 13" src="https://github.com/tokens-studio/figma-plugin/assets/114073780/b6610627-6a64-46e2-aff5-b70e49a11678"> |

