### PR TITLE
fix: maintain set ordering on creation

### DIFF
--- a/packages/tokens-studio-for-figma/src/utils/tokenset/__tests__/findParentIndexToInsertSet.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenset/__tests__/findParentIndexToInsertSet.test.ts
@@ -1,0 +1,34 @@
+import type { AnyTokenList } from '@/types/tokens';
+import { findParentIndexToInsertSet } from '../findParentIndexToInsertSet';
+
+describe('findParentIndexToInsertSet', () => {
+  const CURRENT_SETS = [
+    ['base', [{ value: 'Inter', type: 'fontFamilies', name: 'Fam' }]],
+    ['red-brand', [{ value: '#ffff00', type: 'color', name: 'base-red' }]],
+    ['yellow-brand', [{ value: '#ff0000', type: 'color', name: 'base-yellow' }]],
+  ];
+
+  it('should insert a set at the end if it cannot find any related parent', () => {
+    const setToInsert = 'last-set';
+    const result = findParentIndexToInsertSet(CURRENT_SETS as [string, AnyTokenList][], setToInsert);
+    expect(result).toBe(CURRENT_SETS.length);
+  });
+
+  it('should insert a 1 layer nested set next to its parent', () => {
+    const setToInsert = 'base/light';
+    const result = findParentIndexToInsertSet(CURRENT_SETS as [string, AnyTokenList][], setToInsert);
+    expect(result).toBe(0);
+  });
+
+  it('should insert a 2 layer nested set next to its parent', () => {
+    const setToInsert = 'red-brand/light/mobile';
+    const result = findParentIndexToInsertSet(CURRENT_SETS as [string, AnyTokenList][], setToInsert);
+    expect(result).toBe(1);
+  });
+
+  it('should insert a 3 layer nested set next to its parent', () => {
+    const setToInsert = 'yellow-brand/light/mobile/ios';
+    const result = findParentIndexToInsertSet(CURRENT_SETS as [string, AnyTokenList][], setToInsert);
+    expect(result).toBe(CURRENT_SETS.length - 1);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/tokenset/__tests__/updateTokenSetsInState.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenset/__tests__/updateTokenSetsInState.test.ts
@@ -32,7 +32,7 @@ describe('updateTokenSetsInState', () => {
     } as unknown as TokenState;
   });
 
-  it('can delete token sets and update the state appropriately', () => {
+  it('should delete token sets and update the state appropriately', () => {
     const nextState = updateTokenSetsInState(
       defaultTokenState,
       (name, tokenList) => {
@@ -63,7 +63,7 @@ describe('updateTokenSetsInState', () => {
     });
   });
 
-  it('can rename token sets and update the state appropriately', () => {
+  it('should rename token sets and update the state appropriately', () => {
     const nextState = updateTokenSetsInState(
       defaultTokenState,
       (name, tokenList) => {
@@ -97,7 +97,7 @@ describe('updateTokenSetsInState', () => {
     });
   });
 
-  it('re-sets the activeTokenSet when no token sets are left', () => {
+  it('should reset the activeTokenSet when no token sets are left', () => {
     const nextState = updateTokenSetsInState(
       defaultTokenState,
       () => null,
@@ -119,7 +119,7 @@ describe('updateTokenSetsInState', () => {
     });
   });
 
-  it('can add new tokenSets', () => {
+  it('should add a copied token set next to its origin', () => {
     const nextState = updateTokenSetsInState(
       {
         tokens: {
@@ -140,17 +140,69 @@ describe('updateTokenSetsInState', () => {
         ],
       } as unknown as TokenState,
       null,
-      ['dark'],
+      ['global_Copy', [], 1],
     );
 
     expect(nextState).toEqual({
       tokens: {
         global: [],
+        global_Copy: [],
+      },
+      activeTokenSet: 'global',
+      usedTokenSet: {
+        global: TokenSetStatus.ENABLED,
+        global_Copy: TokenSetStatus.DISABLED,
+      },
+      themes: [
+        {
+          id: 'dark',
+          name: 'Dark',
+          selectedTokenSets: {
+            global: TokenSetStatus.ENABLED,
+            global_Copy: TokenSetStatus.DISABLED,
+          },
+        },
+      ],
+    });
+  });
+
+  it('should add new token set next to its parent, if nested', () => {
+    const nextState = updateTokenSetsInState(
+      {
+        tokens: {
+          global: [],
+          dark: [],
+        },
+        activeTokenSet: 'global',
+        usedTokenSet: {
+          global: TokenSetStatus.ENABLED,
+          dark: TokenSetStatus.DISABLED,
+        },
+        themes: [
+          {
+            id: 'dark',
+            name: 'Dark',
+            selectedTokenSets: {
+              global: TokenSetStatus.ENABLED,
+              dark: TokenSetStatus.DISABLED,
+            },
+          },
+        ],
+      } as unknown as TokenState,
+      null,
+      ['global/light', []],
+    );
+
+    expect(nextState).toEqual({
+      tokens: {
+        global: [],
+        'global/light': [],
         dark: [],
       },
       activeTokenSet: 'global',
       usedTokenSet: {
         global: TokenSetStatus.ENABLED,
+        'global/light': TokenSetStatus.DISABLED,
         dark: TokenSetStatus.DISABLED,
       },
       themes: [
@@ -159,6 +211,7 @@ describe('updateTokenSetsInState', () => {
           name: 'Dark',
           selectedTokenSets: {
             global: TokenSetStatus.ENABLED,
+            'global/light': TokenSetStatus.DISABLED,
             dark: TokenSetStatus.DISABLED,
           },
         },

--- a/packages/tokens-studio-for-figma/src/utils/tokenset/findParentIndexToInsertSet.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenset/findParentIndexToInsertSet.ts
@@ -1,0 +1,20 @@
+import type { AnyTokenList } from '@/types/tokens';
+
+export function findParentIndexToInsertSet(currentSets: [string, AnyTokenList][], setToInsert: string) {
+  const matchedLocationToInsertSet = Object.values(currentSets).reduce((acc, val, index) => {
+    const parentSetPath = val[0].split('/');
+    const newSetPath = setToInsert.split('/');
+    const intersectionOfSets = parentSetPath.filter((value) => newSetPath.includes(value));
+    if (intersectionOfSets.length > 0) {
+      if (intersectionOfSets.length >= acc.matchLength) {
+        acc = {
+          insertAt: index,
+          matchLength: intersectionOfSets.length,
+        };
+      }
+    }
+    return acc;
+  }, { insertAt: currentSets.length, matchLength: 0 });
+
+  return matchedLocationToInsertSet.insertAt;
+}

--- a/packages/tokens-studio-for-figma/src/utils/tokenset/updateTokenSetsInState.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenset/updateTokenSetsInState.ts
@@ -3,6 +3,7 @@ import type { TokenState } from '@/app/store/models/tokenState';
 import type { AnyTokenList } from '@/types/tokens';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { tokenSetListToTree } from './tokenSetListToTree';
+import { findParentIndexToInsertSet } from './findParentIndexToInsertSet';
 
 export function updateTokenSetsInState(
   state: TokenState,
@@ -29,7 +30,7 @@ export function updateTokenSetsInState(
   }, []);
 
   newTokenSets.forEach((newSet) => {
-    const insertAt = newSet.length === 3 ? newSet[2] : entries.length;
+    const insertAt = newSet.length === 3 ? newSet[2] : findParentIndexToInsertSet(entries, newSet[0]);
     entries.splice(insertAt, 0, [newSet[0], newSet?.[1] ?? []]);
   });
 


### PR DESCRIPTION
### Why does this PR exist?

Closes [#3007](https://github.com/tokens-studio/figma-plugin/issues/3007#issue-2413515391) 

When creating a new set, even if nested, it was always placed at the end of list.

### What does this pull request do?
* Creates a `findParentIndexToInsertSet` helper, which takes in a list of sets and a set name, and returns the index where to insert the new set!
* Uses the helper in the `updateTokenSetsInState` method
* Create and update tests

### Testing this change
* Open the plugin and ensure you have some sets created, [set-ordering.zip](https://github.com/user-attachments/files/16286192/set-ordering.zip), for example:
```
- base
- yellow-brand
- red-brand
```
* Create a new nested set (1 layer) like `base/light` ---> Note how the set is **next** to `base`
* Create a new nested set (2 layers) like `yellow-brand/light/mobile`  ---> Note how the set is **next** to `yellow-brand`
* Create a new set like `final-set` ---> Note how it goes to the end of the list

https://github.com/user-attachments/assets/66359cd5-f7a5-4f9e-8ba6-c6b2a0a78915