### PR TITLE
fix: update token changes on variable import

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
@@ -18,6 +18,7 @@ const getDefaultStore = () => ({
     tokens: {
       global: [
         {
+          $extensions: { 'studio.tokens': {} },
           name: 'light',
           type: 'typography',
           value: {
@@ -71,6 +72,7 @@ const getDefaultStore = () => ({
           },
         },
         {
+          $extensions: { 'studio.tokens': {} },
           name: 'opacity.50',
           type: 'opacity',
           value: '30%',
@@ -124,6 +126,7 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -139,9 +142,7 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              'studio.tokens': {
-                id: 'mock-uuid',
-              },
+              'studio.tokens': { id: 'mock-uuid' },
             },
             name: 'small',
             type: 'sizing',
@@ -168,6 +169,7 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -177,17 +179,24 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '50%',
           },
           {
+            $extensions: {
+              'studio.tokens': { id: 'mock-uuid' },
+            },
             name: 'small',
             type: 'sizing',
             value: '12',
             description: 'regular sizing token',
           },
           {
+            $extensions: {
+              'studio.tokens': { id: 'mock-uuid' },
+            },
             name: 'black',
             type: 'color',
             value: '#ffffff',
@@ -230,6 +239,7 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -239,15 +249,14 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '50%',
           },
           {
             $extensions: {
-              'studio.tokens': {
-                id: 'mock-uuid',
-              },
+              'studio.tokens': { id: 'mock-uuid' },
             },
             name: 'black',
             type: 'color',
@@ -256,9 +265,7 @@ describe('ImportedTokensDialog', () => {
           },
           {
             $extensions: {
-              'studio.tokens': {
-                id: 'mock-uuid',
-              },
+              'studio.tokens': { id: 'mock-uuid' },
             },
             name: 'headline',
             type: 'boxShadow',
@@ -293,7 +300,7 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: {},
+            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -303,6 +310,7 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '50%',
@@ -329,7 +337,7 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: {},
+            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -339,7 +347,7 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
-            $extensions: {},
+            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '30%',
@@ -370,6 +378,7 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -379,6 +388,7 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '30%',
@@ -403,6 +413,7 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -412,23 +423,27 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
+            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '30%',
           },
           {
+            $extensions: { 'studio.tokens': { id: 'mock-uuid' } },
             name: 'small',
             type: 'sizing',
             value: '12',
             description: 'regular sizing token',
           },
           {
+            $extensions: { 'studio.tokens': { id: 'mock-uuid' } },
             name: 'black',
             type: 'color',
             value: '#ffffff',
             description: 'regular color token',
           },
           {
+            $extensions: { 'studio.tokens': { id: 'mock-uuid' } },
             name: 'headline',
             type: 'boxShadow',
             value: {

--- a/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { IconButton, Button, Heading } from '@tokens-studio/ui';
+import { IconButton, Button } from '@tokens-studio/ui';
 import Modal from './Modal';
 import { Dispatch } from '../store';
 import useManageTokens from '../store/useManageTokens';
@@ -12,7 +12,6 @@ import TrashIcon from '@/icons/trash.svg';
 import Box from './Box';
 import { ImportToken } from '@/types/tokens';
 import Text from './Text';
-import { UpdateTokenPayload } from '@/types/payloads';
 import Accordion from './Accordion';
 import { Count } from './Count';
 
@@ -114,23 +113,60 @@ export default function ImportedTokensDialog() {
   }, [setNewTokens, newTokens]);
 
   const handleCreateAllClick = React.useCallback(() => {
+    const multipleNewTokens = newTokens.map((token) => ({
+      parent: token.parent || activeTokenSet,
+      name: token.name,
+      value: token.value,
+      type: token.type,
+      description: token.description,
+      shouldUpdateDocument: false,
+    }));
+
     // Create new Tokens
-    importMultipleTokens(newTokens as UpdateTokenPayload[]);
+    importMultipleTokens({ multipleNewTokens });
     setNewTokens([]);
-  }, [newTokens, importMultipleTokens]);
+  }, [activeTokenSet, importMultipleTokens, newTokens]);
 
   const handleUpdateAllClick = React.useCallback(() => {
+    const multipleUpdatedTokens = updatedTokens.map((token) => ({
+      parent: token.parent || activeTokenSet,
+      name: token.name,
+      value: token.value,
+      type: token.type,
+      description: token.description,
+      shouldUpdateDocument: false,
+    }));
+
     // Update all existing tokens
-    importMultipleTokens(updatedTokens as UpdateTokenPayload[]);
+    importMultipleTokens({ multipleUpdatedTokens });
     setUpdatedTokens([]);
-  }, [updatedTokens, importMultipleTokens]);
+  }, [updatedTokens, importMultipleTokens, activeTokenSet]);
 
   const handleImportAllClick = React.useCallback(() => {
+    const multipleUpdatedTokens = updatedTokens.map((token) => ({
+      parent: token.parent || activeTokenSet,
+      name: token.name,
+      value: token.value,
+      type: token.type,
+      description: token.description,
+      shouldUpdateDocument: false,
+    }));
+
+    const multipleNewTokens = newTokens.map((token) => ({
+      parent: token.parent || activeTokenSet,
+      name: token.name,
+      value: token.value,
+      type: token.type,
+      description: token.description,
+      shouldUpdateDocument: false,
+    }));
+
     // Update all existing tokens, and create new ones
-    importMultipleTokens([...newTokens, ...updatedTokens] as UpdateTokenPayload[]);
+    importMultipleTokens({ multipleUpdatedTokens, multipleNewTokens });
+
     setUpdatedTokens([]);
     setNewTokens([]);
-  }, [importMultipleTokens, newTokens, updatedTokens]);
+  }, [activeTokenSet, importMultipleTokens, newTokens, updatedTokens]);
 
   const handleCreateSingleClick = React.useCallback((token: any) => {
     // Create new tokens according to styles

--- a/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
@@ -231,11 +231,28 @@ export default function useManageTokens() {
     });
   }, [renameTokenAcrossSets]);
 
-  const importMultipleTokens = useCallback(async (data: UpdateTokenPayload[]) => {
+  const importMultipleTokens = useCallback(async ({ multipleUpdatedTokens, multipleNewTokens }: { multipleUpdatedTokens?: EditSingleTokenData[], multipleNewTokens?: CreateSingleTokenData[] }) => {
     dispatch.uiState.startJob({ name: BackgroundJobs.UI_RENAME_TOKEN_ACROSS_SETS, isInfinite: true });
-    dispatch.tokenState.importMultipleTokens(data);
+
+    const hasUpdatedTokens = multipleUpdatedTokens && multipleUpdatedTokens.length > 0;
+    const hasNewTokens = multipleNewTokens && multipleNewTokens.length > 0;
+
+    if (hasUpdatedTokens) {
+      multipleUpdatedTokens.forEach((t) => {
+        editSingleToken(t);
+      });
+    }
+
+    if (hasNewTokens) {
+      if (multipleNewTokens) {
+        multipleNewTokens.forEach((t) => {
+          createSingleToken(t);
+        });
+      }
+    }
+
     dispatch.uiState.completeJob(BackgroundJobs.UI_RENAME_TOKEN_ACROSS_SETS);
-  }, [dispatch.uiState, dispatch.tokenState]);
+  }, [dispatch.uiState, createSingleToken, editSingleToken]);
 
   return useMemo(() => ({
     editSingleToken, createSingleToken, deleteSingleToken, deleteGroup, duplicateSingleToken, renameGroup, duplicateGroup, renameTokensAcrossSets, importMultipleTokens, deleteDuplicates,


### PR DESCRIPTION
### Why does this PR exist?

Closes [#2529](https://github.com/tokens-studio/figma-plugin/issues/2529)

Updating a variable value in Figma was not reflected in the plugin until views were changed. This ensures tokens updated are immediatly reflected when importing variables.

### What does this pull request do?
* The method `importMultipleTokens` within the `useManageTokens` hook, now uses the sibling methods of `editSingleToken` & `createSingleToken` to dispatch update actions
* `ImportedTokensDialog` updates the payload sent to `importMultipleTokens` in order to update tokens correctly
* Cleans up unused assets in relevant files

### Testing this change

🎨 [Simple Figma file](https://www.figma.com/design/J6EJHGZ8UxlQhTbhaPOJbX/Import-variables-update?node-id=0-1&t=T9WFrm7lYgUk5XSI-1)

1. Create a local variable in Figma. In this example: `test-color: #F0B0B0`
2. Open the plugin. Click on **Styles & Variables** ---> **Import Variables** (don't tick any options) ---> Click  **Import**
3. See the **Imported** modal with changes. Click **Import all**. 
4. See the token updated in the **Tokens** tab

https://github.com/tokens-studio/figma-plugin/assets/114073780/e01967c3-428f-4947-a1d5-92639c226d5c

#### Scenarios

1. Update Figma variable
2. Follow steps as above to **Import Variables**
3. See changes!

| Before | After | Expectation | 
| ----- | ----- | ----- | 
Give the variable a new value of `#B0F0E4`. Updated value is instantly visible in the token. | Variable value update is instantly visible in the token  ✅ | 👈 [This](https://github.com/tokens-studio/figma-plugin/issues/2529) ✨ 
Rename the variable to `test-color-new`. A new token name <> value is created. | 👈 Same | ❓  | 
Delete the variable. No changes in the token. | 👈 Same | ❓ | 