### PR TITLE
Add support for transform numbers

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/helpers.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/helpers.ts
@@ -68,6 +68,7 @@ export function transformValue(value: string, type: string, baseFontSize: string
     case 'fontSizes':
     case 'fontSize':
     case 'dimension':
+    case 'number':
       return convertTypographyNumberToFigma(value, baseFontSize);
     case 'fontWeights':
     case 'fontWeight':

--- a/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.test.ts
@@ -3,6 +3,8 @@ import { SingleToken } from '@/types/tokens';
 import setValuesOnVariable from './setValuesOnVariable';
 import { TokenTypes } from '@/constants/TokenTypes';
 
+const baseFontSize = '16px';
+
 // TODO: A lot of these tests could be rearranged and grouped follow the order of logic of each file, to see better what happy / sad paths are being covered.
 
 describe('SetValuesOnVariable', () => {
@@ -36,7 +38,7 @@ describe('SetValuesOnVariable', () => {
         variableId: '123',
       },
     ] as SingleToken<true, { path: string, variableId: string }>[];
-    setValuesOnVariable(variablesInFigma, tokens, collection, mode);
+    setValuesOnVariable(variablesInFigma, tokens, collection, mode, baseFontSize);
     expect(mockSetValueForMode).toBeCalledWith(mode, 8);
   });
 
@@ -50,7 +52,7 @@ describe('SetValuesOnVariable', () => {
         type: TokenTypes.SIZING,
       },
     ] as SingleToken<true, { path: string, variableId: string }>[];
-    setValuesOnVariable(variablesInFigma, tokens, collection, mode);
+    setValuesOnVariable(variablesInFigma, tokens, collection, mode, baseFontSize);
     expect(mockCreateVariable).toBeCalledWith('button/primary/width', collection, 'FLOAT');
   });
 
@@ -65,7 +67,7 @@ describe('SetValuesOnVariable', () => {
         variableId: '123',
       },
     ];
-    const result = await setValuesOnVariable(variablesInFigma, tokens, collection, mode, true);
+    const result = await setValuesOnVariable(variablesInFigma, tokens, collection, mode, baseFontSize, true);
     expect(result.renamedVariableKeys).toEqual(['123']);
     expect(variablesInFigma[0].name).toEqual('button/primary/height');
     expect(mockCreateVariable).not.toBeCalled();
@@ -78,9 +80,9 @@ describe('SetValuesOnVariable', () => {
       value: 300,
       rawValue: 300,
       type: TokenTypes.FONT_WEIGHTS,
-      variableId: '1234'
+      variableId: '1234',
     }];
-    await setValuesOnVariable(variablesInFigma, tokens, collection, mode);
+    await setValuesOnVariable(variablesInFigma, tokens, collection, mode, baseFontSize);
     expect(mockCreateVariable).toBeCalledWith('global/fontWeight', collection, 'FLOAT');
-  })
+  });
 });

--- a/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.ts
@@ -6,6 +6,7 @@ import setStringValuesOnVariable from './setStringValuesOnVariable';
 import { convertTokenTypeToVariableType } from '@/utils/convertTokenTypeToVariableType';
 import { checkCanReferenceVariable } from '@/utils/alias/checkCanReferenceVariable';
 import { TokenTypes } from '@/constants/TokenTypes';
+import { transformValue } from './helpers';
 
 export type ReferenceVariableType = {
   variable: Variable;
@@ -18,6 +19,7 @@ export default async function setValuesOnVariable(
   tokens: SingleToken<true, { path: string, variableId: string }>[],
   collection: VariableCollection,
   mode: string,
+  baseFontSize: string,
   shouldRename = false,
 ) {
   const variableKeyMap: Record<string, string> = {};
@@ -57,9 +59,11 @@ export default async function setValuesOnVariable(
               setColorValuesOnVariable(variable, mode, token.value);
             }
             break;
-          case 'FLOAT':
-            setNumberValuesOnVariable(variable, mode, Number(token.value));
+          case 'FLOAT': {
+            const transformedValue = transformValue(String(token.value), token.type, baseFontSize);
+            setNumberValuesOnVariable(variable, mode, Number(transformedValue));
             break;
+          }
           case 'STRING':
             if (typeof token.value === 'string') {
               setStringValuesOnVariable(variable, mode, token.value);

--- a/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.ts
@@ -60,7 +60,7 @@ export default async function setValuesOnVariable(
             }
             break;
           case 'FLOAT': {
-            const transformedValue = transformValue(String(token.value), token.type, baseFontSize);
+            const transformedValue = transformValue(String(token.value), token.type, baseFontSize, true);
             setNumberValuesOnVariable(variable, mode, Number(transformedValue));
             break;
           }

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -29,7 +29,7 @@ export default async function updateVariables({
     }
   });
 
-  const variableObj = await setValuesOnVariable(variablesInCollection, variablesToCreate, collection, mode, settings.renameExistingStylesAndVariables);
+  const variableObj = await setValuesOnVariable(variablesInCollection, variablesToCreate, collection, mode, settings.baseFontSize, settings.renameExistingStylesAndVariables);
   const removedVariables: string[] = [];
 
   // Remove variables not handled in the current theme


### PR DESCRIPTION
Fixes https://github.com/tokens-studio/figma-plugin/issues/2991

### Why does this PR exist?

Fixes an issue where number tokens that contained a unit (something we should *not* encourage, but currently a few users have this setup) were created as 0 values in variables.

### What does this pull request do?

Adds a step to the transformValue step and `setValuesOnVariable` step that transforms the value of number variables

### Testing this change

Use the testing file from @SamIam4Hyma and test
