### PR TITLE
Fix composition tokens not applying raw values for colours

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
@@ -32,7 +32,7 @@ export default async function setColorValuesOnTarget({
       existingPaint = target.strokes[0] ?? null;
     }
 
-    if (resolvedValue.startsWith('linear-gradient')) {
+    if (resolvedValue.startsWith?.('linear-gradient')) {
       const fallbackValue = defaultTokenValueRetriever.get(token)?.value;
       const { gradientStops, gradientTransform } = convertStringToFigmaGradient(fallbackValue);
 
@@ -53,8 +53,8 @@ export default async function setColorValuesOnTarget({
                   color: {
                     type: 'VARIABLE_ALIAS',
                     id: referenceVariableExists.id,
-                  }
-                }
+                  },
+                },
               };
             }
             return stop;
@@ -94,7 +94,7 @@ export default async function setColorValuesOnTarget({
       const valueToApply = fallbackValue ?? givenValue;
 
       if (!successfullyAppliedVariable) {
-        const { color, opacity } = convertToFigmaColor(valueToApply);
+        const { color, opacity } = convertToFigmaColor(typeof valueToApply === 'string' ? valueToApply : givenValue || '');
         const newPaint: SolidPaint = { color, opacity, type: 'SOLID' };
         await unbindVariableFromTarget(target, key, newPaint);
         if (!existingPaint || !isPaintEqual(newPaint, existingPaint)) {


### PR DESCRIPTION
### Why does this PR exist?

Follow-up PR

Fixes #3014  <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Try applying this composition token to a node and verify that it applies and doesn't error:

```
{
  "test": {
    "value": {
      "borderColor": "#FFF000",
      "sizing": "{medium} + 40",
      "fill": "#0fa",
      "borderRadiusTopLeft": "16 + 8",
      "backgroundBlur": "12px"
    },
    "type": "composition"
  }
}
```

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<img width="611" alt="image" src="https://github.com/user-attachments/assets/3d4f7c98-789c-4b12-8de5-8ba5959d7e54">


<!--
  Add any other context or screenshots about the pull request
-->
