### PR TITLE
chore: remove style setting on node warning

### DIFF
--- a/packages/tokens-studio-for-figma/src/utils/tryApplyVariableId.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tryApplyVariableId.test.ts
@@ -17,6 +17,14 @@ describe('tryApplyVariableId', () => {
       },
     },
   } as unknown as SceneNode;
+  const mockVariable = {
+    id: 'VariableID:519:32875',
+    key: '12345',
+    variableCollectionId: 'VariableCollectionId:12:12345',
+    name: 'token',
+    value: '8',
+    resolveForConsumer: mockResolveForConsumer,
+  };
 
   afterEach(() => {
     defaultTokenValueRetriever.clearCache();
@@ -39,14 +47,6 @@ describe('tryApplyVariableId', () => {
   });
 
   it('when there is a matching variable, should try to apply variable', async () => {
-    const mockVariable = {
-      id: 'VariableID:519:32875',
-      key: '12345',
-      variableCollectionId: 'VariableCollectionId:12:12345',
-      name: 'token',
-      value: '8',
-      resolveForConsumer: mockResolveForConsumer,
-    };
     mockImportVariableByKeyAsync.mockImplementationOnce(() => mockVariable);
     mockResolveForConsumer.mockImplementationOnce(() => mockVariable);
     const variableReferences = new Map();
@@ -56,6 +56,6 @@ describe('tryApplyVariableId', () => {
     });
     expect(await tryApplyVariableId(node, 'width', 'token')).toBe(true);
     expect(mockImportVariableByKeyAsync).toBeCalledWith('VariableID:519:32875');
-    expect(mockSetBoundVariable).toBeCalledWith('width', 'VariableID:519:32875');
+    expect(mockSetBoundVariable).toBeCalledWith('width', mockVariable);
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/tryApplyVariableId.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tryApplyVariableId.ts
@@ -9,7 +9,7 @@ export async function tryApplyVariableId(node: SceneNode, type: VariableBindable
 
   if (variable && type in node) {
     try {
-      node.setBoundVariable(type, variable.id);
+      node.setBoundVariable(type, variable);
       if (node.boundVariables?.[type] !== undefined) {
         const valueOnVariable = variable.resolveForConsumer(node).value;
         const valueOnNode = node[type as keyof typeof node];


### PR DESCRIPTION
### Why does this PR exist?

N/A - discovered while testing [#2991](https://github.com/tokens-studio/figma-plugin/issues/2991)

Removes warning messages when applying styling to nodes:
> Calling setBoundVariable with a variable id is deprecated. Please pass the variable node instead.

### What does this pull request do?

Passes an instance of the **variable** instead of a variable **id** to the `setBoundVariable()` method.

See Figma Plugin API update docs: https://www.figma.com/plugin-docs/updates/page/2/#methodproperty-usage-changes

### Testing this change

* Open the plugin 
* Apply any styling to nodes
* See there are no warnings on the console!
