### PR TITLE
Fix resolve duplicate modal crash with object values

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
@@ -3,6 +3,7 @@ import { useUIDSeed } from 'react-uid';
 import {
   Heading, RadioGroup, RadioIndicator, RadioItem, RadioItemBefore,
   Stack,
+  Text,
   Tooltip,
 } from '@tokens-studio/ui';
 import { SingleToken } from '@/types/tokens';
@@ -36,7 +37,12 @@ function ResolveDuplicateTokenSingle({ token }: { token: SingleToken }) {
             ))}
           </Stack>
         ) : (
-          <TokenTooltipContentValue token={token} ignoreResolvedValue />
+          <>
+            {/* Comment to avoid nested ternary warning */}
+            {typeof token.value === 'string' ? <Text>{token.value as string}</Text>
+              : <TokenTooltipContentValue token={token} ignoreResolvedValue />}
+          </>
+
         )}
       </Box>
     </Tooltip>

--- a/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
@@ -2,11 +2,20 @@ import React from 'react';
 import {
   Heading, RadioGroup, RadioIndicator, RadioItem, RadioItemBefore,
   Stack,
-  Text,
   Tooltip,
 } from '@tokens-studio/ui';
 import { SingleToken } from '@/types/tokens';
 import Box from '../Box';
+import TooltipProperty from '../TokenTooltip/TooltipProperty';
+import { CompositionTokenValue } from '@/types/CompositionTokenProperty';
+import { TokenTooltipContentValue } from '../TokenTooltip/TokenTooltipContentValue';
+
+export const CompositionValueDisplay: React.FC<React.PropsWithChildren<React.PropsWithChildren<{ property: string, value: CompositionTokenValue | number }>>> = ({ property, value }) => (
+  <TooltipProperty
+    label={property}
+    value={typeof value === 'string' || typeof value === 'number' ? value : '…'}
+  />
+);
 
 function ResolveDuplicateTokenSingle({ token }: { token: SingleToken }) {
   return (
@@ -20,9 +29,7 @@ function ResolveDuplicateTokenSingle({ token }: { token: SingleToken }) {
           border: (typeof token.value === 'string' && (token.value as string).startsWith('#')) ? `1px solid ${token.value as string}` : undefined,
         }}
       >
-        <Text>
-          {token.value as string}
-        </Text>
+        <TokenTooltipContentValue token={token} ignoreResolvedValue />
       </Box>
     </Tooltip>
   );
