### PR TITLE
Fix checkbox UI for duplicate resolve modal

### DIFF
--- a/.changeset/spotty-parents-train.md
+++ b/.changeset/spotty-parents-train.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix a visual bug in the Resolve Duplicate Tokens modal

--- a/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/DuplicateResolver/ResolveDuplicateTokenGroup.tsx
@@ -83,7 +83,7 @@ export default function ResolveDuplicateTokenGroup({
           {groupValue.map((uniqueToken, i) => (
             // eslint-disable-next-line react/no-array-index-key
             <RadioItem key={`${uniqueToken.name}-${i}`} value={`${setName}:${uniqueToken.name}:${i}`} css={{ alignItems: 'center' }}>
-              <RadioItemBefore data-state={checkedToken === `${setName}:${uniqueToken.name}:${i}` ? 'checked' : 'unchecked'}>
+              <RadioItemBefore data-state={checkedToken === `${setName}:${uniqueToken.name}:${i}` ? 'checked' : 'unchecked'} css={{ flexShrink: 0 }}>
                 <RadioIndicator />
               </RadioItemBefore>
               <ResolveDuplicateTokenSingle token={uniqueToken} />


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes #3068  <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

- Fixes checkbox for max width value previews.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Use this tokens JSON

```json
{
"a": {
    "test": {
      "$type": "color",
      "$value": "#0aa"
    }
  },
  "a-copy": {
    "test": {
      "$type": "color",
      "$value": "linear-gradient(180deg, {colors.teal.800}, {colors.teal.800}, {colors.teal.800}, #0fa, {colors.teal.800} , #0fa 100%)"
    }
  }
}
```

Change `const error ...` in `DuplicateTokenGroupModal` to this (might need to set some types to `any` for the build to pass):

```
const error: any = useMemo(() => null, [isOpen, activeTokenSet, newName, oldName, selectedTokenSets, tokens, type]);
```

- Duplicate the group `a-copy` to `a`

- Open the duplicate resolve modal button in the footer.

- Verify that the radio checkbox isn't stretched

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<img width="532" alt="image" src="https://github.com/user-attachments/assets/eea36061-4e39-455e-b71e-cb4d3ddc332b">


<!--
  Add any other context or screenshots about the pull request
-->
