### PR TITLE
Fixes UI breaking when sentry record was executing too fast

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/sentry.ts
+++ b/packages/tokens-studio-for-figma/src/app/sentry.ts
@@ -16,14 +16,20 @@ export const replay = new Sentry.Replay({
 });
 
 export const setupReplay = () => {
-  const client = Sentry.getCurrentHub().getClient();
+  setTimeout(() => {
+    try {
+      const client = Sentry.getCurrentHub().getClient();
 
-  if (client) {
-    if (!client?.getIntegration(Sentry.Replay)) {
-      // @ts-ignore This should never be undefined after the check above
-      client.addIntegration(replay);
+      if (client) {
+        if (!client.getIntegration(Sentry.Replay)) {
+          // @ts-ignore This should never be undefined after the check above
+          client.addIntegration(replay);
+        }
+      }
+    } catch (error) {
+      console.error('Error setting up Sentry Replay:', error);
     }
-  }
+  }, 2000); // Delay by 2000 milliseconds (2 seconds)
 };
 
 export const initializeSentry = () => {


### PR DESCRIPTION
Not sure why, but when session record was on and executed immediately (ie. no external git source) then the ui would break 🫠 

This adds a timeout of 2s on initiating the replay. which seems to fix it.

To test:
Enable session record in the settings
Go to a new file and open the plugin

Before (note the icon buttons in the bottom right)

<img width="496" alt="CleanShot 2024-08-10 at 12 32 32@2x" src="https://github.com/user-attachments/assets/119a44f0-edf8-4f73-b8e9-e00b237379ed">

After:

<img width="495" alt="CleanShot 2024-08-10 at 12 31 31@2x" src="https://github.com/user-attachments/assets/04d978db-b496-475b-84b9-721a2c7bd880">
