### PR TITLE
Revert github pull to large modal with css fixes

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ChangedStateList.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ChangedStateList.tsx
@@ -31,7 +31,7 @@ function ChangedStateList() {
   return (
     <Stack direction="column" gap={1} css={{ padding: '$4' }}>
       {Object.entries(changedState.tokens).length > 0 && Object.entries(changedState.tokens)?.map(([tokenSet, tokenList]) => (
-        <Box key={tokenSet}>
+        <Box key={tokenSet} css={{ maxWidth: '100%' }}>
           <ChangeStateListingHeading count={tokenList.length} onCollapse={handleSetIntCollapsed} set={tokenSet} label={tokenSet} isCollapsed={collapsedChangedStateList.includes(tokenSet)} />
           {!collapsedChangedStateList.includes(tokenSet) && tokenList && (
             tokenList.map((token) => (

--- a/packages/tokens-studio-for-figma/src/app/components/ChangedTokenItem.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ChangedTokenItem.tsx
@@ -15,12 +15,12 @@ export default function ChangedTokenItem({
   return (
     <Stack direction="row" justify="between" css={{ padding: '$2 0' }}>
       <Stack direction={token.importType === 'REMOVE' ? 'row' : 'column'} gap={1} justify="between" css={{ width: '100%' }}>
-        <Text bold size="small">{token.name}</Text>
+        <Text bold size="small" css={{ wordBreak: 'break-word' }}>{token.name}</Text>
         {
           ((token.importType === 'UPDATE' && token.oldValue) || token.importType === 'NEW') && (
             <Stack direction="row" align="center" justify="between" gap={3}>
               <Text size="small">{t('value')}</Text>
-              <Stack direction="row" align="center" gap={1}>
+              <Stack direction="row" align="center" gap={1} css={{ maxWidth: '60%' }}>
                 {token.oldValue ? (
                   <StyledDiff type="danger">
                     {typeof token.oldValue === 'object' ? JSON.stringify(token.oldValue) : token.oldValue}
@@ -36,7 +36,7 @@ export default function ChangedTokenItem({
         {((token.importType === 'UPDATE' && token.oldDescription) || (token.importType === 'NEW' && token.description)) && (
         <Stack direction="row" align="start" justify="between" gap={1}>
           <Text size="small">{t('description')}</Text>
-          <Stack direction="column" align="end" gap={1}>
+          <Stack direction="column" align="end" gap={1} css={{ maxWidth: '60%' }}>
             {token.oldDescription ? (
               <StyledDiff type="danger">
                 {token.oldDescription}

--- a/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
@@ -32,7 +32,7 @@ function PullDialog() {
           title={t('pullFrom', { provider: transformProviderName(storageType.provider) })}
           showClose
           full
-          size="fullscreen"
+          size="large"
           isOpen
           close={onCancel}
           stickyFooter


### PR DESCRIPTION
### Why does this PR exist?

Fixes #2980 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

- Reverts GitHub pull modal to `large` instead of `fullscreen`
- Fixes some CSS issues (width overflow and word break), related to less available screen real estate

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Setup a GitHub repo
- Sync tokens to the GitHub repo
- Make changes (i.e. rename the set names)
- Click the `Pull From GitHub` button in the bottom footer bar

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<img width="546" alt="image" src="https://github.com/user-attachments/assets/bc18b7fb-17ef-4ad4-ab3c-884117302c95">

<img width="546" alt="image" src="https://github.com/user-attachments/assets/1ee55783-8ddf-4ab5-96aa-d8649e30492d">

<img width="547" alt="image" src="https://github.com/user-attachments/assets/8d058bad-57c5-4561-b33b-60ea17236d46">



<!--
  Add any other context or screenshots about the pull request
-->
