### PR TITLE
fix: exporting and applying styles correctly references the tokens

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -20,7 +20,7 @@ export class TokenValueRetriever {
   public createStylesWithVariableReferences;
 
   private getAdjustedTokenName(tokenName: string): string {
-    const withIgnoredFirstPart = this.ignoreFirstPartForStyles ? tokenName.split('.').slice(1).join('.') : tokenName;
+    const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1 ? tokenName.split('.').slice(1).join('.') : tokenName;
     const withPrefix = [this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
     return withPrefix;
   }

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/setNodeData.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/setNodeData.ts
@@ -20,7 +20,7 @@ export const setNodeData: AsyncMessageChannelHandlers[AsyncMessageTypes.SET_NODE
         variableReferences: figmaVariableReferences,
         styleReferences: figmaStyleReferences,
         stylePathPrefix,
-        ignoreFirstPartForStyles: msg.settings.prefixStylesWithThemeName,
+        ignoreFirstPartForStyles: msg.settings.ignoreFirstPartForStyles,
         applyVariablesStylesOrRawValue: msg.settings.applyVariablesStylesOrRawValue,
       });
 

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
@@ -25,7 +25,7 @@ export default async function updateStyles(
     // When multiple theme has the same active Token set then the last activeTheme wins
     const activeTheme = activeThemes.find((theme) => Object.entries(theme.selectedTokenSets).some(([tokenSet, status]) => status === TokenSetStatus.ENABLED && tokenSet === token.internal__Parent));
     const prefix = settings.prefixStylesWithThemeName && activeTheme ? activeTheme.name : null;
-    const slice = settings?.ignoreFirstPartForStyles ? 1 : 0;
+    const slice = settings?.ignoreFirstPartForStyles && token.name.split('.').length > 1 ? 1 : 0;
     const path = convertTokenNameToPath(token.name, prefix, slice);
     return {
       ...token,


### PR DESCRIPTION
### Why does this PR exist?

Closes #3049

When users were exporting styles that had either **"Ignore first part of token name for styles"** or **"Prefix styles with active theme name"** toggled **ON**, the styles applied to the node would reference the _resolve value_ instead of the _token name_

<img width="250" alt="Screenshot 2024-08-07 at 11 54 18" src="https://github.com/user-attachments/assets/0027801b-db11-43b4-9f46-fc8c5574b8cc">

### What does this pull request do?
* Passes the correct props related to the toggle options onto the `TokenValueRetriever` 
* When "**Ignore first part...**" is toggled, the token at hand is only manipulated when its path length is over 1

### Testing this change
🔨 Tested with [tokens.json](https://github.com/user-attachments/files/16510283/tokens.json)
⏯️ Styles & Variables -> Export Styles & Variables -> Tick everything under **Styles** -> Select Themes / Token Sets (ensure there's at least 1 active one)

https://github.com/user-attachments/assets/edea2f82-f29e-40fd-9c31-69ddf20dbeac

#### A. No options toggled
✅ `1-color-token` shows as the fill when the color token ⚫ is clicked
✅ `1-color-token` shows as the fill when the “Apply to selection” button is clicked

#### B. Ignore first part...
✅ `1-color-token` shows as the fill when the color token ⚫ is clicked
✅ `1-color-token` shows as the fill when the “Apply to selection” button is clicked

#### C. Prefix styles with... (⚠️ Need to delete the styles created beforehand in Figma)
✅  `first-theme/1-color-token` shows as the fill when the color token ⚫ is clicked
✅  `first-theme/1-color-token` shows as the fill when the “Apply to selection” button is clicked

#### B & C  (⚠️ Need to delete the styles created beforehand in Figma)
✅  `first-theme/1-color-token` shows as the fill when the color token ⚫ is clicked
✅ `first-theme/1-color-token` shows as the fill when the “Apply to selection” button is clicked