### PR TITLE
Cypress tests for select in modal and duplicate resolving

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -75,9 +75,10 @@ jobs:
         uses: anuraag016/Jest-Coverage-Diff@master
         with:
           fullCoverageDiff: false
-          runCommand: "cd packages/tokens-studio-for-figma && npm run test:coverage:ci"
+          runCommand: "cd packages/tokens-studio-for-figma && npm run test:coverage:ci && cd ../.. && mv packages/tokens-studio-for-figma/coverage-summary.json coverage-summary.json"
           afterSwitchCommand: yarn
           useSameComment: true
+          delta: 1
   test-transform:
     name: Transformer Tests
     runs-on: ubuntu-22.04

--- a/packages/tokens-studio-for-figma/cypress/e2e/tokens.cy.js
+++ b/packages/tokens-studio-for-figma/cypress/e2e/tokens.cy.js
@@ -367,4 +367,147 @@ describe('TokenListing', () => {
     });
     cy.get('@postMessage').should('be.calledThrice');
   });
+  it('click outside select in modal doesn’t close modal', () => {
+    cy.startup(mockStartupParams);
+    cy.get('[data-testid="button-configure"]').should('be.visible')
+    cy.receiveSetTokens({
+      version: '5',
+      values: {
+        options: [{
+          name: 'sizing.xs',
+          value: 4,
+          type: 'sizing'
+        }, {
+          name: 'opacity.30',
+          value: '30%',
+          type: 'opacity'
+        }, {
+          name: 'font-size.4',
+          value: '4px',
+          type: 'fontSizes'
+        }],
+        global: [{
+          name: 'sizing.xs',
+          value: 4,
+          type: 'sizing'
+        }],
+      },
+    });
+    cy.get('[data-testid=tokenlisting-color] [data-testid=button-add-new-token]').click();
+
+    fillInput({
+      input: 'name',
+      value: 'modifyToken',
+    });
+
+    cy.get('[data-testid=button-add-new-modify]').click();
+    cy.get('[data-testid=colortokenform-operation-button]').click();
+
+    cy.get('body').type('{esc}');
+
+    fillInputNth({
+      input: 'value',
+      value: '#000000',
+      nth: 0,
+    });
+    fillInputNth({
+      input: 'value',
+      value: '0.5',
+      nth: 1,
+      submit: true,
+    });
+    cy.get('@postMessage').should('be.calledThrice');
+  });
+
+  it('can delete duplicate tokens with duplicate resolve modal', () => {
+    cy.startup(mockStartupParams);
+    cy.get('[data-testid="button-configure"]').should('be.visible')
+    cy.receiveSetTokens({
+      version: '5',
+      values: {
+        options: [{
+          name: 'sizing.xs',
+          value: 4,
+          type: 'sizing'
+        }, {
+          name: 'opacity.30',
+          value: '30%',
+          type: 'opacity'
+        }, {
+          name: 'font-size.4',
+          value: '4px',
+          type: 'fontSizes'
+        }, {
+          name: 'buttons.default',
+          value: '#0af',
+          type: 'color'
+        }, {
+          name: 'buttons.default',
+          value: '#0fa',
+          type: 'color'
+        }],
+        global: [{
+          name: 'sizing.xs',
+          value: 4,
+          type: 'sizing'
+        }, {
+          name: 'buttons.default',
+          value: '#0fa',
+          type: 'color'
+        }, {
+          name: 'buttons.default',
+          value: 4,
+          type: 'sizing'
+        }],
+      },
+    });
+    cy.get('[data-testid=resolve-duplicate-modal-open-button]').click();
+
+    cy.get('[role="radiogroup"] [value="global:buttons.default:1"]').click();
+
+    cy.get('#resolveDuplicateTokenGroup').submit();
+    cy.get('#confirmDeleteDuplicates').submit();
+
+    cy.get('@postMessage').should('be.calledThrice');
+
+    cy.get('[data-testid=resolve-duplicate-modal-open-button]').should('not.exist');
+
+    // Verify duplicates were correctly deleted
+    cy.window().its('store').invoke('getState').its('tokenState').its('tokens').should('deep.equal', {
+      "options": [
+        {
+          "name": "sizing.xs",
+          "value": 4,
+          "type": "sizing"
+        },
+        {
+          "name": "opacity.30",
+          "value": "30%",
+          "type": "opacity"
+        },
+        {
+          "name": "font-size.4",
+          "value": "4px",
+          "type": "fontSizes"
+        },
+        {
+          "name": "buttons.default",
+          "value": "#0af",
+          "type": "color"
+        }
+      ],
+      "global": [
+        {
+          "name": "sizing.xs",
+          "value": 4,
+          "type": "sizing"
+        },
+        {
+          "name": "buttons.default",
+          "value": 4,
+          "type": "sizing"
+        }
+      ]
+    })
+  });
 });