@@ -47,7 +54,10 @@ export default function ResolveDuplicateTokenGroup({
       key={`${groupKey}`}
     >
       <Stack direction="row" css={{ marginBottom: '$4' }}>
-        <Heading size="small"><Box as="span" css={{ minWidth: '$9', display: 'inline-flex' }}>Token</Box>{groupKey}</Heading>
+        <Heading size="small">
+          <Box as="span" css={{ minWidth: '$9', display: 'inline-flex' }}>Token</Box>
+          {groupKey}
+        </Heading>
       </Stack>
       <Stack direction="row">
         <Heading size="small" css={{ minWidth: '$9' }}>Value</Heading>

--- a/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useUIDSeed } from 'react-uid';
 import {
   Heading, RadioGroup, RadioIndicator, RadioItem, RadioItemBefore,
   Stack,
@@ -6,18 +7,13 @@ import {
 } from '@tokens-studio/ui';
 import { SingleToken } from '@/types/tokens';
 import Box from '../Box';
-import TooltipProperty from '../TokenTooltip/TooltipProperty';
-import { CompositionTokenValue } from '@/types/CompositionTokenProperty';
 import { TokenTooltipContentValue } from '../TokenTooltip/TokenTooltipContentValue';
-
-export const CompositionValueDisplay: React.FC<React.PropsWithChildren<React.PropsWithChildren<{ property: string, value: CompositionTokenValue | number }>>> = ({ property, value }) => (
-  <TooltipProperty
-    label={property}
-    value={typeof value === 'string' || typeof value === 'number' ? value : '…'}
-  />
-);
+import { isSingleBoxShadowToken } from '@/utils/is';
+import { SingleShadowValueDisplay } from '../TokenTooltip/SingleShadowValueDisplay';
+import { TokenBoxshadowValue } from '@/types/values';
 
 function ResolveDuplicateTokenSingle({ token }: { token: SingleToken }) {
+  const seed = useUIDSeed();
   return (
     <Tooltip label={`Type: ${token.type}`}>
       <Box
@@ -29,7 +25,19 @@ function ResolveDuplicateTokenSingle({ token }: { token: SingleToken }) {
           border: (typeof token.value === 'string' && (token.value as string).startsWith('#')) ? `1px solid ${token.value as string}` : undefined,
         }}
       >
-        <TokenTooltipContentValue token={token} ignoreResolvedValue />
+        {(isSingleBoxShadowToken(token) && Array.isArray(token.value)) ? (
+          <Stack direction="column" align="start" gap={3} wrap>
+            {token.value.map((t, index) => (
+              <SingleShadowValueDisplay
+                key={seed(t)}
+                value={Array.isArray(token.value) ? token.value[index] as TokenBoxshadowValue : undefined}
+                resolvedValue={t as TokenBoxshadowValue}
+              />
+            ))}
+          </Stack>
+        ) : (
+          <TokenTooltipContentValue token={token} ignoreResolvedValue />
+        )}
       </Box>
     </Tooltip>
   );

--- a/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/SingleCompositionValueDisplay.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/SingleCompositionValueDisplay.tsx
@@ -6,13 +6,16 @@ import { CompositionTokenValue } from '@/types/CompositionTokenProperty';
 type Props = {
   property: string;
   value: SingleToken['value'] | number;
-  resolvedValue: CompositionTokenValue | number;
+  resolvedValue: CompositionTokenValue | number | false;
 };
 
-export const SingleCompositionValueDisplay: React.FC<React.PropsWithChildren<React.PropsWithChildren<Props>>> = ({ property, value, resolvedValue }) => (
-  <TooltipProperty
-    label={property}
-    value={typeof value === 'string' || typeof value === 'number' ? value : '…'}
-    resolvedValue={typeof resolvedValue === 'string' || typeof resolvedValue === 'number' ? resolvedValue : '…'}
-  />
-);
+export const SingleCompositionValueDisplay: React.FC<React.PropsWithChildren<React.PropsWithChildren<Props>>> = ({ property, value, resolvedValue }) => {
+  const resolvedValueString = (typeof resolvedValue === 'string' || typeof resolvedValue === 'number' || resolvedValue === undefined) ? resolvedValue : '…';
+  return (
+    <TooltipProperty
+      label={property}
+      value={typeof value === 'string' || typeof value === 'number' ? value : '…'}
+      resolvedValue={(resolvedValue === false) ? undefined : resolvedValueString}
+    />
+  );
+};

--- a/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/SingleTypographyValueDisplay.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/SingleTypographyValueDisplay.tsx
@@ -5,7 +5,7 @@ import Stack from '../Stack';
 
 type Props = {
   value: TokenTypographyValue;
-  resolvedValue: TokenTypographyValue;
+  resolvedValue?: TokenTypographyValue;
 };
 
 export const SingleTypographyValueDisplay: React.FC<React.PropsWithChildren<React.PropsWithChildren<Props>>> = ({ value, resolvedValue }) => (

--- a/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/TokenTooltipContentValue.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/TokenTooltipContentValue.tsx
@@ -20,17 +20,19 @@ import { SingleColorValueDisplay } from './SingleColorValueDisplay';
 
 type Props = {
   token: SingleToken;
+  ignoreResolvedValue?: boolean;
 };
 
 // Returns token value in display format
-export const TokenTooltipContentValue: React.FC<React.PropsWithChildren<React.PropsWithChildren<Props>>> = ({ token }) => {
+export const TokenTooltipContentValue: React.FC<React.PropsWithChildren<React.PropsWithChildren<Props>>> = ({ token, ignoreResolvedValue }) => {
   const seed = useUIDSeed();
   const tokensContext = React.useContext(TokensContext);
   const { getTokenValue } = useTokens();
-  const resolvedValue = React.useMemo(() => getTokenValue(token.name, tokensContext.resolvedTokens)?.value, [
+  const resolvedValue = React.useMemo(() => (ignoreResolvedValue ? undefined : getTokenValue(token.name, tokensContext.resolvedTokens)?.value), [
     token,
     getTokenValue,
     tokensContext.resolvedTokens,
+    ignoreResolvedValue,
   ]);
 
   if (isSingleTypographyToken(token)) {
@@ -43,7 +45,7 @@ export const TokenTooltipContentValue: React.FC<React.PropsWithChildren<React.Pr
   }
 
   if (
-    resolvedValue
+    (resolvedValue || ignoreResolvedValue)
     && typeof resolvedValue !== 'string'
     && !Array.isArray(resolvedValue)
     && isSingleCompositionToken(token)
@@ -56,7 +58,7 @@ export const TokenTooltipContentValue: React.FC<React.PropsWithChildren<React.Pr
             property={property}
             value={value}
             // @TODO strengthen the type checking here
-            resolvedValue={get(resolvedValue, property) as CompositionTokenValue}
+            resolvedValue={ignoreResolvedValue ? false : get(resolvedValue as SingleToken, property) as CompositionTokenValue}
           />
         ))}
       </Stack>

--- a/packages/tokens-studio-for-figma/src/app/components/__tests__/TokenBottomBar.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/__tests__/TokenBottomBar.test.tsx
@@ -5,6 +5,7 @@ import { createMockStore, render, waitFor } from '../../../../tests/config/setup
 import { TokenTypes } from '@/constants/TokenTypes';
 
 import TokensBottomBar from '../TokensBottomBar';
+import { BoxShadowTypes } from '@/constants/BoxShadowTypes';
 
 function emptyFunc() {}
 
@@ -58,6 +59,50 @@ describe('TokenBottomBar', () => {
               type: TokenTypes.COLOR,
               value: '#000000',
               description: 'regular color token',
+            },
+            {
+              name: 'boxShadow.default',
+              type: TokenTypes.BOX_SHADOW,
+              value: [
+                {
+                  x: '4',
+                  y: '0',
+                  blur: '0',
+                  spread: '0',
+                  color: '#000000',
+                  type: BoxShadowTypes.INNER_SHADOW,
+                },
+                {
+                  x: '4',
+                  y: '0',
+                  blur: '0',
+                  spread: '0',
+                  color: '#000000',
+                  type: BoxShadowTypes.INNER_SHADOW,
+                },
+              ],
+            },
+            {
+              name: 'boxShadow.default',
+              type: TokenTypes.BOX_SHADOW,
+              value: [
+                {
+                  x: '2',
+                  y: '0',
+                  blur: '0',
+                  spread: '0',
+                  color: '#000000',
+                  type: BoxShadowTypes.INNER_SHADOW,
+                },
+                {
+                  x: '2',
+                  y: '0',
+                  blur: '0',
+                  spread: '0',
+                  color: '#000000',
+                  type: BoxShadowTypes.INNER_SHADOW,
+                },
+              ],
             },
           ],
         },

--- a/packages/tokens-studio-for-figma/src/app/components/__tests__/TokenBottomBar.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/__tests__/TokenBottomBar.test.tsx
@@ -104,6 +104,22 @@ describe('TokenBottomBar', () => {
                 },
               ],
             },
+            {
+              name: 'composition.default',
+              type: TokenTypes.COMPOSITION,
+              value: {
+                height: '20px',
+                minHeight: '20px',
+              },
+            },
+            {
+              name: 'composition.default',
+              type: TokenTypes.COMPOSITION,
+              value: {
+                height: '40px',
+                minHeight: '40px',
+              },
+            },
           ],
         },
       },


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes #3025 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Create duplicate typography, composite and box shadow token values by switching to the production version and use `Duplicate Group`
- Open the Resolve Duplicates Modal and verify that the previews show correctly and the plugin doesn't crash

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<img width="505" alt="image" src="https://github.com/user-attachments/assets/1ad4d7aa-6fca-45bb-8dd8-e0d9a96761f0">

<img width="514" alt="image" src="https://github.com/user-attachments/assets/118509d7-ce21-477e-ba2b-a0f24653c844">


<!--
  Add any other context or screenshots about the pull request
-->
