### PR TITLE
fix: handle errors when importing variables

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/pullVariables.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullVariables.test.ts
@@ -15,7 +15,7 @@ describe('pullStyles', () => {
           return Promise.resolve(JSON.stringify({ baseFontSize: 16 }));
         }
         return Promise.resolve(null);
-      })
+      }),
     },
     variables: {
       getVariableCollectionById: jest.fn().mockReturnValue({
@@ -62,7 +62,7 @@ describe('pullStyles', () => {
             '1:1': 24,
             '1:2': 24,
             '1:3': 24,
-          }
+          },
         },
         {
           name: 'Number2',
@@ -74,7 +74,33 @@ describe('pullStyles', () => {
             '1:1': 16,
             '1:2': 16,
             '1:3': 16,
-          }
+          },
+        },
+        {
+          name: 'String',
+          remote: false,
+          resolvedType: 'STRING',
+          description: '',
+          valuesByMode: {
+            '1:0': 'Hello',
+            '1:1': 'Hello',
+            '1:2': 'Hello',
+            '1:3': 'Hello',
+          },
+          Id: 'VariableCollectionId:1:0',
+        },
+        {
+          name: 'Boolean',
+          remote: false,
+          resolvedType: 'BOOLEAN',
+          description: '',
+          valuesByMode: {
+            '1:0': true,
+            '1:1': true,
+            '1:2': true,
+            '1:3': true,
+          },
+          Id: 'VariableCollectionId:1:0',
         },
       ]),
     },
