### PR TITLE
fix endless loader

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
@@ -145,7 +145,6 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
       <Modal
         size="fullscreen"
         full
-        compact
         isOpen={showChangeSets}
         close={handleCancelChangeSets}
         backArrow
@@ -165,7 +164,6 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
         {/* Commenting until we have docs <Link target="_blank" href={docsLinks.sets}>{`${t('generic.learnMore')} – ${t('docs.referenceOnlyMode')}`}</Link> */}
         <Stack
           direction="column"
-          gap={2}
           css={{
             marginBlockStart: '$4',
           }}

--- a/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.ts
@@ -1,4 +1,8 @@
-export function convertFontWeightToFigma(value: string) {
+export function convertFontWeightToFigma(value: string, shouldOutputForVariables = false): string[] {
+  if (shouldOutputForVariables) {
+    return [value];
+  }
+
   switch (value) {
     case '100':
       return ['Thin', 'Hairline'];

--- a/packages/tokens-studio-for-figma/src/plugin/helpers.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/helpers.ts
@@ -72,7 +72,7 @@ export function transformValue(value: string, type: string, baseFontSize: string
       return convertTypographyNumberToFigma(value, baseFontSize);
     case 'fontWeights':
     case 'fontWeight':
-      return convertFontWeightToFigma(value);
+      return convertFontWeightToFigma(value, shouldOutputForVariables);
     case 'letterSpacing':
       return convertLetterSpacingToFigma(value, baseFontSize, shouldOutputForVariables);
     case 'lineHeights':

--- a/packages/tokens-studio-for-figma/src/plugin/setNumberValuesOnVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setNumberValuesOnVariable.ts
@@ -1,10 +1,8 @@
 export default function setNumberValuesOnVariable(variable: Variable, mode: string, value: number) {
-  if (isNaN(value)) {
-    console.warn('Skipping setting numberVariable due to invalid value: NaN', value);
-    return;
-  }
-
   try {
+    if (isNaN(value)) {
+      throw new Error(`Skipping due to invalid value: ${value}`);
+    }
     variable.setValueForMode(mode, value);
   } catch (e) {
     console.error('Error setting numberVariable', e);

--- a/packages/tokens-studio-for-figma/src/plugin/setNumberValuesOnVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setNumberValuesOnVariable.ts
@@ -1,4 +1,9 @@
 export default function setNumberValuesOnVariable(variable: Variable, mode: string, value: number) {
+  if (isNaN(value)) {
+    console.warn('Skipping setting numberVariable due to invalid value: NaN', value);
+    return;
+  }
+
   try {
     variable.setValueForMode(mode, value);
   } catch (e) {

--- a/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setValuesOnVariable.ts
@@ -50,22 +50,25 @@ export default async function setValuesOnVariable(
 
         switch (variableType) {
           case 'BOOLEAN':
-            if (typeof token.value === 'string') {
+            if (typeof token.value === 'string' && !token.value.includes('{')) {
               setBooleanValuesOnVariable(variable, mode, token.value);
             }
             break;
           case 'COLOR':
-            if (typeof token.value === 'string') {
+            if (typeof token.value === 'string' && !token.value.includes('{')) {
               setColorValuesOnVariable(variable, mode, token.value);
             }
             break;
           case 'FLOAT': {
-            const transformedValue = transformValue(String(token.value), token.type, baseFontSize, true);
-            setNumberValuesOnVariable(variable, mode, Number(transformedValue));
+            const value = String(token.value);
+            if (typeof value === 'string' && !value.includes('{')) {
+              const transformedValue = transformValue(value, token.type, baseFontSize, true);
+              setNumberValuesOnVariable(variable, mode, Number(transformedValue));
+            }
             break;
           }
           case 'STRING':
-            if (typeof token.value === 'string') {
+            if (typeof token.value === 'string' && !token.value.includes('{')) {
               setStringValuesOnVariable(variable, mode, token.value);
               // Given we cannot determine the combined family of a variable, we cannot use fallback weights from our estimates.
               // This is not an issue because users can set numerical font weights with variables, so we opt-out of the guesswork and just apply the numerical weight.

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariablesToReference.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariablesToReference.ts
@@ -12,11 +12,15 @@ export default async function updateVariablesToReference(figmaVariables: Map<str
       console.log('error importing variable', e);
     }
     if (!variable) return;
-    await aliasVariable.variable.setValueForMode(aliasVariable.modeId, {
-      type: 'VARIABLE_ALIAS',
-      id: variable.id,
-    });
-    updatedVariables.push(aliasVariable.variable);
+    try {
+      await aliasVariable.variable.setValueForMode(aliasVariable.modeId, {
+        type: 'VARIABLE_ALIAS',
+        id: variable.id,
+      });
+      updatedVariables.push(aliasVariable.variable);
+    } catch (e) {
+      console.log('error setting value for mode', e, aliasVariable, variable);
+    }
   }));
   return updatedVariables;
 }


### PR DESCRIPTION
### Why does this PR exist?

Closes #3054

Users were facing an endless `Creating variables…` loader that didnt go away

### What does this pull request do?

Adds a try { } catch { } block to the `updateVariableToReferences` function that safely proceeds creating variables if we encounter an error trying to set a variable. The reason for this was that sometimes we were passing in the wrong type for a variable that expected something else.

This PR also adds checks to make sure that we do not attempt to set the value if it is `NaN` and logs a warning message if this is the case. As well as adding a check to see if the value is still a raw value.

### Testing this change

Try to recreate with the token sets shared in https://hyma-team.slack.com/archives/C06RHB9RT2B/p1723030872522979