### PR TITLE
fix local variable references normalization

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/getThemeReferences.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/getThemeReferences.test.ts
@@ -1,0 +1,111 @@
+import { AsyncMessageChannel } from '@/AsyncMessageChannel';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import { defaultTokenValueRetriever } from '../../TokenValueRetriever';
+import { getThemeReferences } from '../getThemeReferences';
+
+jest.mock('@/AsyncMessageChannel', () => ({
+  AsyncMessageChannel: {
+    PluginInstance: {
+      message: jest.fn(() => Promise.resolve({
+        themes: [
+          {
+            id: 'theme1',
+            name: 'Theme 1',
+            $figmaVariableReferences: {
+              token1: 'variable1',
+            },
+            $figmaStyleReferences: {
+              token2: 'style1',
+            },
+            selectedTokenSets: {
+              set1: 'enabled',
+            },
+          },
+        ],
+        activeTheme: {
+          set1: 'theme1',
+        },
+      })),
+    },
+  },
+}));
+jest.mock('../../TokenValueRetriever');
+
+describe('getThemeReferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should clear the cache of defaultTokenValueRetriever', async () => {
+    await getThemeReferences();
+    expect(defaultTokenValueRetriever.clearCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call AsyncMessageChannel.PluginInstance.message with GET_THEME_INFO type', async () => {
+    await getThemeReferences();
+    expect(AsyncMessageChannel.PluginInstance.message).toHaveBeenCalledWith({
+      type: AsyncMessageTypes.GET_THEME_INFO,
+    });
+  });
+
+  it('should return the expected result', async () => {
+    const result = await getThemeReferences();
+
+    expect(result).toEqual({
+      figmaStyleReferences: new Map([['token2', 'style1']]),
+      figmaVariableReferences: new Map([['token1', 'variable1']]),
+    });
+  });
+
+  it('should merge variable references with local references', async () => {
+    const localVariables = [
+      {
+        name: 'local/variable1',
+        key: 'localVariable1',
+      },
+    ];
+    const localPaintStyles = [
+      {
+        id: 'style2',
+        name: 'local/style2',
+      },
+    ];
+    jest.spyOn(figma.variables, 'getLocalVariablesAsync').mockResolvedValue(localVariables);
+    jest.spyOn(figma, 'getLocalPaintStyles').mockReturnValue(localPaintStyles);
+
+    const result = await getThemeReferences();
+
+    expect(result).toEqual({
+      figmaStyleReferences: new Map([
+        ['token2', 'style1'],
+        ['local.style2', 'style2'],
+      ]),
+      figmaVariableReferences: new Map([
+        ['token1', 'variable1'],
+        ['local.variable1', 'localVariable1'],
+      ]),
+    });
+  });
+
+  it('should respect theme variable references when conflicting with local', async () => {
+    const localVariables = [
+      {
+        name: 'token1',
+        key: 'variableX',
+      },
+    ];
+    jest.spyOn(figma.variables, 'getLocalVariablesAsync').mockResolvedValue(localVariables);
+
+    const result = await getThemeReferences();
+
+    expect(result).toEqual({
+      figmaStyleReferences: new Map([
+        ['token2', 'style1'],
+        ['local.style2', 'style2'],
+      ]),
+      figmaVariableReferences: new Map([
+        ['token1', 'variable1'],
+      ]),
+    });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/getThemeReferences.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/getThemeReferences.ts
@@ -51,8 +51,8 @@ export async function getThemeReferences(prefixStylesWithThemeName?: boolean) {
   const localVariables = await figma.variables.getLocalVariablesAsync();
 
   localVariables.forEach((variable) => {
-    if (!figmaVariableReferences.has(variable.name)) {
-      const normalizedVariableName = variable.name.split('/').join('.'); // adjusting variable name to match the token name
+    const normalizedVariableName = variable.name.split('/').join('.'); // adjusting variable name to match the token name
+    if (!figmaVariableReferences.has(normalizedVariableName)) {
       figmaVariableReferences.set(normalizedVariableName, variable.key);
     }
   });


### PR DESCRIPTION
### Why does this PR exist?
Fixes https://github.com/tokens-studio/figma-plugin/issues/2987

### What does this pull request do?

Fixes the name normalization as it was performed too late and not before we actually made the comparison.

Also added a test to ensure this doesnt happen

### Testing this change

Create a setup as described or take this .fig and try to theme switch before and after
[theme-switch-bug.fig.zip](https://github.com/user-attachments/files/16168421/theme-switch-bug.fig.zip)

### Additional Notes (if any)

#### Before

https://github.com/user-attachments/assets/49d6650e-d6e1-4863-b405-a115719784df



#### After

https://github.com/user-attachments/assets/6efe54e6-ba64-4b01-92c0-7fda87b5db4f

