### PR TITLE
fix variable rename pos and composition form

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -436,7 +436,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           if (themes.length > 0 && tokenTypesToCreateVariable.includes(internalEditToken.type)) {
             choices.push({
               key: ModalOptions.RENAME_VARIABLE,
-              label: 'Rename variables',
+              label: 'Rename variable',
             });
           }
           if (
@@ -445,7 +445,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           ) {
             choices.push({
               key: StyleOptions.RENAME,
-              label: 'Rename styles',
+              label: 'Rename style',
               enabled: lastUsedRenameStyles,
             });
           }

--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -436,7 +436,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           if (themes.length > 0 && tokenTypesToCreateVariable.includes(internalEditToken.type)) {
             choices.push({
               key: ModalOptions.RENAME_VARIABLE,
-              label: 'Rename variable',
+              label: 'Rename variables',
             });
           }
           if (

--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { Button, Heading, Textarea, Label, Stack } from '@tokens-studio/ui';
+import {
+  Button, Heading, Textarea, Label, Stack,
+} from '@tokens-studio/ui';
 import { track } from '@/utils/analytics';
 import { useShortcut } from '@/hooks/useShortcut';
 import { Dispatch } from '../store';
@@ -21,7 +23,9 @@ import {
 } from '@/types/tokens';
 import { checkIfAlias, checkIfContainsAlias, getAliasValue } from '@/utils/alias';
 import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
-import { activeTokenSetSelector, editTokenSelector, themesListSelector, tokensSelector } from '@/selectors';
+import {
+  activeTokenSetSelector, editTokenSelector, themesListSelector, tokensSelector,
+} from '@/selectors';
 import { TokenTypes } from '@/constants/TokenTypes';
 import TypographyInput from './TypographyInput';
 import DownshiftInput from './DownshiftInput';
@@ -57,18 +61,21 @@ function EditTokenForm({ resolvedTokens }: Props) {
   const editToken = useSelector(editTokenSelector);
   const themes = useSelector(themesListSelector);
   const [selectedTokenSets, setSelectedTokenSets] = React.useState<string[]>([activeTokenSet]);
-  const { editSingleToken, createSingleToken, duplicateSingleToken, renameTokensAcrossSets } = useManageTokens();
-  const { remapToken, renameStylesFromTokens, renameVariablesFromToken, updateVariablesFromToken } = useTokens();
+  const {
+    editSingleToken, createSingleToken, duplicateSingleToken, renameTokensAcrossSets,
+  } = useManageTokens();
+  const {
+    remapToken, renameStylesFromTokens, renameVariablesFromToken, updateVariablesFromToken,
+  } = useTokens();
   const dispatch = useDispatch<Dispatch>();
   const [error, setError] = React.useState<string | null>(null);
   const [internalEditToken, setInternalEditToken] = React.useState<typeof editToken>(editToken);
   const { confirm } = useConfirm();
   const isValidDimensionToken = React.useMemo(
-    () =>
-      internalEditToken.type === TokenTypes.DIMENSION &&
-      (internalEditToken.value?.endsWith('px') ||
-        internalEditToken.value?.endsWith('rem') ||
-        checkIfAlias(internalEditToken as SingleDimensionToken, resolvedTokens)),
+    () => internalEditToken.type === TokenTypes.DIMENSION
+      && (internalEditToken.value?.endsWith('px')
+        || internalEditToken.value?.endsWith('rem')
+        || checkIfAlias(internalEditToken as SingleDimensionToken, resolvedTokens)),
     [internalEditToken, resolvedTokens, checkIfAlias],
   );
   const isValidColorToken = React.useMemo(() => {
@@ -80,9 +87,9 @@ function EditTokenForm({ resolvedTokens }: Props) {
 
   const isValid = React.useMemo(() => {
     if (
-      internalEditToken?.type === TokenTypes.COMPOSITION &&
-      internalEditToken.value &&
-      (internalEditToken.value.hasOwnProperty('') || Object.keys(internalEditToken.value).length === 0)
+      internalEditToken?.type === TokenTypes.COMPOSITION
+      && internalEditToken.value
+      && (internalEditToken.value.hasOwnProperty('') || Object.keys(internalEditToken.value).length === 0)
     ) {
       return false;
     }
@@ -108,11 +115,10 @@ function EditTokenForm({ resolvedTokens }: Props) {
   }, [internalEditToken, resolvedTokens, activeTokenSet, selectedTokenSets]);
 
   const hasAnotherTokenThatStartsWithName = React.useMemo(
-    () =>
-      resolvedTokens
-        .filter((t) => t.internal__Parent === activeTokenSet)
-        .filter((t) => t.name !== internalEditToken?.initialName)
-        .find((t) => t.name.startsWith(`${internalEditToken?.name}.`)),
+    () => resolvedTokens
+      .filter((t) => t.internal__Parent === activeTokenSet)
+      .filter((t) => t.name !== internalEditToken?.initialName)
+      .find((t) => t.name.startsWith(`${internalEditToken?.name}.`)),
     [internalEditToken, resolvedTokens, activeTokenSet],
   );
 
@@ -155,8 +161,8 @@ function EditTokenForm({ resolvedTokens }: Props) {
       setError(t('tokenNamesMustBeUnique', { ns: 'errors' }));
     }
     if (
-      (internalEditToken?.status !== EditTokenFormStatus.EDIT || nameWasChanged) &&
-      hasAnotherTokenThatStartsWithName
+      (internalEditToken?.status !== EditTokenFormStatus.EDIT || nameWasChanged)
+      && hasAnotherTokenThatStartsWithName
     ) {
       setError(t('mustNotUseNameOfAnotherGroup', { ns: 'errors' }));
     }
@@ -361,7 +367,9 @@ function EditTokenForm({ resolvedTokens }: Props) {
   }, [internalEditToken, resolvedTokens]);
 
   // @TODO update to useCallback
-  const submitTokenValue = async ({ type, value, name, $extensions }: EditTokenObject) => {
+  const submitTokenValue = async ({
+    type, value, name, $extensions,
+  }: EditTokenObject) => {
     if (internalEditToken && value && name) {
       let oldName: string | undefined;
       if (internalEditToken.initialName !== name && internalEditToken.initialName) {
@@ -425,20 +433,20 @@ function EditTokenForm({ resolvedTokens }: Props) {
               enabled: UpdateMode.DOCUMENT === lastUsedRenameOption,
             },
           ];
+          if (themes.length > 0 && tokenTypesToCreateVariable.includes(internalEditToken.type)) {
+            choices.push({
+              key: ModalOptions.RENAME_VARIABLE,
+              label: 'Rename variable',
+            });
+          }
           if (
-            themes.length > 0 &&
-            [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(internalEditToken.type)
+            themes.length > 0
+            && [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(internalEditToken.type)
           ) {
             choices.push({
               key: StyleOptions.RENAME,
               label: 'Rename styles',
               enabled: lastUsedRenameStyles,
-            });
-          }
-          if (themes.length > 0 && tokenTypesToCreateVariable.includes(internalEditToken.type)) {
-            choices.push({
-              key: ModalOptions.RENAME_VARIABLE,
-              label: 'Rename variable',
             });
           }
           const tokenSetsContainsSameToken: string[] = [];
@@ -460,9 +468,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           });
           if (confirmData && confirmData.result) {
             if (
-              confirmData.data.some((data: string) =>
-                [UpdateMode.DOCUMENT, UpdateMode.PAGE, UpdateMode.SELECTION].includes(data as UpdateMode),
-              )
+              confirmData.data.some((data: string) => [UpdateMode.DOCUMENT, UpdateMode.PAGE, UpdateMode.SELECTION].includes(data as UpdateMode))
             ) {
               remapToken(oldName, newName, confirmData.data[0]);
               lastUsedRenameOption = confirmData.data[0] as UpdateMode;
@@ -692,9 +698,9 @@ function EditTokenForm({ resolvedTokens }: Props) {
           <Button disabled={!isValid || !!error} variant="primary" type="submit">
             {internalEditToken?.status === EditTokenFormStatus.CREATE && t('create')}
             {internalEditToken?.status === EditTokenFormStatus.EDIT && t('save')}
-            {internalEditToken?.status !== EditTokenFormStatus.CREATE &&
-              internalEditToken?.status !== EditTokenFormStatus.EDIT &&
-              t('duplicate')}
+            {internalEditToken?.status !== EditTokenFormStatus.CREATE
+              && internalEditToken?.status !== EditTokenFormStatus.EDIT
+              && t('duplicate')}
           </Button>
         </Stack>
       </Stack>

--- a/packages/tokens-studio-for-figma/src/app/components/SingleCompositionTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SingleCompositionTokenForm.tsx
@@ -89,6 +89,9 @@ export default function SingleCompositionTokenForm({
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           border: 'none', // We're using a wrapper that controls the border
+          '& * svg': property ? { // Hides the arrow for properties
+            display: 'none',
+          } : {},
         }}
         data-testid="composition-token-dropdown"
       />

--- a/packages/tokens-studio-for-figma/src/app/components/SingleCompositionTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SingleCompositionTokenForm.tsx
@@ -85,9 +85,10 @@ export default function SingleCompositionTokenForm({
           borderBottomRightRadius: '0',
           height: 'auto',
           alignSelf: 'stretch',
-          width: '150px',
+          width: '155px',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
+          border: 'none', // We're using a wrapper that controls the border
         }}
         data-testid="composition-token-dropdown"
       />
@@ -96,7 +97,7 @@ export default function SingleCompositionTokenForm({
               && properties.map((prop, idx) => <Select.Item data-testid={`item-dropdown-menu-element-${prop}`} key={`property-${seed(idx)}`} value={prop}>{prop}</Select.Item>)}
       </Select.Content>
     </Select>
-  )
+  );
 
   return (
     <Box css={{


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/3020
Fixes https://github.com/tokens-studio/figma-plugin/issues/3016

Includes formatting changes as well (automatically on save)

<img width="461" alt="CleanShot 2024-07-24 at 08 42 45@2x" src="https://github.com/user-attachments/assets/da808dba-d4a4-4c34-81db-58136a373d99">

also includes a fix for composition token forms (by making sure the longest string is readable)

<img width="446" alt="image" src="https://github.com/user-attachments/assets/5481d58d-388e-4523-a201-71423b25ef7f">
