### PR TITLE
Fix bitbucket folder sync pull

### DIFF
--- a/.changeset/mighty-cooks-punch.md
+++ b/.changeset/mighty-cooks-punch.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-Fix issue with Bitbucket sync wiping sets when they are in a folder format
+Fixed an issue with Bitbucket sync that caused sets to be wiped when they are in a folder format

--- a/.changeset/mighty-cooks-punch.md
+++ b/.changeset/mighty-cooks-punch.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix issue with Bitbucket sync wiping sets when they are in a folder format

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -217,7 +217,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
             data: parsed as AnyTokenSet<false>,
           };
         });
-      } else if(jsonFiles) {
+      } else if (jsonFiles) {
         const parsed = jsonFiles as GitSingleFileObject;
         return [
           {
@@ -247,7 +247,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
           })),
         ];
       }
-      return{
+      return {
         errorMessage: ErrorMessages.VALIDATION_ERROR,
       };
     } catch (e) {

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -174,7 +174,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
               });
               const dirData = await dirResponse.json();
               return dirData.values.filter((file: any) => file.path.endsWith('.json'));
-            })
+            }),
         );
 
         jsonFiles = jsonFiles.concat(...directoryFiles);


### PR DESCRIPTION
### Why does this PR exist?

Resolves #3070 

In the 2.0 version of the plugin, the users are unable to fetch sets from Bitbucket remote storage, when the sets are in a folder structure. For example if a set exists as folder1/set1, it shall be unable to fetch it and even delete the existing folder sets.

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

- This PR scans through the response of the Bitbucket API and filters the directories as well(which was earlier being ignored), and then fetches the sets in json format from each of those folders.
- It then scans through all the json files(which was being done previously as well, but now includes the folder structure sets as well)

### Testing this change

- Create a set in a folder,
- Add some tokens in the set
- Push to Bitbucket
- Then pull from Bitbucket
- Expected: It should not wipe the folder sets and pull the sets in the folder
