### PR TITLE
fix: position of name help text in BitBucket Form

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/BitbucketForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/BitbucketForm.tsx
@@ -74,6 +74,7 @@ export default function BitbucketForm({
         <FormField>
           <Label htmlFor="name">{t('name')}</Label>
           <TextInput value={values.name || ''} onChange={onChange} type="text" name="name" id="name" required />
+          <Text muted>{t('nameHelpText')}</Text>
         </FormField>
         <FormField>
           <Label htmlFor="name">{t('providers.bitbucket.username')}</Label>
@@ -85,7 +86,6 @@ export default function BitbucketForm({
             id="username"
             required
           />
-          <Text muted>{t('nameHelpText')}</Text>
         </FormField>
         <FormField>
           <Label htmlFor="secret">{t('providers.bitbucket.appPassword')}</Label>


### PR DESCRIPTION
simple change of position of name help text in the Bitbucket Sync Form
<img width="495" alt="Screenshot 2024-08-13 at 14 05 00" src="https://github.com/user-attachments/assets/dfbfb3eb-379b-49b8-8e15-c31bc6a0379b">
