### PR TITLE
Fix: Allow expressions to return string and boolean values

### DIFF
--- a/.changeset/wild-drinks-pretend.md
+++ b/.changeset/wild-drinks-pretend.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes math evaluation to allow boolean and strings as return values

--- a/packages/tokens-studio-for-figma/src/utils/math/__tests__/checkAndEvaluateMath.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/math/__tests__/checkAndEvaluateMath.test.ts
@@ -53,4 +53,16 @@ describe('checkAndEvaluateMath', () => {
     expect(checkAndEvaluateMath('sample(cubicBezier1D(0.45,0.34),0.2)')).toEqual(0.213);
     expect(checkAndEvaluateMath('sample(cubicBezier1D(0.45,0.34),0.2)')).toEqual(0.213);
   });
+
+  it('handles boolean values correctly', () => {
+    expect(checkAndEvaluateMath('true')).toEqual(true);
+    expect(checkAndEvaluateMath('false')).toEqual(false);
+    expect(checkAndEvaluateMath('3 > 2')).toEqual(true);
+    expect(checkAndEvaluateMath('3 < 2')).toEqual(false);
+    expect(checkAndEvaluateMath('3 == 3')).toEqual(true);
+  });
+
+  it('handles string values correctly', () => {
+    expect(checkAndEvaluateMath(`true ? 'yes' : 'no'`)).toEqual('yes');
+  });
 });

--- a/packages/tokens-studio-for-figma/src/utils/math/checkAndEvaluateMath.ts
+++ b/packages/tokens-studio-for-figma/src/utils/math/checkAndEvaluateMath.ts
@@ -72,13 +72,18 @@ export function checkAndEvaluateMath(expr: string) {
     unit = calcReduced.unit;
   }
 
-  let evaluated: number;
+  let evaluated: number | string | boolean; // Can be array too, but arrays support in TS is blurry
 
   try {
     evaluated = parser.evaluate(`${unitlessExpr}`);
   } catch (ex) {
     return expr;
   }
+
+  if(typeof evaluated === 'boolean' || typeof evaluated === 'string') {
+    return evaluated;
+  }
+
   try {
     return unit ? `${evaluated}${unit}` : Number.parseFloat(evaluated.toFixed(3));
   } catch (ex) {


### PR DESCRIPTION
<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Currently, we're unable to use logic to return boolean values or strings when using expr-eval



<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

- Evaluated can be number, string or boolean. 
- Added tests for string and boolean expressions

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

```
{
  "str": {
    "value": "true ? 'yes' : 'no'",
    "type": "other"
  },
  "three-bigger-than-two": {
    "value": "3 > 2 ? true : false",
    "type": "other"
  }
}
```

Create these tokens, values should return `yes` and `true`
In previous versions, checkAndEvaluateMaths would not parse these values properly.

### Additional Notes (if any)
I'm also looking into how arrays could be handled, as I feel the map() function from expr-eval could be useful


<!--
  Add any other context or screenshots about the pull request
-->
