### PR TITLE
Fix manage themes padding

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/SingleThemeEntry.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageThemesModal/SingleThemeEntry.tsx
@@ -83,6 +83,7 @@ export const SingleThemeEntry: React.FC<React.PropsWithChildren<React.PropsWithC
         gridTemplateColumns: 'min-content auto repeat(3, max-content) min-content',
         alignItems: 'center',
         gridGap: '$2',
+        flex: 1,
       }}
     >
 

--- a/packages/tokens-studio-for-figma/src/app/components/StyledDragger/DragItem.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StyledDragger/DragItem.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import { useDragControls, useMotionValue } from 'framer-motion';
+import { Stack } from '@tokens-studio/ui';
 import { useSelector } from 'react-redux';
+
 import { editProhibitedSelector } from '@/selectors';
 import { DragControlsContext } from '@/context';
 import { ReorderItem } from '@/motion/ReorderItem';
@@ -30,5 +32,9 @@ export function DragItem<T>({ item, children }: Props<T>) {
         </ReorderItem>
       </DragControlsContext.Provider>
     )
-    : React.createElement(React.Fragment, {}, children);
+    : (
+      <Stack direction="row">
+        {children}
+      </Stack>
+    );
 }


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Cloes #2981  <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- In `src/selectors/editProhibitedSelector.ts`, replace `(state) => state.editProhibited` with `() => true`
- Open the `Manage Themes` modal
- Verify that there is padding

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

**Before**

![before](https://github.com/user-attachments/assets/2304f4e7-72d4-4f7e-b5a4-330a51eebd68)

**After**

<img width="544" alt="after" src="https://github.com/user-attachments/assets/f2aa9c2d-fb05-4cc3-a3d8-7e6e8e01c60a">


<!--
  Add any other context or screenshots about the pull request
-->
