### PR TITLE
fix: prevents duplicated format sensitive keys on tokens when pushing to remotes

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/createTokenObj.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/createTokenObj.test.tsx
@@ -1,29 +1,33 @@
-import { createTokensObject, transformName } from './createTokenObj';
+import { TokenTypes } from '@/constants/TokenTypes';
+import { createTokensObject, transformName, appendTypeToToken } from './createTokenObj';
 
 const baseTokens = {
   input: [
     {
-      id: '123', type: 'color', description: 'some color', name: 'global.colors.gray.500', value: '#ff0000',
+      id: '123', type: TokenTypes.COLOR, description: 'some color', name: 'global.colors.gray.500', value: '#ff0000',
     },
     {
-      id: '123', type: 'color', description: 'some color', name: 'global.colors.gray.400', value: '#ff0000',
+      id: '123', type: TokenTypes.COLOR, description: 'some color', name: 'global.colors.gray.400', value: '#ff0000',
     },
     {
       id: '123',
-      type: 'color',
+      type: TokenTypes.COLOR,
       description: 'some color',
       name: 'theme.colors.interaction.background.default',
       value: '#ff0000',
     },
     {
       id: '123',
-      type: 'color',
+      type: TokenTypes.COLOR,
       description: 'some color',
       name: 'global.colors.gray.50',
       value: '#ff0000',
     },
     {
-      id: '123', type: 'asset', description: 'some assets', name: 'global.assets.image', value: 'http://image.png',
+      id: '123', type: TokenTypes.ASSET, description: 'some assets', name: 'global.assets.image', value: 'http://image.png',
+    },
+    {
+      id: '123', type: TokenTypes.OTHER, description: 'some other components', name: 'components.button', value: '{composition.action.button}',
     },
   ],
   output: {
@@ -88,13 +92,24 @@ const baseTokens = {
         },
       },
     },
