### PR TITLE
fix: revert and fix attach when creating styles

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/store/models/reducers/__tests__/assignStyleIdsToCurrentTheme.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/reducers/__tests__/assignStyleIdsToCurrentTheme.test.ts
@@ -21,10 +21,10 @@ describe('assignStyleIdsToCurrentTheme', () => {
         { id: 'theme2', selectedTokenSets: {}, $figmaStyleReferences: { token1: 'style1' } },
       ],
     };
-    expect(assignStyleIdsToCurrentTheme(state, styleIds, tokens)).toEqual(expectedState);
+    expect(assignStyleIdsToCurrentTheme(state, { styleIds, tokens, selectedThemes: ['theme1'] })).toEqual(expectedState);
   });
 
-  it('should not update the state if there is no active theme', () => {
+  it('should not update the state if there is no selected theme', () => {
     const state = {
       activeTheme: {},
       themes: [
@@ -34,10 +34,10 @@ describe('assignStyleIdsToCurrentTheme', () => {
     } as unknown as TokenState;
     const styleIds = { token1: 'style2' };
     const tokens = [{ name: 'token1', internal__Parent: 'set1' }] as unknown as ResolveTokenValuesResult[];
-    expect(assignStyleIdsToCurrentTheme(state, styleIds, tokens)).toEqual(state);
+    expect(assignStyleIdsToCurrentTheme(state, { styleIds, tokens, selectedThemes: [] })).toEqual(state);
   });
 
-  it('should not update the state if the token is not used in any active theme', () => {
+  it('should not update the state if the token is not used in any selected theme', () => {
     const state = {
       activeTheme: { id: 'theme1' },
       themes: [
@@ -47,6 +47,6 @@ describe('assignStyleIdsToCurrentTheme', () => {
     } as unknown as TokenState;
     const styleIds = { token1: 'style2' };
     const tokens = [{ name: 'token1', internal__Parent: 'set1' }] as unknown as ResolveTokenValuesResult[];
-    expect(assignStyleIdsToCurrentTheme(state, styleIds, tokens)).toEqual(state);
+    expect(assignStyleIdsToCurrentTheme(state, { styleIds, tokens, selectedThemes: ['theme1'] })).toEqual(state);
   });
 });

--- a/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/assignStyleIdsToCurrentTheme.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/assignStyleIdsToCurrentTheme.ts
@@ -2,12 +2,12 @@ import type { TokenState } from '../../tokenState';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 
-export function assignStyleIdsToCurrentTheme(state: TokenState, styleIds: Record<string, string>, tokens: ResolveTokenValuesResult[]): TokenState {
-  // ignore if there is no active themes
-  if (Object.keys(state.activeTheme).length < 1) return state;
+export function assignStyleIdsToCurrentTheme(state: TokenState, { styleIds, tokens, selectedThemes }: { styleIds: Record<string, string>, tokens: ResolveTokenValuesResult[], selectedThemes: string[] }): TokenState {
+  // ignore if there is no selectedThemes
+  if (selectedThemes.length < 1) return state;
 
   const updatedThemes = [...state.themes];
-  const activeThemes = state.themes.filter((theme) => Object.values(state.activeTheme).some((v) => v === theme.id)).reverse();
+  const activeThemes = state.themes.filter((theme) => selectedThemes.some((v) => v === theme.id)).reverse();
   Object.entries(styleIds).forEach(([tokenName, styleId]) => {
     // Find the activeTheme object which involved this token
     const activeTheme = activeThemes.find((theme) => Object.entries(theme.selectedTokenSets).some(([tokenSet, status]) => status === TokenSetStatus.ENABLED

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
@@ -18,7 +18,7 @@ export const createStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.CREATE_
       createStylesWithVariableReferences: msg.settings.createStylesWithVariableReferences,
       applyVariablesStylesOrRawValue: msg.settings.applyVariablesStylesOrRawValue,
     });
-    const styleIds = await updateStyles(msg.tokens, msg.settings, true, msg.selectedThemes);
+    const styleIds = await updateStyles(msg.tokens, msg.settings, true);
 
     return {
       styleIds,

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.test.ts
@@ -106,9 +106,9 @@ describe('updateStyles', () => {
           },
           type: TokenTypes.TYPOGRAPHY,
           styleId: '',
-        }
+        },
       ],
-      settings: {} as SettingsState
+      settings: {} as SettingsState,
     });
     expect(colorSpy).toHaveBeenCalled();
     expect(textSpy).toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe('updateStyles', () => {
     await updateStyles([...colorTokens], {
       prefixStylesWithThemeName: true,
       stylesColor: true,
-    } as SettingsState, false, ['light']);
+    } as SettingsState, false);
     expect(colorSpy).toHaveBeenCalledWith(
       colorTokens,
       false,

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
@@ -15,13 +15,12 @@ export default async function updateStyles(
   tokens: AnyTokenList,
   settings: SettingsState,
   shouldCreate = false,
-  selectedThemes?: string[]
 ): Promise<Record<string, string>> {
   // Big O (n * m * l): (n = amount of tokens, m = amount of active themes, l = amount of tokenSets)
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
   });
-  const activeThemes = themeInfo.themes.filter((theme) => selectedThemes?.includes(theme.id));
+  const activeThemes = themeInfo.themes.filter((theme) => Object.values(themeInfo.activeTheme).some((v) => v === theme.id)).reverse();
   const styleTokens = tokens.map((token) => {
     // When multiple theme has the same active Token set then the last activeTheme wins
     const activeTheme = activeThemes.find((theme) => Object.entries(theme.selectedTokenSets).some(([tokenSet, status]) => status === TokenSetStatus.ENABLED && tokenSet === token.internal__Parent));

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -177,7 +177,6 @@ export type CreateAnnotationAsyncMessageResult = AsyncMessage<AsyncMessageTypes.
 export type CreateStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.CREATE_STYLES, {
   tokens: AnyTokenList;
   settings: SettingsState;
-  selectedThemes?: string[];
 }>;
 export type CreateStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.CREATE_STYLES, {
   styleIds: Record<string, string>;


### PR DESCRIPTION
### Why does this PR exist?

Fixes the issue our users have been having with RC11 on https://tokens-studio.slack.com/archives/C073SSG7DC7/p1722027287469299   if they were exporting to Styles we would ignore certain token sets. This was due to the new behavior we introduced in RC11 that made it so that when you create styles we iterate over each theme and look at each own on its own.

Its obvious our users arent setup for this as they have themes that are using `disabled` token sets and not as would be correct set as source.

### What does this pull request do?

This PR reverts the behavior while keeping the behavior that the original issue there was trying to solve (attaching styles wasnt working anymore)

### Testing this change

Create a few themes and then create styles.