### PR TITLE
fix: ensure remote changes are correctly tracked in the plugin

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
@@ -191,9 +191,27 @@ describe('pullTokensFactory', () => {
     mockFetchBranches.mockResolvedValueOnce(['main']);
     mockPullTokens.mockResolvedValueOnce({
       tokens: {
+        global: [
+          {
+            value: '12px',
+            type: 'spacing',
+            description: 'first spacing here',
+            name: '1-spacing-token',
+          },
+          {
+            value: '#ff00ff',
+            type: 'color',
+            name: '1-color-token',
+          },
+          {
+            value: '12px',
+            type: 'fontSizes',
+            name: '1-font-size-token',
+          },
+        ],
       },
       themes: [],
-      metadata: {},
+      metadata: { tokenSetOrder: ['global'] },
     });
 
     await fn();
@@ -244,7 +262,7 @@ describe('pullTokensFactory', () => {
     expect(state.uiState.activeTab).toEqual(Tabs.START);
   });
 
-  it('should verify the API credentials without pulling if there are local changes', async () => {
+  it('should verify the API credentials and pull even if there are local changes', async () => {
     const mockStore = createMockStore({
       uiState: {
         storageType: mockStorageType,
@@ -289,10 +307,11 @@ describe('pullTokensFactory', () => {
 
     await fn();
     const state = mockStore.getState();
-    expect(mockUseRemoteTokens.pullTokens).not.toBeCalled();
+    expect(mockUseRemoteTokens.pullTokens).toBeCalledTimes(1);
     expect(state.branchState.branches).toEqual(['main']);
     expect(state.tokenState.tokens).toEqual(mockParams.localTokenData?.values);
     expect(state.uiState.activeTab).toEqual(Tabs.TOKENS);
+    expect(state.tokenState.remoteData).toEqual({ metadata: null, themes: [], tokens: {} });
   });
 
   it('should go to start tab if the localTokenData is missing somehow', async () => {

--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
@@ -78,14 +78,16 @@ export function pullTokensFactory(
           dispatch.tokenState.setActiveTheme({ newActiveTheme: activeTheme || null, shouldUpdateNodes: false });
           dispatch.tokenState.setCollapsedTokenSets(params.localTokenData?.collapsedTokenSets || []);
 
+          const remoteData = await useRemoteTokensResult.pullTokens({
+            context: matchingSet,
+            featureFlags: flags,
+            activeTheme,
+            usedTokenSet: params.localTokenData?.usedTokenSet,
+            collapsedTokenSets: params.localTokenData?.collapsedTokenSets,
+            updateLocalTokens: shouldPull,
+          });
+
           if (shouldPull) {
-            const remoteData = await useRemoteTokensResult.pullTokens({
-              context: matchingSet,
-              featureFlags: flags,
-              activeTheme,
-              usedTokenSet: params.localTokenData?.usedTokenSet,
-              collapsedTokenSets: params.localTokenData?.collapsedTokenSets,
-            });
             // If there's no data stored on the remote, show a message - e.g. file doesn't exist.
             if (!remoteData) {
               notifyToUI('Failed to fetch tokens from remote storage', { error: true });

--- a/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
@@ -114,7 +114,9 @@ export default function BranchSelector() {
         setCurrentBranch(branch);
         dispatch.uiState.setApiData({ ...apiData, branch });
         dispatch.uiState.setLocalApiState({ ...localApiState, branch });
-        await pullTokens({ context: { ...apiData, branch }, usedTokenSet, activeTheme });
+        await pullTokens({
+          context: { ...apiData, branch }, usedTokenSet, activeTheme, updateLocalTokens: true,
+        });
         AsyncMessageChannel.ReactInstance.message({
           type: AsyncMessageTypes.CREDENTIALS,
           credential: { ...apiData, branch },

--- a/packages/tokens-studio-for-figma/src/app/components/Footer.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Footer.tsx
@@ -54,7 +54,7 @@ export default function Footer() {
   const onPushButtonClicked = React.useCallback(() => pushTokens(), [pushTokens]);
   const onPullButtonClicked = React.useCallback(() => pullTokens({ usedTokenSet, activeTheme }), [pullTokens, usedTokenSet, activeTheme]);
   const handlePullTokens = useCallback(() => {
-    pullTokens({ usedTokenSet, activeTheme });
+    pullTokens({ usedTokenSet, activeTheme, updateLocalTokens: true });
   }, [pullTokens, usedTokenSet, activeTheme]);
 
   return (

--- a/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ImportedTokensDialog.test.tsx
@@ -18,7 +18,6 @@ const getDefaultStore = () => ({
     tokens: {
       global: [
         {
-          $extensions: { 'studio.tokens': {} },
           name: 'light',
           type: 'typography',
           value: {
@@ -72,7 +71,6 @@ const getDefaultStore = () => ({
           },
         },
         {
-          $extensions: { 'studio.tokens': {} },
           name: 'opacity.50',
           type: 'opacity',
           value: '30%',
@@ -126,7 +124,6 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -169,7 +166,6 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -179,7 +175,6 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '50%',
@@ -239,7 +234,6 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -249,7 +243,6 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '50%',
@@ -300,7 +293,6 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -310,7 +302,6 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '50%',
@@ -337,7 +328,6 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {
@@ -347,7 +337,6 @@ describe('ImportedTokensDialog', () => {
             },
           },
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'opacity.50',
             type: 'opacity',
             value: '30%',
@@ -378,7 +367,6 @@ describe('ImportedTokensDialog', () => {
       expect(mockStore.getState().tokenState.tokens.global).toEqual(
         [
           {
-            $extensions: { 'studio.tokens': {} },
             name: 'light',
             type: 'typography',
             value: {

--- a/packages/tokens-studio-for-figma/src/app/components/modals/CreateBranchModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/modals/CreateBranchModal.tsx
@@ -72,7 +72,7 @@ export default function CreateBranchModal({
         onSuccess(branch, branches ?? []);
         if (!isCurrentChanges) {
           await pullTokens({
-            context: { ...apiData, branch }, usedTokenSet, activeTheme,
+            context: { ...apiData, branch }, usedTokenSet, activeTheme, updateLocalTokens: true,
           });
         }
       } else {

--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -82,7 +82,11 @@ export const useADO = () => {
           activeTheme,
           hasChangedRemote: true,
         });
-
+        dispatch.tokenState.setRemoteData({
+          tokens,
+          themes,
+          metadata,
+        });
         pushDialog({ state: 'success' });
 
         return {

--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -207,6 +207,11 @@ export const useADO = () => {
               activeTheme,
               hasChangedRemote: true,
             });
+            dispatch.tokenState.setRemoteData({
+              tokens: sortedValues,
+              themes: content.themes,
+              metadata: content.metadata,
+            });
             dispatch.tokenState.setCollapsedTokenSets([]);
             notifyToUI('Pulled tokens from ADO');
           }

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -89,6 +89,11 @@ export function useBitbucket() {
           activeTheme,
           hasChangedRemote: true,
         });
+        dispatch.tokenState.setRemoteData({
+          tokens,
+          themes,
+          metadata,
+        });
         pushDialog({ state: 'success' });
         return {
           status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -215,10 +215,15 @@ export function useBitbucket() {
             if (userDecision) {
               const sortedValues = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder);
               dispatch.tokenState.setTokenData({
-                values: content.tokens,
+                values: sortedValues,
                 themes: content.themes,
                 activeTheme,
                 usedTokenSet,
+              });
+              dispatch.tokenState.setRemoteData({
+                tokens: sortedValues,
+                themes: content.themes,
+                metadata: content.metadata,
               });
               dispatch.tokenState.setCollapsedTokenSets([]);
               notifyToUI('Pulled tokens from Bitbucket');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
@@ -267,6 +267,13 @@ export function useGenericVersionedStorage() {
           activeTheme,
           hasChangedRemote: true,
         });
+        dispatch.tokenState.setRemoteData({
+          tokens: content.tokens,
+          themes: content.themes,
+          metadata: {
+            tokenSetOrder: Object.keys(content.tokens),
+          },
+        });
         return content;
       }
 

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -83,6 +83,11 @@ export function useGitHub() {
           activeTheme,
           hasChangedRemote: true,
         });
+        dispatch.tokenState.setRemoteData({
+          tokens,
+          themes,
+          metadata,
+        });
         pushDialog({ state: 'success' });
         return {
           status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -218,6 +218,11 @@ export function useGitHub() {
               usedTokenSet,
               hasChangedRemote: true,
             });
+            dispatch.tokenState.setRemoteData({
+              tokens: sortedValues,
+              themes: content.themes,
+              metadata: content.metadata,
+            });
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(commitSha ? { commitSha } : {}) });
             notifyToUI('Pulled tokens from GitHub');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -230,6 +230,11 @@ export function useGitLab() {
               activeTheme,
               hasChangedRemote: true,
             });
+            dispatch.tokenState.setRemoteData({
+              tokens: sortedValues,
+              themes: content.themes,
+              metadata: content.metadata,
+            });
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(latestCommitDate ? { commitDate: latestCommitDate } : {}) });
             notifyToUI('Pulled tokens from GitLab');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -93,7 +93,11 @@ export function useGitLab() {
           activeTheme,
           hasChangedRemote: true,
         });
-
+        dispatch.tokenState.setRemoteData({
+          tokens,
+          themes,
+          metadata,
+        });
         pushDialog({ state: 'success' });
         return {
           status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
@@ -212,6 +212,11 @@ export function useJSONbin() {
         activeTheme,
         hasChangedRemote: true,
       });
+      dispatch.tokenState.setRemoteData({
+        tokens: applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder),
+        themes: content.themes,
+        metadata: { tokenSetOrder: Object.keys(tokens) },
+      });
       return content;
     }
     return content;

--- a/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
@@ -70,7 +70,11 @@ export function useSupernova() {
             activeTheme,
             hasChangedRemote: true,
           });
-
+          dispatch.tokenState.setRemoteData({
+            tokens,
+            themes,
+            metadata,
+          });
           pushDialog({ state: 'success' });
           return {
             status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
@@ -101,7 +101,11 @@ export function useTokensStudio() {
             activeTheme,
             hasChangedRemote: true,
           });
-
+          dispatch.tokenState.setRemoteData({
+            tokens,
+            themes,
+            metadata,
+          });
           pushDialog({ state: 'success' });
           return {
             status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
@@ -64,6 +64,11 @@ export default function useURL() {
             usedTokenSet: usedTokenSets,
             activeTheme,
           });
+          dispatch.tokenState.setRemoteData({
+            tokens: applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder),
+            themes: content.themes,
+            metadata: content.metadata,
+          });
           dispatch.tokenState.setEditProhibited(true);
           return content;
         }

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.test.ts
@@ -54,7 +54,7 @@ const mockSelector = (selector: Selector) => {
           {
             value: '#ffffff',
             type: 'color',
-            name: 'black',
+            name: 'white',
           },
         ],
       };
@@ -92,7 +92,7 @@ jest.mock('react-redux', () => ({
       setChangedState: mocksetChangedState,
       resetChangedState: mockResetChangedState,
       setRemoteData: mockSetRemoteData,
-      setTokenFormat: mockSetTokenFormat
+      setTokenFormat: mockSetTokenFormat,
     },
     branchState: {
       setBranches: mockSetBranches,
@@ -308,7 +308,7 @@ describe('remoteTokens', () => {
               {
                 value: '#ffffff',
                 type: 'color',
-                name: 'black',
+                name: 'white',
               },
             ],
           },
@@ -344,7 +344,7 @@ describe('remoteTokens', () => {
               {
                 value: '#ffffff',
                 type: 'color',
-                name: 'black',
+                name: 'white',
               },
             ],
           },
@@ -369,10 +369,21 @@ describe('remoteTokens', () => {
               {
                 value: '#ffffff',
                 type: 'color',
-                name: 'black',
+                name: 'white',
               },
             ],
           },
+        });
+        expect(mockSetRemoteData).toBeCalledWith({
+          tokens: { global: [{ name: 'white', type: 'color', value: '#ffffff' }] },
+          themes: [{
+            id: 'light',
+            name: 'Light',
+            selectedTokenSets: {
+              global: 'enabled',
+            },
+          }],
+          metadata: { commitMessage: 'Initial commit' },
         });
       }
     });
@@ -465,7 +476,7 @@ describe('remoteTokens', () => {
                 {
                   value: '#000000',
                   type: 'color',
-                  name: 'white',
+                  name: 'black',
                 },
               ],
             },
@@ -480,6 +491,18 @@ describe('remoteTokens', () => {
       if (context === gitHubContext || context === gitLabContext || context === adoContext || context === bitbucketContext) {
         expect(notifyToUI).toBeCalledTimes(1);
         expect(notifyToUI).toBeCalledWith(`Pulled tokens from ${contextName}`);
+        expect(mockSetRemoteData).toBeCalledTimes(1);
+        expect(mockSetRemoteData).toBeCalledWith({
+          tokens: { global: [{ name: 'black', type: 'color', value: '#000000' }] },
+          themes: [{
+            id: 'black',
+            name: 'Black',
+            selectedTokenSets: {
+              global: 'enabled',
+            },
+          }],
+          metadata: { commitMessage: 'Initial commit' },
+        });
       }
     });
   });
@@ -509,7 +532,7 @@ describe('remoteTokens', () => {
                 {
                   value: '#000000',
                   type: 'color',
-                  name: 'white',
+                  name: 'black',
                 },
               ],
             },
@@ -632,6 +655,22 @@ describe('remoteTokens', () => {
       ));
       if (context === gitHubContext || context === gitLabContext || context === adoContext || context === bitbucketContext) {
         await waitFor(() => { result.current.pushTokens({ context: context as StorageTypeCredentials }); });
+
+        expect(mockSetTokenData).toBeCalledWith({
+          activeTheme: {}, hasChangedRemote: true, themes: [{ id: 'light', name: 'Light', selectedTokenSets: { global: 'enabled' } }], usedTokenSet: {}, values: { global: [{ name: 'white', type: 'color', value: '#ffffff' }] },
+        });
+        expect(mockSetRemoteData).toBeCalledWith({
+          tokens: { global: [{ name: 'white', type: 'color', value: '#ffffff' }] },
+          themes: [{
+            id: 'light',
+            name: 'Light',
+            selectedTokenSets: {
+              global: 'enabled',
+            },
+          }],
+          metadata: { tokenSetOrder: ['global'] },
+        });
+
         expect(mockPushDialog).toBeCalledTimes(2);
         expect(mockPushDialog.mock.calls[1][0].state).toBe('success');
       }
@@ -903,7 +942,7 @@ describe('remoteTokens', () => {
   });
 
   Object.values(contextMap).forEach((context) => {
-    it(`fetch branchs on ${context.provider}`, async () => {
+    it(`fetch branches on ${context.provider}`, async () => {
       if (context === gitHubContext || context === gitLabContext || context === adoContext || context === bitbucketContext) {
         mockFetchBranches.mockImplementation(() => (
           Promise.resolve(['main'])
@@ -935,7 +974,7 @@ describe('remoteTokens', () => {
           {
             value: '#ffffff',
             type: 'color',
-            name: 'black',
+            name: 'white',
           },
         ],
       },
@@ -953,7 +992,7 @@ describe('remoteTokens', () => {
     expect(await result.current.fetchTokensFromFileOrDirectory({ files: null })).toEqual(null);
   });
 
-  Object.values(contextMap).forEach((context) => {
+  [...Object.values(contextMap), { provider: 'genericVersionedStorage' }, { provider: 'unknown new provider' }].forEach((context) => {
     it(`checkRemoteChange from ${context.provider}`, async () => {
       if (context === gitHubContext) {
         mockGetCommitSha.mockImplementation(() => (

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -209,7 +209,7 @@ export default function useRemoteTokens() {
                 break;
             }
             const remoteThemes: ThemeObject[] = remoteData.themes || [];
-            // remove those active thems that are no longer present in remoteThemes
+            // remove those active themes that are no longer present in remoteThemes
             const filteredThemes = activeTheme
               ? Object.keys(activeTheme).reduce((acc, key) => {
                 if (remoteThemes.find((theme) => theme.id === activeTheme[key])) {
@@ -219,7 +219,7 @@ export default function useRemoteTokens() {
               }, {} as Record<string, string>)
               : {};
 
-            if (updateLocalTokens) {
+            if (updateLocalTokens || shouldOverride) {
               dispatch.tokenState.setTokenData({
                 values: remoteData.tokens,
                 themes: remoteData.themes,

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -40,6 +40,7 @@ type PullTokensOptions = {
   usedTokenSet?: UsedTokenSetsMap | null;
   activeTheme?: Record<string, string>;
   collapsedTokenSets?: string[] | null;
+  updateLocalTokens?: boolean;
 };
 
 // @TODO typings and hooks
@@ -103,7 +104,7 @@ export default function useRemoteTokens() {
 
   const pullTokens = useCallback(
     async ({
-      context = api, featureFlags, usedTokenSet, activeTheme, collapsedTokenSets,
+      context = api, featureFlags, usedTokenSet, activeTheme, collapsedTokenSets, updateLocalTokens = false,
     }: PullTokensOptions) => {
       track('pullTokens', { provider: context.provider });
       showPullDialog('loading');
@@ -149,9 +150,16 @@ export default function useRemoteTokens() {
           throw new Error('Not implemented');
       }
       if (remoteData?.status === 'success') {
+        dispatch.tokenState.setRemoteData({
+          tokens: remoteData.tokens,
+          themes: remoteData.themes,
+          metadata: remoteData.metadata,
+        });
         if (activeTab !== Tabs.LOADING) {
-          const format = getFormat();
-          dispatch.tokenState.setTokenFormat(format);
+          if (updateLocalTokens) {
+            const format = getFormat();
+            dispatch.tokenState.setTokenFormat(format);
+          }
         }
         if (activeTab === Tabs.LOADING || !isEqual(tokens, remoteData.tokens) || !isEqual(themes, remoteData.themes)) {
           let shouldOverride = false;
@@ -204,28 +212,24 @@ export default function useRemoteTokens() {
             // remove those active thems that are no longer present in remoteThemes
             const filteredThemes = activeTheme
               ? Object.keys(activeTheme).reduce((acc, key) => {
-                  if (remoteThemes.find((theme) => theme.id === activeTheme[key])) {
-                    acc[key] = activeTheme[key];
-                  }
-                  return acc;
-                }, {} as Record<string, string>)
+                if (remoteThemes.find((theme) => theme.id === activeTheme[key])) {
+                  acc[key] = activeTheme[key];
+                }
+                return acc;
+              }, {} as Record<string, string>)
               : {};
 
-            dispatch.tokenState.setRemoteData({
-              tokens: remoteData.tokens,
-              themes: remoteData.themes,
-              metadata: remoteData.metadata
-            });
+            if (updateLocalTokens) {
+              dispatch.tokenState.setTokenData({
+                values: remoteData.tokens,
+                themes: remoteData.themes,
+                activeTheme: filteredThemes,
+                usedTokenSet: usedTokenSet ?? {},
+                hasChangedRemote: true,
+              });
 
-            dispatch.tokenState.setTokenData({
-              values: remoteData.tokens,
-              themes: remoteData.themes,
-              activeTheme: filteredThemes,
-              usedTokenSet: usedTokenSet ?? {},
-              hasChangedRemote: true,
-            });
-
-            dispatch.tokenState.setCollapsedTokenSets(collapsedTokenSets || []);
+              dispatch.tokenState.setCollapsedTokenSets(collapsedTokenSets || []);
+            }
             track('Launched with token sets', {
               count: Object.keys(remoteData.tokens).length,
               setNames: Object.keys(remoteData.tokens),


### PR DESCRIPTION
### Why does this PR exist?

Closes #3028 (_potentially_, also #3031 & #2984)

Differences between remote and local changes were inconsistently wrong.

### What does this pull request do?

* Instantly saves the **pushed** changes on the `remoteState` (Redux global state)
* Always pulls remote data on **plugin startup** and sets them on the `remoteState` (Redux global state) without overriding the local changes (if they exist)

### Testing this change

> ⚠️ ⚠️ ⚠️ This was only tested using GitHub ⚠️ ⚠️ ⚠️ 

Setup a remote storage of your choice. I used these tokens: [simple-tokens.json](https://github.com/user-attachments/files/16426192/simple-tokens.json) 🎨 

#### Scenario 1
 * Locally change a token
 * Don't push the changes
 * Close & open the plugin
 * See the same changes are still there!

https://github.com/user-attachments/assets/af98fba3-baf4-44aa-91ac-90a8b5a49a8d

#### Scenario 2
* Locally change a token
* Push the changes
* Locally change other token(s)
* See only these changes in the diff!
* Reopen the plugin, see all up to date with the remote

https://github.com/user-attachments/assets/7a93b36f-c134-4826-a5cf-be82a062d3dc
