### PR TITLE
fix: ADO single and multi file tests

### DIFF
--- a/.changeset/shaggy-sheep-know.md
+++ b/.changeset/shaggy-sheep-know.md
@@ -1,5 +1,0 @@
----
-"@tokens-studio/figma-plugin": patch
----
-
-Adapts unit tests to reflect ADO writing in single and multi file setups

--- a/.changeset/shaggy-sheep-know.md
+++ b/.changeset/shaggy-sheep-know.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Adapts unit tests to reflect ADO writing in single and multi file setups

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/ADOTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/ADOTokenStorage.test.ts
@@ -21,6 +21,10 @@ describe('ADOTokenStorage', () => {
     storageProvider.changePath('tokens.json');
   });
 
+  afterEach(() => {
+    mockFetch.mockClear();
+  });
+
   it('can fetch branches', async () => {
     mockFetch.mockImplementationOnce(() => Promise.resolve({
       ok: true,
@@ -264,323 +268,359 @@ describe('ADOTokenStorage', () => {
     });
   });
 
-  // TODO: Comment these back in, this test is failing due to recent changes in https://github.com/tokens-studio/figma-plugin/pull/3071 - functionality wise its working
-  // it('should be able to write', async () => {
-  //   mockFetch.mockImplementationOnce(() => Promise.resolve({
-  //     ok: true,
-  //     json: () => Promise.resolve({
-  //       count: 1,
-  //       value: [
-  //         { name: 'refs/heads/main' },
-  //       ],
-  //     }),
-  //   })).mockImplementationOnce(() => Promise.resolve({
-  //     ok: true,
-  //     json: () => Promise.resolve({
-  //       count: 1,
-  //       value: [
-  //         {
-  //           name: 'refs/heads/main',
-  //           objectId: 'main',
-  //         },
-  //       ],
-  //     }),
-  //   })).mockImplementationOnce(() => Promise.resolve({
-  //     ok: true,
-  //     json: () => Promise.resolve({
-  //       count: 1,
-  //       value: [
-  //         { path: '/data/tokens.json' },
-  //       ],
-  //     }),
-  //   })).mockImplementationOnce(() => Promise.resolve({
-  //     ok: true,
-  //     json: () => Promise.resolve({
-  //       count: 1,
-  //       value: [
-  //         { commitId: '123abc' },
-  //       ],
-  //     }),
-  //   }))
-  //     .mockImplementationOnce(() => Promise.resolve({
-  //       ok: true,
-  //     }));
+  it('should be able to write', async () => {
+    mockFetch.mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        count: 1,
+        value: [
+          { name: 'refs/heads/main' },
+        ],
+      }),
+    })).mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        count: 1,
+        value: [
+          { name: 'refs/heads/main' },
+        ],
+      }),
+    }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          count: 1,
+          value: [
+            { objectId: 'abc123', path: '/data/tokens.json' },
+          ],
+        }),
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          count: 1,
+          value: [
+            { name: 'refs/heads/main', objectId: 'abc123' },
+          ],
+        }),
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          count: 1,
+          value: [
+            { commitId: 'hello123' },
+          ],
+        }),
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          count: 1,
+          value: [
+            { name: 'refs/heads/main', objectId: 'abc123' },
+          ],
+        }),
+      }));
 
