### PR TITLE
fix remote change indicator

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ChangedStateList.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ChangedStateList.tsx
@@ -6,11 +6,14 @@ import ChangedTokenItem from './ChangedTokenItem';
 import { StyledDiff } from './StyledDiff';
 import { useChangedState } from '@/hooks/useChangedState';
 
-function ChangedStateList() {
-  const { changedState } = useChangedState();
+function ChangedStateList({ type }: { type: 'push' | 'pull' }) {
+  const { changedPullState, changedPushState } = useChangedState();
   const [collapsed, setCollapsed] = React.useState(false);
   const { t } = useTranslation(['tokens']);
   const [collapsedChangedStateList, setCollapsedChangedStateList] = React.useState<Array<string>>([]);
+
+  const changedState = type === 'push' ? changedPushState : changedPullState;
+
   const handleSetIntCollapsed = React.useCallback((e: React.MouseEvent<HTMLButtonElement>, tokenSet: string) => {
     e.stopPropagation();
     if (e.altKey) {
@@ -29,7 +32,7 @@ function ChangedStateList() {
   }, [collapsedChangedStateList, changedState.tokens, collapsed]);
 
   return (
-    <Stack direction="column" gap={1} css={{ padding: '$4' }}>
+    <Stack direction="column" gap={1} css={{ padding: '$4', width: '100%' }}>
       {Object.entries(changedState.tokens).length > 0 && Object.entries(changedState.tokens)?.map(([tokenSet, tokenList]) => (
         <Box key={tokenSet} css={{ maxWidth: '100%' }}>
           <ChangeStateListingHeading count={tokenList.length} onCollapse={handleSetIntCollapsed} set={tokenSet} label={tokenSet} isCollapsed={collapsedChangedStateList.includes(tokenSet)} />

--- a/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
@@ -47,12 +47,10 @@ function PullDialog() {
             </Stack>
           )}
         >
-          <Stack direction="column" gap={4}>
-            <Stack direction="row" gap={2} css={{ padding: '$4' }}>
-              {t('override')}
-            </Stack>
-            <ChangedStateList />
+          <Stack direction="row" gap={2} css={{ padding: '$4', paddingBottom: 0 }}>
+            {t('override')}
           </Stack>
+          <ChangedStateList type="pull" />
         </Modal>
       );
     }

--- a/packages/tokens-studio-for-figma/src/app/components/PushDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/PushDialog.tsx
@@ -180,7 +180,7 @@ function PushDialog() {
                 handleCommitMessageChange={handleCommitMessageChange}
               />
             )}
-            {activeTab === 'diff' && <ChangedStateList />}
+            {activeTab === 'diff' && <ChangedStateList type="push" />}
             {activeTab === 'json' && <PushJSON />}
           </Stack>
         </Modal>

--- a/packages/tokens-studio-for-figma/src/app/store/models/uiState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/uiState.tsx
@@ -90,6 +90,7 @@ export interface UIState {
   showAutoSuggest: boolean;
   showConvertTokenFormatModal: boolean;
   sidebarWidth: number;
+  hasRemoteChange: boolean;
 }
 
 const defaultConfirmState: ConfirmProps = {
@@ -149,6 +150,7 @@ export const uiState = createModel<RootModel>()({
     showAutoSuggest: false,
     showConvertTokenFormatModal: false,
     sidebarWidth: 150,
+    hasRemoteChange: false,
   } as unknown as UIState,
   reducers: {
     setShowConvertTokenFormatModal: (state, data: boolean) => ({
@@ -162,6 +164,10 @@ export const uiState = createModel<RootModel>()({
     setShowPullDialog: (state, data: string | false) => ({
       ...state,
       showPullDialog: data,
+    }),
+    setHasRemoteChange: (state, data: boolean) => ({
+      ...state,
+      hasRemoteChange: data,
     }),
     setShowConfirm: (
       state,

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.test.ts
@@ -42,6 +42,7 @@ const mockResetChangedState = jest.fn();
 const mockGetCommitSha = jest.fn();
 const mockGetLatestCommitDate = jest.fn();
 const mockSetRemoteData = jest.fn();
+const mockSetHasRemoteChange = jest.fn();
 
 // Hide log calls unless they are expected
 jest.spyOn(console, 'log').mockImplementation(() => { });
@@ -83,6 +84,7 @@ jest.mock('react-redux', () => ({
       setApiData: mockSetApiData,
       setStorage: mockSetStorage,
       setShowConfirm: mockSetShowConfirm,
+      setHasRemoteChange: mockSetHasRemoteChange,
     },
     tokenState: {
       setLastSyncedState: mockSetLastSyncedState,

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -156,6 +156,7 @@ export default function useRemoteTokens() {
           themes: remoteData.themes,
           metadata: remoteData.metadata,
         });
+        dispatch.uiState.setHasRemoteChange(false);
         const stringifiedRemoteTokens = JSON.stringify(compact([remoteData.tokens, remoteData.themes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         if (activeTab !== Tabs.LOADING) {
@@ -608,9 +609,10 @@ export default function useRemoteTokens() {
           hasChange = false;
           break;
       }
+      dispatch.uiState.setHasRemoteChange(hasChange);
       return hasChange;
     },
-    [api, checkRemoteChangeForGitHub, checkRemoteChangeForGitLab],
+    [api, checkRemoteChangeForGitHub, checkRemoteChangeForGitLab, dispatch.uiState],
   );
 
   return useMemo(

--- a/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
@@ -21,13 +21,25 @@ export function useChangedState() {
   const tokenFormat = useSelector(tokenFormatSelector);
   const dispatch = useDispatch();
 
-  const changedState = useMemo(() => {
+  const changedPushState = useMemo(() => {
     const tokenSetOrder = Object.keys(tokens);
     return findDifferentState(remoteData, {
       tokens,
       themes,
       metadata: storageType.provider !== StorageProviderType.LOCAL ? { tokenSetOrder } : {},
     });
+  }, [remoteData, tokens, themes, storageType]);
+
+  const changedPullState = useMemo(() => {
+    const tokenSetOrder = Object.keys(tokens);
+    return findDifferentState(
+      {
+        tokens,
+        themes,
+        metadata: storageType.provider !== StorageProviderType.LOCAL ? { tokenSetOrder } : {},
+      },
+      remoteData,
+    );
   }, [remoteData, tokens, themes, storageType]);
 
   const hasChanges = useMemo(() => {
@@ -38,5 +50,5 @@ export function useChangedState() {
     return hasChanged;
   }, [tokens, themes, lastSyncedState, tokenFormat, dispatch.tokenState]);
 
-  return { changedState, hasChanges };
+  return { changedPushState, changedPullState, hasChanges };
 }


### PR DESCRIPTION
### Why does this PR exist?

Closes #3057

We previously showed the wrong state when pulling changes, which had the "new state" on the left side which had shown this as the "old state".

Also, the indicator didnt disappear. The reason for that was that this was a local state variable, which was not reset when pulling changes - only when 60 seconds pass.

### What does this pull request do?

This PR changes things so that we have a uiState for the remote change indicator, which is reset when pulling changes. Also, we show the correct state when pulling changes by having two different changedState implementations (which just reverses the order)

### Testing this change

Have two files open that have the same remote. Change tokens in one file and push. Then wait 60 seconds for the indicator to appear and pull the changes. Also, when pushing and pulling, look at the token values in the diff state.

### Additional Notes (if any)

https://github.com/user-attachments/assets/79151bd4-077d-4c99-90a8-74e0a8567dc1

