### PR TITLE
Fixes broken UI issue

### DIFF
--- a/.changeset/silly-beds-drum.md
+++ b/.changeset/silly-beds-drum.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue with UI appearing broken, related to the debug session recording feature

--- a/packages/tokens-studio-for-figma/src/app/sentry.ts
+++ b/packages/tokens-studio-for-figma/src/app/sentry.ts
@@ -16,14 +16,20 @@ export const replay = new Sentry.Replay({
 });
 
 export const setupReplay = () => {
-  const client = Sentry.getCurrentHub().getClient();
+  setTimeout(() => {
+    try {
+      const client = Sentry.getCurrentHub().getClient();
 
-  if (client) {
-    if (!client?.getIntegration(Sentry.Replay)) {
-      // @ts-ignore This should never be undefined after the check above
-      client.addIntegration(replay);
+      if (client) {
+        if (!client?.getIntegration(Sentry.Replay)) {
+          // @ts-ignore This should never be undefined after the check above
+          client.addIntegration(new Replay());
+        }
+      }
+    } catch (error) {
+      console.error('Error setting up Sentry Replay:', error);
     }
-  }
+  }, 2000); // Delay by 2000 milliseconds (2 seconds) to make sure we load in UI properly, see https://github.com/tokens-studio/figma-plugin/issues/3073
 };
 
 export const initializeSentry = () => {


### PR DESCRIPTION
### Why does this PR exist?

Closes #3073 

We didnt await setupReplay before, which seems to have caused some issues initializing our CSS styles.

### What does this pull request do?

Adds a 2 second timeout to session recording.

### Testing this change

Enable remote storage, enable session recording. Restart plugin. All should look good. With 2.0 prod it looks broken.

### Additional Notes (if any)

Before:

<img width="448" alt="CleanShot 2024-08-15 at 10 29 35@2x" src="https://github.com/user-attachments/assets/3d5d536c-50df-4abe-9e09-5ebc98f55b9a">


After:

<img width="459" alt="CleanShot 2024-08-15 at 10 27 25@2x" src="https://github.com/user-attachments/assets/4fa769fe-2ad6-4aa5-a72a-160114b7f5db">