+    other: {
+      values: {
+        components: {
+          button: {
+            description: 'some other components',
+            id: '123',
+            name: 'components.button',
+            type: 'other',
+            value: '{composition.action.button}',
+          },
+        },
+      },
+    },
   },
 };
 
 describe('createTokenObj', () => {
-  it('creates a token object', () => {
-    expect(createTokensObject(baseTokens.input)).toEqual(baseTokens.output);
-  });
+  it('creates a token object', () => expect(createTokensObject(baseTokens.input)).toEqual(baseTokens.output));
 
   it('should transform name', () => {
     const tokenNames = [
@@ -178,9 +193,66 @@ describe('createTokenObj', () => {
         input: 'asset',
         output: 'asset',
       },
+      {
+        input: 'button',
+        output: 'other',
+      },
     ];
     tokenNames.forEach((tokenName) => {
       expect(transformName(tokenName.input)).toEqual(tokenName.output);
     });
+  });
+
+  it('should append type to token', () => {
+    const INPUT_TOKENS = [
+      {
+        id: '123',
+        description: 'some description',
+        name: 'global.colors.red',
+        value: '#ff0000',
+        type: TokenTypes.COLOR,
+      },
+      {
+        id: '123',
+        description: 'some description',
+        name: 'global.spacing.small',
+        value: '8px',
+        type: TokenTypes.SPACING,
+      },
+      {
+        id: '123',
+        description: 'some description',
+        name: 'global.fontSizes.medium',
+        value: '16px',
+        type: TokenTypes.FONT_SIZES,
+      },
+    ];
+
+    const RESULT_TOKENS = [
+      {
+        id: '123',
+        description: 'some description',
+        name: 'global.colors.red',
+        value: '#ff0000',
+        type: 'color',
+      },
+      {
+        id: '123',
+        description: 'some description',
+        name: 'global.spacing.small',
+        value: '8px',
+        type: 'spacing',
+      },
+      {
+        id: '123',
+        description: 'some description',
+        name: 'global.fontSizes.medium',
+        value: '16px',
+        type: 'fontSizes',
+      },
+    ];
+
+    const result = INPUT_TOKENS.map((token) => appendTypeToToken(token));
+    expect(result).toEqual(RESULT_TOKENS);
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/convertTokensToObject.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/convertTokensToObject.test.ts
@@ -1,54 +1,205 @@
 import convertTokensToObject from './convertTokensToObject';
+import { AnyTokenList } from '@/types/tokens';
+import { TokenFormatOptions, TokenFormat } from '@/plugin/TokenFormatStoreClass';
+
 import input from './test/github/input.json';
 import output from './test/github/output.json';
 
-describe('convertTokensToObject', () => {
-  it('converts array-like tokens to nested object', () => {
-    const tokens = {
-      options: [
-        {
-          name: 'colors.red',
-          type: 'color',
-          value: '#ff0000',
-        },
-        {
-          name: 'colors.blue',
-          value: '#0000ff',
-        },
-      ],
-      theme: [
-        {
-          name: 'colors.primary',
-          value: '$colors.red',
-        },
-      ],
-    };
+const INPUT_TOKENS = {
+  base: [
+    {
+      name: 'colors.red',
+      type: 'color',
+      value: '#ff0000',
+    },
+    {
+      name: 'colors.blue',
+      type: 'color',
+      value: '#0000ff',
+    },
+  ],
+  extras: [
+    {
+      name: 'dimensions.scale',
+      type: 'dimension',
+      value: '2',
+      description: 'We use this to scale things',
+    },
+    {
+      name: 'dimensions.xs',
+      type: 'dimension',
+      value: '4',
+    },
+  ],
+} as Record<string, AnyTokenList>;
 
-    expect(convertTokensToObject(tokens, true)).toEqual({
-      options: {
-        colors: {
-          red: {
-            value: '#ff0000',
-            type: 'color',
-          },
-          blue: {
-            value: '#0000ff',
-            type: 'color',
-          },
-        },
+const INPUT_TOKENS_WITH_INHERITED_TYPES = {
+  base: [
+    {
+      name: 'colors.red',
+      type: 'color',
+      value: '#ff0000',
+      inheritTypeLevel: 2,
+    },
+    {
+      name: 'colors.blue',
+      type: 'color',
+      value: '#0000ff',
+      inheritTypeLevel: 2,
+    },
+  ],
+  extras: [
+    {
+      name: 'dimensions.scale',
+      type: 'dimension',
+      value: '2',
+      description: 'We use this to scale things',
+      inheritTypeLevel: 2,
+    },
+    {
+      name: 'dimensions.xs',
+      type: 'dimension',
+      value: '4',
+      inheritTypeLevel: 2,
+    },
+  ],
+} as Record<string, AnyTokenList>;
+
+const OUTPUT_LEGACY_FORMAT_OBJECT = {
+  base: {
+    colors: {
+      red: {
+        type: 'color',
+        value: '#ff0000',
       },
-      theme: {
-        colors: {
-          primary: {
-            value: '$colors.red',
-            type: 'color',
-          },
-        },
+      blue: {
+        type: 'color',
+        value: '#0000ff',
       },
+    },
+  },
+  extras: {
+    dimensions: {
+      scale: {
+        type: 'dimension',
+        value: '2',
+        description: 'We use this to scale things',
+      },
+      xs: {
+        type: 'dimension',
+        value: '4',
+      },
+    },
+  },
+};
+
+const OUTPUT_LEGACY_FORMAT_OBJECT_WITH_INHERITED_TYPES = {
+  base: {
+    colors: {
+      red: {
+        value: '#ff0000',
+      },
+      blue: {
+        value: '#0000ff',
+      },
+      type: 'color',
+    },
+  },
+  extras: {
+    dimensions: {
+      scale: {
+        value: '2',
+        description: 'We use this to scale things',
+      },
+      xs: {
+        value: '4',
+      },
+      type: 'dimension',
+    },
+  },
+};
+
+const OUTPUT_DTCG_FORMAT_OBJECT = {
+  base: {
+    colors: {
+      red: {
+        $type: 'color',
+        $value: '#ff0000',
+      },
+      blue: {
+        $type: 'color',
+        $value: '#0000ff',
+      },
+    },
+  },
+  extras: {
+    dimensions: {
+      scale: {
+        $type: 'dimension',
+        $value: '2',
+        $description: 'We use this to scale things',
+      },
+      xs: {
+        $type: 'dimension',
+        $value: '4',
+      },
+    },
+  },
+};
+
+const OUTPUT_DTCG_FORMAT_OBJECT_WITH_INHERITED_TYPES = {
+  base: {
+    colors: {
+      red: {
+        $value: '#ff0000',
+      },
+      blue: {
+        $value: '#0000ff',
+      },
+      $type: 'color',
+    },
+  },
+  extras: {
+    dimensions: {
+      scale: {
+        $value: '2',
+        $description: 'We use this to scale things',
+      },
+      xs: {
+        $value: '4',
+      },
+      $type: 'dimension',
+    },
+  },
+};
+
+describe('convertTokensToObject', () => {
+  describe('when the format is set to legacy', () => {
+    it('should convert array-like tokens to a nested object', () => {
+      TokenFormat.setFormat(TokenFormatOptions.Legacy);
+      expect(convertTokensToObject(INPUT_TOKENS, true)).toEqual(OUTPUT_LEGACY_FORMAT_OBJECT);
+    });
+
+    it('should convert array-like tokens with inherited types to a nested object', () => {
+      TokenFormat.setFormat(TokenFormatOptions.Legacy);
+      expect(convertTokensToObject(INPUT_TOKENS_WITH_INHERITED_TYPES, true)).toEqual(OUTPUT_LEGACY_FORMAT_OBJECT_WITH_INHERITED_TYPES);
     });
   });
 
-  it('keeps input the same', () => {
-    expect(convertTokensToObject(output, true)).toEqual(input);
+  describe('when the format is set to DTCG', () => {
+    it('should convert array-like tokens to a nested object', () => {
+      TokenFormat.setFormat(TokenFormatOptions.DTCG);
+      expect(convertTokensToObject(INPUT_TOKENS, true)).toEqual(OUTPUT_DTCG_FORMAT_OBJECT);
+    });
+
+    it('should convert array-like tokens with inherited types to a nested object', () => {
+      TokenFormat.setFormat(TokenFormatOptions.DTCG);
+      expect(convertTokensToObject(INPUT_TOKENS_WITH_INHERITED_TYPES, true)).toEqual(OUTPUT_DTCG_FORMAT_OBJECT_WITH_INHERITED_TYPES);
+    });
+  });
+
+  it('should maintain the output values the same as the input, if there are no format changes', () => {
+    TokenFormat.setFormat(TokenFormatOptions.Legacy);
+    expect(convertTokensToObject(output as unknown as Record<string, AnyTokenList>, true)).toEqual(input);
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/setTokenKey.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/setTokenKey.test.ts
@@ -1,0 +1,52 @@
+import {
+  setTokenKey, FormatSensitiveTokenKeys, SingleTokenWithoutName,
+} from '@/utils/setTokenKey';
+import { TokenFormatOptions, TokenFormat } from '@/plugin/TokenFormatStoreClass';
+
+describe('setTokenKey', () => {
+  const KEY_VALUES = Object.values(FormatSensitiveTokenKeys);
+  const LEGACY_TOKEN_FORMAT = { value: '#FFFFFF', type: 'color' } as SingleTokenWithoutName;
+  const DTCG_TOKEN_FORMAT = { $value: '#FFFFFF', $type: 'color' } as unknown as SingleTokenWithoutName;
+
+  describe('when the format is set to legacy', () => {
+    it('should update the keys given the token is DTCG', () => {
+      TokenFormat.setFormat(TokenFormatOptions.Legacy);
+
+      const input = { ...DTCG_TOKEN_FORMAT };
+      KEY_VALUES.forEach((v) => setTokenKey(input, v));
+
+      expect(input).toEqual(LEGACY_TOKEN_FORMAT);
+    });
+
+    it('should not update the keys when the input token is DTCG and it does not have the given key', () => {
+      TokenFormat.setFormat(TokenFormatOptions.Legacy);
+
+      const input = { ...LEGACY_TOKEN_FORMAT };
+      const originalInput = { ...input };
+      setTokenKey(input, FormatSensitiveTokenKeys.DESCRIPTION);
+
+      expect(input).toEqual(originalInput);
+    });
+  });
+
+  describe('when the format is set to DTCG', () => {
+    it('should update the keys given the token is legacy', () => {
+      TokenFormat.setFormat(TokenFormatOptions.DTCG);
+
+      const input = { ...LEGACY_TOKEN_FORMAT };
+      KEY_VALUES.forEach((v) => setTokenKey(input, v));
+
+      expect(input).toEqual(DTCG_TOKEN_FORMAT);
+    });
+
+    it('should not update the keys if the given legacy token does not have the key', () => {
+      TokenFormat.setFormat(TokenFormatOptions.DTCG);
+
+      const input = { ...DTCG_TOKEN_FORMAT };
+      const originalInput = { ...input };
+      setTokenKey(input, FormatSensitiveTokenKeys.DESCRIPTION);
+
+      expect(input).toEqual(originalInput);
+    });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/setTokenKey.ts
+++ b/packages/tokens-studio-for-figma/src/utils/setTokenKey.ts
@@ -1,0 +1,30 @@
+import { SingleToken } from '@/types/tokens';
+import { TokenFormat, TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
+
+export type SingleTokenWithoutName = Omit<SingleToken, 'name'>;
+export type SingleTokenWithoutType = Omit<SingleToken, 'type'>;
+
+export enum FormatSensitiveTokenKeys {
+  TYPE = 'type',
+  VALUE = 'value',
+  DESCRIPTION = 'description',
+}
+
+export function setTokenKey(token: SingleTokenWithoutName | SingleTokenWithoutNameOrType, keyName: FormatSensitiveTokenKeys): SingleTokenWithoutName | SingleTokenWithoutNameOrType {
+  const isDTCG = TokenFormat.format === TokenFormatOptions.DTCG;
+
+  if (isDTCG) {
+    token[`$${keyName}`] = token[keyName];
+    if (token.hasOwnProperty(keyName)) {
+      delete token[keyName];
+    }
+  } else {
+    const tempValue = token[`$${keyName}`] || token[keyName];
+    token[keyName] = tempValue;
+    if (token.hasOwnProperty(`$${keyName}`)) {
+      delete token[`$${keyName}`];
+    }
+  }
+
+  return token;
+}

--- a/packages/tokens-studio-for-figma/src/utils/setTokenKey.ts
+++ b/packages/tokens-studio-for-figma/src/utils/setTokenKey.ts
@@ -2,7 +2,7 @@ import { SingleToken } from '@/types/tokens';
 import { TokenFormat, TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
 
 export type SingleTokenWithoutName = Omit<SingleToken, 'name'>;
-export type SingleTokenWithoutType = Omit<SingleToken, 'type'>;
+export type SingleTokenWithoutNameOrType = Omit<SingleToken, 'name' | 'type'>;
 
 export enum FormatSensitiveTokenKeys {
   TYPE = 'type',


### PR DESCRIPTION
### Why does this PR exist?

Closes [#3017](https://github.com/tokens-studio/figma-plugin/issues/3017#issue-2424807255)

Switching between legacy and W3C DTCG format would wrongly push duplicated keys on the remotes 
(i.e. `type: 'color'` and `$type: 'color'`) causing issues on tokens when using them.

### What does this pull request do?
* Creates a helper called `setTokenKey` which checks the format being used before adding | removing keys and values on the token
* Uses this helper in `convertTokensToObject`, which is the core method used in **RemoteTokenStorage** before pushing to remotes!
* Adapts and adds test coverage to these methods

### Testing this change

📖 🔨 Test file: [colors.json](https://github.com/user-attachments/files/16374078/colors.json)
☝️ Set up alongside a remote providers (this was tested with Github)

#### Non-inherited types

1. Note how these are in **legacy** format
2. Switch to **W3C DTCG** format, don't push yet
3. Go back to the Tokens tab and see the token & the updated JSON view (`$value`, `$description`, `$type`)
4. Push to your remote
5. See no duplicated keys, and the correct  **W3C DTCG** format ✅ 
6. 🔁 Do the same switching back to **legacy** format ✅ 

https://github.com/user-attachments/assets/900ee853-826d-443c-a686-a9c78ebd38b4

#### Inherited types

1. Remove the `"type": "color"` from any group
2. Note how it is shifted to the bottom of the group
3. Push to your remote
4. Repeat steps **2 - 6** as above 👀 

https://github.com/user-attachments/assets/ea37b8a7-639a-4fe7-911e-e0a95dc4c5d0

### Additional comments
⏳ Nice to have in the future: the `Diff` tab (before pushing) is empty when switching formats, as it doesn't compare **keys** (`type` vs `$type**). Should have a message that shows the user that the formatting has been updated, somehow? 
<img width="250" alt="Screenshot 2024-07-23 at 19 34 22" src="https://github.com/user-attachments/assets/411de6f8-3ba4-484f-a212-0ca90fd49915">