@@ -120,63 +146,81 @@ describe('pullStyles', () => {
           name: 'Number1',
           parent: 'Collection 1/Default',
           type: 'number',
-          value: 24
+          value: 24,
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Dark',
           type: 'number',
-          value: 24
+          value: 24,
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Light',
           type: 'number',
-          value: 24
+          value: 24,
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Custom',
           type: 'number',
-          value: 24
+          value: 24,
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Default',
           type: 'number',
-          value: 16
+          value: 16,
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Dark',
           type: 'number',
-          value: 16
+          value: 16,
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Light',
           type: 'number',
-          value: 16
+          value: 16,
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Custom',
           type: 'number',
-          value: 16
-        }
-      ]
+          value: 16,
+        },
+      ],
+      booleans: [{
+        description: '', name: 'Boolean', parent: 'Collection 1/Default', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Dark', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Light', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Custom', type: 'boolean', value: 'true',
+      }],
+      strings: [{
+        description: '', name: 'String', parent: 'Collection 1/Default', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Dark', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Light', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Custom', type: 'text', value: 'Hello',
+      }],
     });
   });
 
   it('pulls variables with Convert numbers to dimensions option', async () => {
-    await pullVariables({ useDimensions: true, useRem: false });
+    await pullVariables({ useDimensions: 'true', useRem: false });
 
     expect(notifyStyleValuesSpy).toHaveBeenCalledWith({
       colors: [
@@ -215,63 +259,81 @@ describe('pullStyles', () => {
           name: 'Number1',
           parent: 'Collection 1/Default',
           type: 'dimension',
-          value: '24px'
+          value: '24px',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Dark',
           type: 'dimension',
-          value: '24px'
+          value: '24px',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Light',
           type: 'dimension',
-          value: '24px'
+          value: '24px',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Custom',
           type: 'dimension',
-          value: '24px'
+          value: '24px',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Default',
           type: 'dimension',
-          value: '16px'
+          value: '16px',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Dark',
           type: 'dimension',
-          value: '16px'
+          value: '16px',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Light',
           type: 'dimension',
-          value: '16px'
+          value: '16px',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Custom',
           type: 'dimension',
-          value: '16px'
-        }
-      ]
+          value: '16px',
+        },
+      ],
+      booleans: [{
+        description: '', name: 'Boolean', parent: 'Collection 1/Default', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Dark', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Light', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Custom', type: 'boolean', value: 'true',
+      }],
+      strings: [{
+        description: '', name: 'String', parent: 'Collection 1/Default', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Dark', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Light', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Custom', type: 'text', value: 'Hello',
+      }],
     });
   });
 
   it('pulls variables with Use rem for dimension values option', async () => {
-    await pullVariables({ useDimensions: false, useRem: true });
+    await pullVariables({ useDimensions: false, useRem: 'true' });
 
     expect(notifyStyleValuesSpy).toHaveBeenCalledWith({
       colors: [
@@ -310,63 +372,81 @@ describe('pullStyles', () => {
           name: 'Number1',
           parent: 'Collection 1/Default',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Dark',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Light',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Custom',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Default',
           type: 'dimension',
-          value: '1rem'
+          value: '1rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Dark',
           type: 'dimension',
-          value: '1rem'
+          value: '1rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Light',
           type: 'dimension',
-          value: '1rem'
+          value: '1rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Custom',
           type: 'dimension',
-          value: '1rem'
-        }
-      ]
+          value: '1rem',
+        },
+      ],
+      booleans: [{
+        description: '', name: 'Boolean', parent: 'Collection 1/Default', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Dark', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Light', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Custom', type: 'boolean', value: 'true',
+      }],
+      strings: [{
+        description: '', name: 'String', parent: 'Collection 1/Default', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Dark', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Light', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Custom', type: 'text', value: 'Hello',
+      }],
     });
   });
 
   it('pulls variables with dimensions in rem if both options are selected', async () => {
-    await pullVariables({ useDimensions: true, useRem: true });
+    await pullVariables({ useDimensions: 'true', useRem: 'true' });
 
     expect(notifyStyleValuesSpy).toHaveBeenCalledWith({
       colors: [
@@ -405,58 +485,76 @@ describe('pullStyles', () => {
           name: 'Number1',
           parent: 'Collection 1/Default',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Dark',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Light',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number1',
           parent: 'Collection 1/Custom',
           type: 'dimension',
-          value: '1.5rem'
+          value: '1.5rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Default',
           type: 'dimension',
-          value: '1rem'
+          value: '1rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Dark',
           type: 'dimension',
-          value: '1rem'
+          value: '1rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Light',
           type: 'dimension',
-          value: '1rem'
+          value: '1rem',
         },
         {
           description: '',
           name: 'Number2',
           parent: 'Collection 1/Custom',
           type: 'dimension',
-          value: '1rem'
-        }
-      ]
+          value: '1rem',
+        },
+      ],
+      booleans: [{
+        description: '', name: 'Boolean', parent: 'Collection 1/Default', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Dark', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Light', type: 'boolean', value: 'true',
+      }, {
+        description: '', name: 'Boolean', parent: 'Collection 1/Custom', type: 'boolean', value: 'true',
+      }],
+      strings: [{
+        description: '', name: 'String', parent: 'Collection 1/Default', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Dark', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Light', type: 'text', value: 'Hello',
+      }, {
+        description: '', name: 'String', parent: 'Collection 1/Custom', type: 'text', value: 'Hello',
+      }],
     });
   });
 });


### PR DESCRIPTION
### Why does this PR exist?

Closes [#3045](https://github.com/tokens-studio/figma-plugin/issues/3045)

When there was an error importing Variables from Figma, the whole process stopped.

### What does this pull request do?

Adds a try / catch block when importing Figma Variables, therefore any errors are shown in the console, and the Plugin continues to import the rest.

### Testing this change
* Go to this file: [DS](https://www.figma.com/design/bcF9PczrsSsorC4zWO2WNv/DS?node-id=5002-58299&t=Kk7WjM9H6ZGwzvzd-0) 
* See that the local variables are there (6 collections)
* Open the plugin -> Styles & Variables -> Import Variables (Tick "Convert numbers to dimensions")
* It will take some time ⏳ 
* See the handled error message _("Error handling variable")_ & tokens in the Plugin ✨ 

<img width="600" alt="Screenshot 2024-08-02 at 13 12 41" src="https://github.com/user-attachments/assets/551f202d-1449-43d6-a251-547053dfef4b">