### PR TITLE
fix: store last synced state from remote

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import React from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -19,6 +20,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 type AdoCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.ADO; }>;
 type AdoFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.ADO; }>;
@@ -87,6 +89,8 @@ export const useADO = () => {
           themes,
           metadata,
         });
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
 
         return {
@@ -212,6 +216,8 @@ export const useADO = () => {
               themes: content.themes,
               metadata: content.metadata,
             });
+            const stringifiedRemoteTokens = JSON.stringify(compact([sortedValues, content.themes, TokenFormat.format]), null, 2);
+            dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
             dispatch.tokenState.setCollapsedTokenSets([]);
             notifyToUI('Pulled tokens from ADO');
           }

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -19,6 +20,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 type BitbucketCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.BITBUCKET }>;
 type BitbucketFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.BITBUCKET }>;
@@ -94,6 +96,8 @@ export function useBitbucket() {
           themes,
           metadata,
         });
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {
           status: 'success',
@@ -225,6 +229,8 @@ export function useBitbucket() {
                 themes: content.themes,
                 metadata: content.metadata,
               });
+              const stringifiedRemoteTokens = JSON.stringify(compact([sortedValues, content.themes, TokenFormat.format]), null, 2);
+              dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
               dispatch.tokenState.setCollapsedTokenSets([]);
               notifyToUI('Pulled tokens from Bitbucket');
             }

--- a/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../../../plugin/notifiers';
 import * as pjs from '../../../../../package.json';
@@ -21,6 +22,7 @@ import {
 } from '@/types/StorageType';
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { ErrorMessages } from '@/constants/ErrorMessages';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 export async function updateGenericVersionedTokens({
   tokens,
@@ -274,6 +276,8 @@ export function useGenericVersionedStorage() {
             tokenSetOrder: Object.keys(content.tokens),
           },
         });
+        const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, content.themes, TokenFormat.format]), null, 2);
+        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         return content;
       }
 

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -21,6 +22,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 type GithubCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITHUB; }>;
 type GithubFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITHUB }>;
@@ -88,6 +90,8 @@ export function useGitHub() {
           themes,
           metadata,
         });
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {
           status: 'success',
@@ -223,6 +227,8 @@ export function useGitHub() {
               themes: content.themes,
               metadata: content.metadata,
             });
+            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, content.themes, TokenFormat.format]), null, 2);
+            dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(commitSha ? { commitSha } : {}) });
             notifyToUI('Pulled tokens from GitHub');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -22,6 +23,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 export type GitlabCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITLAB; }>;
 type GitlabFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITLAB }>;
@@ -98,6 +100,8 @@ export function useGitLab() {
           themes,
           metadata,
         });
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {
           status: 'success',
@@ -235,6 +239,8 @@ export function useGitLab() {
               themes: content.themes,
               metadata: content.metadata,
             });
+            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, content.themes, TokenFormat.format]), null, 2);
+            dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(latestCommitDate ? { commitDate: latestCommitDate } : {}) });
             notifyToUI('Pulled tokens from GitLab');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../../plugin/notifiers';
 import * as pjs from '../../../../package.json';
@@ -17,6 +18,7 @@ import { StorageTypeCredentials, StorageTypeFormValues } from '@/types/StorageTy
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 export async function updateJSONBinTokens({
   tokens, themes, context, updatedAt, oldUpdatedAt = null, storeTokenIdInJsonEditor, dispatch,
@@ -217,6 +219,8 @@ export function useJSONbin() {
         themes: content.themes,
         metadata: { tokenSetOrder: Object.keys(tokens) },
       });
+      const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), content.themes, TokenFormat.format]), null, 2);
+      dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
       return content;
     }
     return content;

--- a/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '@/plugin/notifiers';
 import {
@@ -21,6 +22,7 @@ import { RemoteResponseData } from '../../../../types/RemoteResponseData';
 import { ErrorMessages } from '../../../../constants/ErrorMessages';
 import { applyTokenSetOrder } from '../../../../utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 type SupernovaCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.SUPERNOVA }>;
 type SupernovaFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.SUPERNOVA }>;
@@ -75,6 +77,8 @@ export function useSupernova() {
             themes,
             metadata,
           });
+          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+          dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
           pushDialog({ state: 'success' });
           return {
             status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '@/plugin/notifiers';
 import {
@@ -21,6 +22,7 @@ import { ErrorMessages } from '../../../../constants/ErrorMessages';
 import { PushOverrides } from '../../remoteTokens';
 import { RemoteTokenStorageMetadata } from '@/storage/RemoteTokenStorage';
 import { applyTokenSetOrder } from '@/utils/tokenset';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 type TokensStudioCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.TOKENS_STUDIO }>;
 type TokensStudioFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.TOKENS_STUDIO }>;
@@ -106,6 +108,8 @@ export function useTokensStudio() {
             themes,
             metadata,
           });
+          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+          dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
           pushDialog({ state: 'success' });
           return {
             status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
+import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../../plugin/notifiers';
 import { UrlTokenStorage } from '@/storage/UrlTokenStorage';
@@ -11,6 +12,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { activeThemeSelector, usedTokenSetSelector } from '@/selectors';
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { applyTokenSetOrder } from '@/utils/tokenset';
+import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 
 type UrlCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.URL; }>;
 
@@ -69,6 +71,8 @@ export default function useURL() {
             themes: content.themes,
             metadata: content.metadata,
           });
+          const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), content.themes, TokenFormat.format]), null, 2);
+          dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
           dispatch.tokenState.setEditProhibited(true);
           return content;
         }

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
+import compact from 'just-compact';
 import { track } from '@/utils/analytics';
 import { useJSONbin } from './providers/jsonbin';
 import useURL from './providers/url';
@@ -23,7 +24,7 @@ import { StorageProviderType } from '@/constants/StorageProviderType';
 import { StorageTypeCredentials, StorageTypeFormValues } from '@/types/StorageType';
 import { useGenericVersionedStorage } from './providers/generic/versionedStorage';
 import { RemoteResponseData, RemoteResponseStatus } from '@/types/RemoteResponseData';
-import { getFormat } from '@/plugin/TokenFormatStoreClass';
+import { getFormat, TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { isEqual } from '@/utils/isEqual';
@@ -155,6 +156,8 @@ export default function useRemoteTokens() {
           themes: remoteData.themes,
           metadata: remoteData.metadata,
         });
+        const stringifiedRemoteTokens = JSON.stringify(compact([remoteData.tokens, remoteData.themes, TokenFormat.format]), null, 2);
+        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         if (activeTab !== Tabs.LOADING) {
           if (updateLocalTokens) {
             const format = getFormat();


### PR DESCRIPTION
### Why does this PR exist?

Closes #2984 

Ensures that every time remote changes are made, the provider data is saved in the local state as `lastSyncedState`. Treat this as a follow-up from the merged PR https://github.com/tokens-studio/figma-plugin/pull/3035

### What does this pull request do?

Dispatches data to set `setLastSyncedState` (the same as `setRemoteData`) so that `tokenState` is up to date with the freshest remote status.

### Testing this change
* Open the plugin
* Make token changes
* Push changes
* Continue to use the plugin and see no 'notification' bubble shows to push anything!

https://github.com/user-attachments/assets/6568d740-1039-4d59-b546-842ca90f1454