--- a/packages/tokens-studio-for-figma/cypress/e2e/tokens.cy.js
+++ b/packages/tokens-studio-for-figma/cypress/e2e/tokens.cy.js
@@ -367,7 +367,7 @@ describe('TokenListing', () => {
     });
     cy.get('@postMessage').should('be.calledThrice');
   });
-  it('click outside select in modal doesn’t close modal', () => {
+  it('click outside modify select color create modal doesn’t close modal', () => {
     cy.startup(mockStartupParams);
     cy.get('[data-testid="button-configure"]').should('be.visible')
     cy.receiveSetTokens({
@@ -403,7 +403,15 @@ describe('TokenListing', () => {
     cy.get('[data-testid=button-add-new-modify]').click();
     cy.get('[data-testid=colortokenform-operation-button]').click();
 
+    cy.get('span:contains("darken")').parent().should('be.visible');
+    cy.get('span:contains("darken")').click();
+    cy.get('[data-testid=colortokenform-operation-button]').click();
+    cy.get('span:contains("darken")').parent().should('be.visible');
+
     cy.get('body').type('{esc}');
+
+    cy.get('span:contains("alpha")').should('not.exist');
+    cy.get('[data-testid="colortokenform-operation-button"]').should('be.visible');
 
     fillInputNth({
       input: 'value',
@@ -414,6 +422,59 @@ describe('TokenListing', () => {
       input: 'value',
       value: '0.5',
       nth: 1,
+      submit: true,
+    });
+    cy.get('@postMessage').should('be.calledThrice');
+  });
+  it('click outside select in composition create modal doesn’t close modal', () => {
+    cy.startup(mockStartupParams);
+    cy.get('[data-testid="button-configure"]').should('be.visible')
+    cy.receiveSetTokens({
+      version: '5',
+      values: {
+        options: [{
+          name: 'sizing.xs',
+          value: 4,
+          type: 'sizing'
+        }, {
+          name: 'opacity.30',
+          value: '30%',
+          type: 'opacity'
+        }, {
+          name: 'font-size.4',
+          value: '4px',
+          type: 'fontSizes'
+        }],
+        global: [{
+          name: 'sizing.xs',
+          value: 4,
+          type: 'sizing'
+        }],
+      },
+    });
+    cy.get('[data-testid=tokenlisting-composition] [data-testid=button-add-new-token]').click();
+
+    fillInput({
+      input: 'name',
+      value: 'compositionToken',
+    });
+
+    cy.get('[data-testid="composition-token-dropdown"]').click();
+
+    cy.get('span:contains("minWidth")').parent().should('be.visible');
+    cy.get('span:contains("minWidth")').parent().click();
+    cy.get('[data-testid="composition-token-dropdown"]').click();
+    
+
+    cy.get('body').type('{esc}');
+
+    cy.get('span:contains("darken")').should('not.exist');
+    cy.get('[data-testid="composition-token-dropdown"]').should('be.visible');
+
+    fillInputNth({
+      input: 'value',
+      value: '#000000',
+      nth: 0,
       submit: true,
     });
     cy.get('@postMessage').should('be.calledThrice');

--- a/packages/tokens-studio-for-figma/src/app/components/ColorTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ColorTokenForm.tsx
@@ -265,7 +265,7 @@ export default function ColorTokenForm({
             }}
             >
               <Select data-testid="colortokenform-operation-selector" value={internalEditToken?.$extensions?.['studio.tokens']?.modify?.type || 'Choose an operation'} onValueChange={onOperationSelected}>
-                <Select.Trigger label="Operation" value={internalEditToken?.$extensions?.['studio.tokens']?.modify?.type || 'Choose an operation'} />
+                <Select.Trigger data-testid="colortokenform-operation-button" label="Operation" value={internalEditToken?.$extensions?.['studio.tokens']?.modify?.type || 'Choose an operation'} />
                 <Select.Content>
                   {Object.values(ColorModifierTypes).map((operation, index) => <Select.Item key={`operation-${seed(index)}`} value={operation}>{operation}</Select.Item>)}
                 </Select.Content>

--- a/packages/tokens-studio-for-figma/src/app/components/ConfirmDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ConfirmDialog.tsx
@@ -31,7 +31,9 @@ const ChoiceCheckbox: React.FC<React.PropsWithChildren<React.PropsWithChildren<{
 function ConfirmDialog() {
   const confirmButton = React.useRef<HTMLButtonElement | null>(null);
   const firstInput = React.useRef<HTMLInputElement | null>(null);
-  const { onConfirm, onCancel, confirmState } = useConfirm();
+  const {
+    onConfirm, onCancel, confirmState,
+  } = useConfirm();
   const [chosen, setChosen] = React.useState<string[]>([]);
   const [inputValue, setInputValue] = React.useState('');
 
@@ -86,7 +88,7 @@ function ConfirmDialog() {
 
   return confirmState.show ? (
     <Modal isOpen close={onCancel} title={confirmState?.text && confirmState.text}>
-      <form onSubmit={handleConfirm}>
+      <form id={confirmState.formId} onSubmit={handleConfirm}>
         <Stack direction="column" justify="start" gap={4}>
           <Stack direction="column" gap={4}>
             {confirmState?.description && (

--- a/packages/tokens-studio-for-figma/src/app/components/Footer.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Footer.tsx
@@ -173,6 +173,7 @@ export default function Footer() {
             <IconButton
               onClick={handleResolveDuplicateOpen}
               icon={<WarningTriangleSolid />}
+              data-testid="resolve-duplicate-modal-open-button"
               variant="invisible"
               size="small"
               tooltip="Duplicate Warning"

--- a/packages/tokens-studio-for-figma/src/app/hooks/useConfirm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useConfirm.tsx
@@ -26,6 +26,7 @@ function useConfirm<C = any>() {
       choices,
       input,
       variant,
+      formId,
     } = opts;
 
     dispatch.uiState.setShowConfirm({
@@ -36,6 +37,7 @@ function useConfirm<C = any>() {
       text: text ?? '',
       choices: choices ?? [],
       variant,
+      formId,
     });
 
     return new Promise<ResolveCallbackPayload<C>>((res) => {

--- a/packages/tokens-studio-for-figma/src/app/store/models/uiState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/uiState.tsx
@@ -32,6 +32,7 @@ export type ConfirmProps = {
     type: 'text';
     placeholder: string;
   };
+  formId?: string;
 };
 
 export type AddJobTasksPayload = {
@@ -175,6 +176,7 @@ export const uiState = createModel<RootModel>()({
           type: 'text';
           placeholder: string;
         };
+        formId?: string;
       },
     ) => ({
       ...state,
@@ -187,6 +189,7 @@ export const uiState = createModel<RootModel>()({
         cancelAction: data.cancelAction || defaultConfirmState.cancelAction,
         input: data.input,
         variant: data.variant,
+        formId: data.formId,
       },
     }),
     setSelectedLayers: (state, data: number) => ({

--- a/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
@@ -178,6 +178,7 @@ export default function useManageTokens() {
 
   const deleteDuplicates = useCallback(async (duplicates: { set: string, path: string, index: number }[]) => {
     const userConfirmation = await confirm({
+      formId: 'confirmDeleteDuplicates',
       text: 'Delete duplicate tokens?',
       description: 'Are you sure you want to delete duplicate tokens, keeping only the selected ones?',
       variant: 'danger',


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Test for #2885  <!-- link the related issue -->
Test for #2779 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

- Adds Cypress test for clicking outside Select (to verify this bug isn't reintroduced)
- Cypress test for resolving duplicate modal
- Fixes GitHub CI workflow action for test coverage

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

```sh
cd packages/tokens-studio-for-figma
yarn build:cy
yarn serve
yarn cy:run
```

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