-  //   storageProvider.selectBranch('main');
-  //   storageProvider.changePath('data/tokens.json');
-  //   expect(await storageProvider.write([
-  //     {
-  //       type: 'metadata',
-  //       path: '$metadata.json',
-  //       data: {},
-  //     },
-  //     {
-  //       type: 'themes',
-  //       path: '$themes.json',
-  //       data: [
-  //         {
-  //           id: 'light',
-  //           name: 'Light',
-  //           selectedTokenSets: {
-  //             global: TokenSetStatus.ENABLED,
-  //           },
-  //         },
-  //       ],
-  //     },
-  //     {
-  //       type: 'tokenSet',
-  //       name: 'global',
-  //       path: 'global.json',
-  //       data: {
-  //         red: {
-  //           type: TokenTypes.COLOR,
-  //           name: 'red',
-  //           value: '#ff0000',
-  //         },
-  //       },
-  //     },
-  //   ], {
-  //     commitMessage: 'Initial commit',
-  //   })).toBe(true);
-  //   expect(mockFetch).toHaveBeenNthCalledWith(
-  //     5,
-  //     `${baseUrl}/${projectId}/_apis/git/repositories/${repositoryId}/pushes?api-version=6.0`,
-  //     {
-  //       method: 'POST',
-  //       headers: {
-  //         'Content-Type': 'application/json',
-  //         Authorization: `Basic ${btoa(`:${secret}`)}`,
-  //       },
-  //       body: JSON.stringify({
-  //         refUpdates: [
-  //           {
-  //             name: 'refs/heads/main',
-  //             oldObjectId: '123abc',
-  //           },
-  //         ],
-  //         commits: [
-  //           {
-  //             comment: 'Initial commit',
-  //             changes: [
-  //               {
-  //                 changeType: 'edit',
-  //                 item: { path: '/data/tokens.json' },
-  //                 newContent: {
-  //                   content: JSON.stringify({
-  //                     $metadata: {},
-  //                     $themes: [
-  //                       {
-  //                         id: 'light',
-  //                         name: 'Light',
-  //                         selectedTokenSets: {
-  //                           global: TokenSetStatus.ENABLED,
-  //                         },
-  //                       },
-  //                     ],
-  //                     global: {
-  //                       red: {
-  //                         type: TokenTypes.COLOR,
-  //                         name: 'red',
-  //                         value: '#ff0000',
-  //                       },
-  //                     },
-  //                   }, null, 2),
-  //                   contentType: 'rawtext',
-  //                 },
-  //               },
-  //             ],
-  //           },
-  //         ],
-  //       }),
-  //     },
-  //   );
-  // });
+    storageProvider.selectBranch('main');
+    storageProvider.changePath('data/tokens.json');
+    expect(await storageProvider.write([
+      {
+        type: 'metadata',
+        path: '$metadata.json',
+        data: {},
+      },
+      {
+        type: 'themes',
+        path: '$themes.json',
+        data: [
+          {
+            id: 'light',
+            name: 'Light',
+            selectedTokenSets: {
+              global: TokenSetStatus.ENABLED,
+            },
+          },
+        ],
+      },
+      {
+        type: 'tokenSet',
+        name: 'global',
+        path: 'global.json',
+        data: {
+          red: {
+            type: TokenTypes.COLOR,
+            name: 'red',
+            value: '#ff0000',
+          },
+        },
+      },
+    ], {
+      commitMessage: 'Initial commit',
+    })).toBe(true);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      6,
+      `${baseUrl}/${projectId}/_apis/git/repositories/${repositoryId}/pushes?api-version=6.0`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${btoa(`:${secret}`)}`,
+        },
+        body: JSON.stringify({
+          refUpdates: [
+            {
+              name: 'refs/heads/main',
+              oldObjectId: 'hello123',
+            },
+          ],
+          commits: [
+            {
+              comment: 'Initial commit',
+              changes: [
+                {
+                  changeType: 'edit',
+                  item: { path: '/data/tokens.json' },
+                  newContent: {
+                    content: JSON.stringify({
+                      $metadata: {},
+                      $themes: [
+                        {
+                          id: 'light',
+                          name: 'Light',
+                          selectedTokenSets: {
+                            global: TokenSetStatus.ENABLED,
+                          },
+                        },
+                      ],
+                      global: {
+                        red: {
+                          type: TokenTypes.COLOR,
+                          name: 'red',
+                          value: '#ff0000',
+                        },
+                      },
+                    }, null, 2),
+                    contentType: 'rawtext',
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      },
+    );
+  });
 
-  // TODO: Comment these back in, this test is failing due to recent changes in https://github.com/tokens-studio/figma-plugin/pull/3071 - functionality wise its working
-  // it('should be able to write in a multi file set-up', async () => {
-  //   mockFetch.mockImplementationOnce(() => Promise.resolve({
-  //     ok: true,
-  //     json: () => Promise.resolve({
-  //       count: 1,
-  //       value: [
-  //         { name: 'refs/heads/main' },
-  //       ],
-  //     }),
-  //   })).mockImplementationOnce(() => Promise.resolve({
-  //     ok: true,
-  //     json: () => Promise.resolve({
-  //       count: 1,
-  //       value: [
-  //         {
-  //           name: 'refs/heads/main',
-  //           objectId: '123abc',
-  //         },
-  //       ],
-  //     }),
-  //   })).mockImplementationOnce(() => Promise.resolve({
-  //     ok: true,
-  //     json: () => Promise.resolve({
-  //       count: 1,
-  //       value: [
-  //         { path: '/multifile/global.json' },
-  //         { path: '/multifile/core.json' },
-  //         { path: '/multifile/internal.json' },
-  //         { path: '/multifile/$themes.json' },
-  //         { path: '/multifile/$metadata.json' },
-  //       ],
-  //     }),
-  //   }))
-  //     .mockImplementationOnce(() => Promise.resolve({
-  //       ok: true,
-  //       json: () => Promise.resolve({
-  //         count: 1,
-  //         value: [
-  //           { commitId: '123abc' },
-  //         ],
-  //       }),
-  //     }))
-  //     .mockImplementationOnce(() => Promise.resolve({ ok: true }))
-  //     .mockImplementationOnce(() => Promise.resolve({ ok: true }));
+  it('should be able to write in a multi file set-up', async () => {
+    mockFetch.mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        count: 1,
+        value: [
+          { name: 'refs/heads/main' },
+        ],
+      }),
+    })).mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        count: 1,
+        value: [
+          {
+            name: 'refs/heads/main',
+            objectId: '123abc',
+          },
+        ],
+      }),
+    })).mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        count: 1,
+        value: [
+          { path: '/multifile/global.json' },
+          { path: '/multifile/core.json' },
+          { path: '/multifile/internal.json' },
+          { path: '/multifile/$themes.json' },
+          { path: '/multifile/$metadata.json' },
+        ],
+      }),
+    })).mockImplementationOnce(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        count: 1,
+        value: [
+          {
+            name: 'refs/heads/main',
+            objectId: '123abc',
+          },
+        ],
+      }),
+    }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          count: 1,
+          value: [
+            { commitId: 'hello123' },
+          ],
+        }),
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          count: 1,
+          value: [
+            { commitId: 'hello123' },
+          ],
+        }),
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          count: 1,
+          value: [
+            {
+              name: 'refs/heads/main',
+              objectId: '123abc',
+            },
+          ],
+        }),
+      }));
 
-  //   storageProvider.enableMultiFile();
-  //   storageProvider.selectBranch('main');
-  //   storageProvider.changePath('multifile');
-  //   expect(await storageProvider.write([
-  //     {
-  //       type: 'metadata',
-  //       path: '$metadata.json',
-  //       data: {
-  //         tokenSetOrder: ['global'],
-  //       },
-  //     },
-  //     {
-  //       type: 'themes',
-  //       path: '$themes.json',
-  //       data: [
-  //         {
-  //           id: 'light',
-  //           name: 'Light',
-  //           selectedTokenSets: {
-  //             global: TokenSetStatus.ENABLED,
-  //           },
-  //         },
-  //       ],
-  //     },
-  //     {
-  //       type: 'tokenSet',
-  //       name: 'global',
-  //       path: 'global.json',
-  //       data: {
-  //         red: {
-  //           type: TokenTypes.COLOR,
-  //           name: 'red',
-  //           value: '#ff0000',
-  //         },
-  //       },
-  //     },
-  //     {
-  //       type: 'tokenSet',
-  //       name: 'core-rename',
-  //       path: 'core-rename.json',
-  //       data: {
-  //         red: {
-  //           type: TokenTypes.COLOR,
-  //           name: 'red',
-  //           value: '#ff0000',
-  //         },
-  //       },
-  //     },
-  //   ], {
-  //     commitMessage: 'Initial commit',
-  //   })).toBe(true);
-  //   expect(mockFetch).toHaveBeenNthCalledWith(
-  //     5,
-  //     `${baseUrl}/${projectId}/_apis/git/repositories/${repositoryId}/pushes?api-version=6.0`,
-  //     {
-  //       method: 'POST',
-  //       headers: {
-  //         'Content-Type': 'application/json',
-  //         Authorization: `Basic ${btoa(`:${secret}`)}`,
-  //       },
-  //       body: JSON.stringify({
-  //         refUpdates: [
-  //           {
-  //             name: 'refs/heads/main',
-  //             oldObjectId: '123abc',
-  //           },
-  //         ],
-  //         commits: [
-  //           {
-  //             comment: 'Initial commit',
-  //             changes: [
-  //               {
-  //                 changeType: 'delete',
-  //                 item: { path: '/multifile/core.json' },
-  //               },
-  //               {
-  //                 changeType: 'delete',
-  //                 item: { path: '/multifile/internal.json' },
-  //               },
-  //               {
-  //                 changeType: 'edit',
-  //                 item: { path: '/multifile/$metadata.json' },
-  //                 newContent: {
-  //                   content: JSON.stringify({
-  //                     tokenSetOrder: ['global'],
-  //                   }, null, 2),
-  //                   contentType: 'rawtext',
-  //                 },
-  //               },
-  //               {
-  //                 changeType: 'edit',
-  //                 item: { path: '/multifile/$themes.json' },
-  //                 newContent: {
-  //                   content: JSON.stringify([
-  //                     {
-  //                       id: 'light',
-  //                       name: 'Light',
-  //                       selectedTokenSets: {
-  //                         global: TokenSetStatus.ENABLED,
-  //                       },
-  //                     },
-  //                   ], null, 2),
-  //                   contentType: 'rawtext',
-  //                 },
-  //               },
-  //               {
-  //                 changeType: 'edit',
-  //                 item: { path: '/multifile/global.json' },
-  //                 newContent: {
-  //                   content: JSON.stringify({
-  //                     red: {
-  //                       type: TokenTypes.COLOR,
-  //                       name: 'red',
-  //                       value: '#ff0000',
-  //                     },
-  //                   }, null, 2),
-  //                   contentType: 'rawtext',
-  //                 },
-  //               },
-  //               {
-  //                 changeType: 'add',
-  //                 item: { path: '/multifile/core-rename.json' },
-  //                 newContent: {
-  //                   content: JSON.stringify({
-  //                     red: {
-  //                       type: TokenTypes.COLOR,
-  //                       name: 'red',
-  //                       value: '#ff0000',
-  //                     },
-  //                   }, null, 2),
-  //                   contentType: 'rawtext',
-  //                 },
-  //               },
-
-  //             ],
-  //           },
-  //         ],
-  //       }),
-  //     },
-  //   );
-  // });
+    storageProvider.enableMultiFile();
+    storageProvider.selectBranch('main');
+    storageProvider.changePath('multifile');
+    expect(await storageProvider.write([
+      {
+        type: 'metadata',
+        path: '$metadata.json',
+        data: {
+          tokenSetOrder: ['global'],
+        },
+      },
+      {
+        type: 'themes',
+        path: '$themes.json',
+        data: [
+          {
+            id: 'light',
+            name: 'Light',
+            selectedTokenSets: {
+              global: TokenSetStatus.ENABLED,
+            },
+          },
+        ],
+      },
+      {
+        type: 'tokenSet',
+        name: 'global',
+        path: 'global.json',
+        data: {
+          red: {
+            type: TokenTypes.COLOR,
+            name: 'red',
+            value: '#ff0000',
+          },
+        },
+      },
+      {
+        type: 'tokenSet',
+        name: 'core-rename',
+        path: 'core-rename.json',
+        data: {
+          red: {
+            type: TokenTypes.COLOR,
+            name: 'red',
+            value: '#ff0000',
+          },
+        },
+      },
+    ], {
+      commitMessage: 'Initial commit',
+    })).toBe(true);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      8,
+      `${baseUrl}/${projectId}/_apis/git/repositories/${repositoryId}/pushes?api-version=6.0`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${btoa(`:${secret}`)}`,
+        },
+        body: JSON.stringify({
+          refUpdates: [
+            {
+              name: 'refs/heads/main',
+              oldObjectId: 'hello123',
+            },
+          ],
+          commits: [
+            {
+              comment: 'Initial commit',
+              changes: [
+                {
+                  changeType: 'add',
+                  item: { path: '/multifile/$metadata.json' },
+                  newContent: {
+                    content: JSON.stringify({
+                      tokenSetOrder: ['global'],
+                    }, null, 2),
+                    contentType: 'rawtext',
+                  },
+                },
+                {
+                  changeType: 'add',
+                  item: { path: '/multifile/$themes.json' },
+                  newContent: {
+                    content: JSON.stringify([
+                      {
+                        id: 'light',
+                        name: 'Light',
+                        selectedTokenSets: {
+                          global: TokenSetStatus.ENABLED,
+                        },
+                      },
+                    ], null, 2),
+                    contentType: 'rawtext',
+                  },
+                },
+                {
+                  changeType: 'add',
+                  item: { path: '/multifile/global.json' },
+                  newContent: {
+                    content: JSON.stringify({
+                      red: {
+                        type: TokenTypes.COLOR,
+                        name: 'red',
+                        value: '#ff0000',
+                      },
+                    }, null, 2),
+                    contentType: 'rawtext',
+                  },
+                },
+                {
+                  changeType: 'add',
+                  item: { path: '/multifile/core-rename.json' },
+                  newContent: {
+                    content: JSON.stringify({
+                      red: {
+                        type: TokenTypes.COLOR,
+                        name: 'red',
+                        value: '#ff0000',
+                      },
+                    }, null, 2),
+                    contentType: 'rawtext',
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      },
+    );
+  });
 });


### PR DESCRIPTION
### Why does this PR exist?

Closes [#3085](https://github.com/tokens-studio/figma-plugin/issues/3085)

### What does this pull request do?

Changes to the way that ADO works meant that the fetch mocks had to be updated to test the functionality correctly

### Testing this change

Run the tests (or see them in the pipeline) - see that `ADOTokenStorageTest.ts` ✅ 