### PR TITLE
chore: add action to post link to built artifact

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,12 +31,30 @@ jobs:
         run: npm run build
       # 6: Store artifact
       - name: Store Artifact
-        uses: actions/upload-artifact@v2
+        id: "store_artifact"
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: |
             packages/tokens-studio-for-figma/dist
             packages/tokens-studio-for-figma/manifest.json
+
+      # 7: Post link to artifact
+      - name: Find artifact comment
+        uses: peter-evans/find-comment@v3
+        id: find_artifact_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: The artifact was successfully created
+      - name: Create or update artifact comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_artifact_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ⤵️ 📦 ✨ The artifact was successfully created! Want to test it? [Download it here](${{steps.store_artifact.outputs.artifact-url}}) 👀 🎁
+          edit-mode: replace
   # install dependencies and run test command
   test:
     name: Tests

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ env:
   LICENSE_API_URL: ${{ secrets.LICENSE_API_URL }}
 
 jobs:
-  # install dependencies and store artifact
+  # Install dependencies and store artifact
   package:
     name: Create Package
     runs-on: ubuntu-22.04
@@ -55,7 +55,7 @@ jobs:
           body: |
             ⤵️ 📦 ✨ The artifact was successfully created! Want to test it? [Download it here](${{steps.store_artifact.outputs.artifact-url}}) 👀 🎁
           edit-mode: replace
-  # install dependencies and run test command
+  # Install dependencies and run test command
   test:
     name: Tests
     runs-on: ubuntu-latest
@@ -70,7 +70,6 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
       - name: Install dependencies
         run: yarn  --frozen-lockfile  --immutable
-      # 4: Run tests
       - name: Run test command
         run: npm run test
   coverage:
@@ -161,7 +160,6 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
       - name: Install dependencies
         run: yarn  --frozen-lockfile  --immutable
-      # 4: Build package
       - name: Run benchmark
         working-directory: packages/tokens-studio-for-figma
         run: npm run benchmark:build && npm run benchmark:run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Store artifact for later use
       - name: Store Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: dist/bundle.zip


### PR DESCRIPTION
### Why does this PR exist?

Make it easier to share individual builds to test.

### What does this pull request do?

* Adds an action [after the artifact is stored](https://github.com/tokens-studio/figma-plugin/blob/release-139/.github/workflows/node.js.yml#L32) that posts a link to download it. Runs on every CI once a PR is created.
* Uses `actions/upload-artifact@v4` to have access to the `artifact-url` it outputs. Older versions will also be deprecated soon 👉 [read more here](https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact)

### Testing this change

[See automated comment below](https://github.com/tokens-studio/figma-plugin/pull/3029#issuecomment-2250833012) 😄 