### PR TITLE
Fix styling issues post 2.0 release

### DIFF
--- a/.changeset/calm-carrots-sit.md
+++ b/.changeset/calm-carrots-sit.md
@@ -1,0 +1,7 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes the issue where only active themes were being exported as styles, even when multiple themes were selected in the options modal.
+
+Fixes the problem where applied styles were not being displayed in figma when the core/global theme was being activated.

--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -26,7 +26,7 @@
     "serve": "serve dist -p 58630",
     "changeset": "changeset",
     "translate": "node  ./scripts/translate.mjs",
-    "lint": "eslint . --quiet --fix",
+    "lint": "eslint src/types/AsyncMessages.ts --quiet --fix",
     "lint:nofix": "eslint .",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -26,7 +26,7 @@
     "serve": "serve dist -p 58630",
     "changeset": "changeset",
     "translate": "node  ./scripts/translate.mjs",
-    "lint": "eslint src/types/AsyncMessages.ts --quiet --fix",
+    "lint": "eslint . --quiet --fix",
     "lint:nofix": "eslint .",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-continue */
 import { useDispatch, useSelector, useStore } from 'react-redux';
 import { useCallback, useMemo, useContext } from 'react';
 import { AnyTokenList, SingleToken, TokenToRename } from '@/types/tokens';
@@ -441,18 +442,18 @@ export default function useTokens() {
       for (const themeId of selectedThemes) {
         const selectedTheme = themes.find((theme) => theme.id === themeId);
         if (!selectedTheme) continue;
-  
+
         const selectedSets = selectedTheme.selectedTokenSets;
-  
+
         const enabledTokenSets = Object.keys(selectedSets)
-        .filter((key) => selectedSets[key] === TokenSetStatus.ENABLED)
-        .map((tokenSet) => tokenSet);
+          .filter((key) => selectedSets[key] === TokenSetStatus.ENABLED)
+          .map((tokenSet) => tokenSet);
 
         if (enabledTokenSets.length === 0) {
-          notifyToUI('No styles created for theme: ' + selectedTheme.name + '. Make sure some sets are enabled.', { error: true });
+          notifyToUI(`No styles created for theme: ${selectedTheme.name}. Make sure some sets are enabled.`, { error: true });
           continue;
         }
-  
+
         const tokensToResolve = Object.keys(selectedSets).flatMap((key) => mergeTokenGroups(tokens, { [key]: selectedSets[key] }));
 
         const resolved = defaultTokenResolver.setTokens(tokensToResolve);
@@ -466,21 +467,21 @@ export default function useTokens() {
           if (shouldCreate) {
             if (!acc.find((token) => curr.name === token.name)) {
               acc.push(curr);
+            }
           }
-        }
-  
+
           return acc;
-        }, []);      
+        }, []);
 
-      const createStylesResult = await wrapTransaction({ name: 'createStyles' }, async () => AsyncMessageChannel.ReactInstance.message({
-        type: AsyncMessageTypes.CREATE_STYLES,
-        tokens: tokensToCreate,
-        settings,
-        selectedTheme: selectedTheme
-      }));
+        const createStylesResult = await wrapTransaction({ name: 'createStyles' }, async () => AsyncMessageChannel.ReactInstance.message({
+          type: AsyncMessageTypes.CREATE_STYLES,
+          tokens: tokensToCreate,
+          settings,
+          selectedTheme,
+        }));
 
-      dispatch.tokenState.assignStyleIdsToCurrentTheme({ styleIds: createStylesResult.styleIds, tokens: tokensToCreate, selectedThemes });
-    }
+        dispatch.tokenState.assignStyleIdsToCurrentTheme({ styleIds: createStylesResult.styleIds, tokens: tokensToCreate, selectedThemes });
+      }
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATE_STYLES);
     },
     [dispatch.tokenState, tokens, settings, themes, dispatch.uiState],

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -449,39 +449,39 @@ export default function useTokens() {
           .filter((key) => selectedSets[key] === TokenSetStatus.ENABLED)
           .map((tokenSet) => tokenSet);
 
-          if (enabledTokenSets.length > 0) {
-            const tokensToResolve = Object.keys(selectedSets).flatMap((key) => mergeTokenGroups(tokens, { [key]: selectedSets[key] }));
-      
-            const resolved = defaultTokenResolver.setTokens(tokensToResolve);
-      
-            const withoutSourceTokens = resolved.filter(
-              (token) => !token.internal__Parent || enabledTokenSets.includes(token.internal__Parent), // filter out SOURCE tokens
-            );
-      
-            const tokensToCreate = withoutSourceTokens.reduce((acc: SingleToken[], curr) => {
-              const shouldCreate = [
-                settings.stylesTypography && curr.type === TokenTypes.TYPOGRAPHY,
-                settings.stylesColor && curr.type === TokenTypes.COLOR,
-                settings.stylesEffect && curr.type === TokenTypes.BOX_SHADOW,
-              ].some((isEnabled) => isEnabled);
-              if (shouldCreate && !acc.find((token) => curr.name === token.name)) {
-                acc.push(curr);
-              }
-      
-              return acc;
-            }, []);
-      
-            const createStylesResult = await wrapTransaction({ name: 'createStyles' }, async () => AsyncMessageChannel.ReactInstance.message({
-              type: AsyncMessageTypes.CREATE_STYLES,
-              tokens: tokensToCreate,
-              settings,
-              selectedTheme,
-            }));
-      
-            dispatch.tokenState.assignStyleIdsToCurrentTheme({ styleIds: createStylesResult.styleIds, tokens: tokensToCreate, selectedThemes });
-          } else {
-            notifyToUI(`No styles created for theme: ${selectedTheme.name}. Make sure some sets are enabled.`, { error: true });
-          }
+        if (enabledTokenSets.length > 0) {
+          const tokensToResolve = Object.keys(selectedSets).flatMap((key) => mergeTokenGroups(tokens, { [key]: selectedSets[key] }));
+
+          const resolved = defaultTokenResolver.setTokens(tokensToResolve);
+
+          const withoutSourceTokens = resolved.filter(
+            (token) => !token.internal__Parent || enabledTokenSets.includes(token.internal__Parent), // filter out SOURCE tokens
+          );
+
+          const tokensToCreate = withoutSourceTokens.reduce((acc: SingleToken[], curr) => {
+            const shouldCreate = [
+              settings.stylesTypography && curr.type === TokenTypes.TYPOGRAPHY,
+              settings.stylesColor && curr.type === TokenTypes.COLOR,
+              settings.stylesEffect && curr.type === TokenTypes.BOX_SHADOW,
+            ].some((isEnabled) => isEnabled);
+            if (shouldCreate && !acc.find((token) => curr.name === token.name)) {
+              acc.push(curr);
+            }
+
+            return acc;
+          }, []);
+
+          const createStylesResult = await wrapTransaction({ name: 'createStyles' }, async () => AsyncMessageChannel.ReactInstance.message({
+            type: AsyncMessageTypes.CREATE_STYLES,
+            tokens: tokensToCreate,
+            settings,
+            selectedTheme,
+          }));
+
+          dispatch.tokenState.assignStyleIdsToCurrentTheme({ styleIds: createStylesResult.styleIds, tokens: tokensToCreate, selectedThemes });
+        } else {
+          notifyToUI(`No styles created for theme: ${selectedTheme.name}. Make sure some sets are enabled.`, { error: true });
+        }
       }
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATE_STYLES);
     },

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -23,14 +23,14 @@ export class TokenValueRetriever {
   public selectedTheme;
 
   private getAdjustedTokenName(tokenName: string, internalParent: string | undefined): string {
-    const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1 
-        ? tokenName.split('.').slice(1).join('.') 
-        : tokenName;
+    const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1
+      ? tokenName.split('.').slice(1).join('.')
+      : tokenName;
 
     const withPrefix = [internalParent || this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
 
     return withPrefix;
-}
+  }
 
   public initiate({
     tokens,

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -22,11 +22,15 @@ export class TokenValueRetriever {
 
   public selectedTheme;
 
-  private getAdjustedTokenName(tokenName: string): string {
-    const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1 ? tokenName.split('.').slice(1).join('.') : tokenName;
-    const withPrefix = [this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
+  private getAdjustedTokenName(tokenName: string, internalParent: string | undefined): string {
+    const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1 
+        ? tokenName.split('.').slice(1).join('.') 
+        : tokenName;
+
+    const withPrefix = [internalParent || this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
+
     return withPrefix;
-  }
+}
 
   public initiate({
     tokens,
@@ -59,7 +63,7 @@ export class TokenValueRetriever {
     this.tokens = new Map<string, any>(tokens.map((token) => {
       const variableId = variableReferences?.get(token.name);
       // For styles, we need to ignore the first part of the token name as well as consider theme prefix
-      const adjustedTokenName = this.getAdjustedTokenName(token.name);
+      const adjustedTokenName = this.getAdjustedTokenName(token.name, token.internal__Parent);
       const styleId = styleReferences?.get(adjustedTokenName);
       return [token.name, {
         ...token, variableId, styleId, adjustedTokenName,

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -1,5 +1,4 @@
 import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
-import { ThemeObject } from '@/types';
 import { RawVariableReferenceMap } from '@/types/RawVariableReferenceMap';
 import { AnyTokenList } from '@/types/tokens';
 
@@ -20,8 +19,6 @@ export class TokenValueRetriever {
 
   public createStylesWithVariableReferences;
 
-  public selectedTheme;
-
   private getAdjustedTokenName(tokenName: string, internalParent: string | undefined): string {
     const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1
       ? tokenName.split('.').slice(1).join('.')
@@ -40,7 +37,6 @@ export class TokenValueRetriever {
     ignoreFirstPartForStyles = false,
     createStylesWithVariableReferences = false,
     applyVariablesStylesOrRawValue = ApplyVariablesStylesOrRawValues.VARIABLES_STYLES,
-    selectedTheme,
   }: { tokens: AnyTokenList,
     variableReferences?: RawVariableReferenceMap,
     styleReferences?: Map<string,
@@ -49,7 +45,6 @@ export class TokenValueRetriever {
     ignoreFirstPartForStyles?: boolean,
     createStylesWithVariableReferences?: boolean,
     applyVariablesStylesOrRawValue?: ApplyVariablesStylesOrRawValues,
-    selectedTheme?: ThemeObject,
   }) {
     this.stylePathPrefix = typeof stylePathPrefix !== 'undefined' ? stylePathPrefix : null;
     this.ignoreFirstPartForStyles = ignoreFirstPartForStyles;
@@ -58,7 +53,6 @@ export class TokenValueRetriever {
     this.variableReferences = variableReferences || new Map();
     this.cachedVariableReferences = new Map();
     this.applyVariablesStylesOrRawValue = applyVariablesStylesOrRawValue;
-    this.selectedTheme = selectedTheme;
 
     this.tokens = new Map<string, any>(tokens.map((token) => {
       const variableId = variableReferences?.get(token.name);
@@ -116,7 +110,6 @@ export class TokenValueRetriever {
     if (this.stylePathPrefix) this.stylePathPrefix = undefined;
     if (this.ignoreFirstPartForStyles) this.ignoreFirstPartForStyles = undefined;
     if (this.createStylesWithVariableReferences) this.createStylesWithVariableReferences = undefined;
-    if (this.selectedTheme) this.selectedTheme = undefined;
   }
 }
 

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -36,7 +36,7 @@ export class TokenValueRetriever {
     ignoreFirstPartForStyles = false,
     createStylesWithVariableReferences = false,
     applyVariablesStylesOrRawValue = ApplyVariablesStylesOrRawValues.VARIABLES_STYLES,
-    selectedTheme
+    selectedTheme,
   }: { tokens: AnyTokenList,
     variableReferences?: RawVariableReferenceMap,
     styleReferences?: Map<string,

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -1,4 +1,5 @@
 import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
+import { ThemeObject } from '@/types';
 import { RawVariableReferenceMap } from '@/types/RawVariableReferenceMap';
 import { AnyTokenList } from '@/types/tokens';
 
@@ -19,6 +20,8 @@ export class TokenValueRetriever {
 
   public createStylesWithVariableReferences;
 
+  public selectedTheme;
+
   private getAdjustedTokenName(tokenName: string): string {
     const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1 ? tokenName.split('.').slice(1).join('.') : tokenName;
     const withPrefix = [this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
@@ -33,6 +36,7 @@ export class TokenValueRetriever {
     ignoreFirstPartForStyles = false,
     createStylesWithVariableReferences = false,
     applyVariablesStylesOrRawValue = ApplyVariablesStylesOrRawValues.VARIABLES_STYLES,
+    selectedTheme
   }: { tokens: AnyTokenList,
     variableReferences?: RawVariableReferenceMap,
     styleReferences?: Map<string,
@@ -41,6 +45,7 @@ export class TokenValueRetriever {
     ignoreFirstPartForStyles?: boolean,
     createStylesWithVariableReferences?: boolean,
     applyVariablesStylesOrRawValue?: ApplyVariablesStylesOrRawValues,
+    selectedTheme?: ThemeObject,
   }) {
     this.stylePathPrefix = typeof stylePathPrefix !== 'undefined' ? stylePathPrefix : null;
     this.ignoreFirstPartForStyles = ignoreFirstPartForStyles;
@@ -49,6 +54,7 @@ export class TokenValueRetriever {
     this.variableReferences = variableReferences || new Map();
     this.cachedVariableReferences = new Map();
     this.applyVariablesStylesOrRawValue = applyVariablesStylesOrRawValue;
+    this.selectedTheme = selectedTheme;
 
     this.tokens = new Map<string, any>(tokens.map((token) => {
       const variableId = variableReferences?.get(token.name);
@@ -106,6 +112,7 @@ export class TokenValueRetriever {
     if (this.stylePathPrefix) this.stylePathPrefix = undefined;
     if (this.ignoreFirstPartForStyles) this.ignoreFirstPartForStyles = undefined;
     if (this.createStylesWithVariableReferences) this.createStylesWithVariableReferences = undefined;
+    if (this.selectedTheme) this.selectedTheme = undefined;
   }
 }
 

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
@@ -17,8 +17,9 @@ export const createStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.CREATE_
       ignoreFirstPartForStyles: msg.settings.ignoreFirstPartForStyles,
       createStylesWithVariableReferences: msg.settings.createStylesWithVariableReferences,
       applyVariablesStylesOrRawValue: msg.settings.applyVariablesStylesOrRawValue,
+      selectedTheme: msg.selectedTheme
     });
-    const styleIds = await updateStyles(msg.tokens, msg.settings, true);
+    const styleIds = await updateStyles(msg.tokens, msg.settings, true, msg.selectedTheme);
 
     return {
       styleIds,

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
@@ -17,7 +17,6 @@ export const createStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.CREATE_
       ignoreFirstPartForStyles: msg.settings.ignoreFirstPartForStyles,
       createStylesWithVariableReferences: msg.settings.createStylesWithVariableReferences,
       applyVariablesStylesOrRawValue: msg.settings.applyVariablesStylesOrRawValue,
-      selectedTheme: msg.selectedTheme,
     });
     const styleIds = await updateStyles(msg.tokens, msg.settings, true, msg.selectedTheme);
 

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createStyles.ts
@@ -17,7 +17,7 @@ export const createStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.CREATE_
       ignoreFirstPartForStyles: msg.settings.ignoreFirstPartForStyles,
       createStylesWithVariableReferences: msg.settings.createStylesWithVariableReferences,
       applyVariablesStylesOrRawValue: msg.settings.applyVariablesStylesOrRawValue,
-      selectedTheme: msg.selectedTheme
+      selectedTheme: msg.selectedTheme,
     });
     const styleIds = await updateStyles(msg.tokens, msg.settings, true, msg.selectedTheme);
 

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
@@ -66,8 +66,6 @@ export default async function updateStyles(
     notifyUI('Some styles were ignored due to "Ignore first part of token name" export setting', { error: true });
   }
 
-  console.log('all style ids are', allStyleIds);
-
   // Remove styles that aren't in the theme or in the exposed token object
   if (settings.removeStylesAndVariablesWithoutConnection) {
     const [allLocalPaintStyles, allLocalTextStyles, allLocalEffectStyles] = await Promise.all([

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
@@ -9,7 +9,7 @@ import updateColorStyles from './updateColorStyles';
 import updateEffectStyles from './updateEffectStyles';
 import updateTextStyles from './updateTextStyles';
 import { notifyUI } from './notifiers';
-import { ThemeObject } from '@/types';
+import type { ThemeObject } from '@/types';
 
 export default async function updateStyles(
   tokens: AnyTokenList,

--- a/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateStyles.ts
@@ -8,28 +8,26 @@ import { transformValue } from './helpers';
 import updateColorStyles from './updateColorStyles';
 import updateEffectStyles from './updateEffectStyles';
 import updateTextStyles from './updateTextStyles';
-import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { notifyUI } from './notifiers';
-import { act } from 'react-dom/test-utils';
 import { ThemeObject } from '@/types';
 
 export default async function updateStyles(
   tokens: AnyTokenList,
   settings: SettingsState,
   shouldCreate = false,
-  selectedTheme?: ThemeObject
+  selectedTheme?: ThemeObject,
 ): Promise<Record<string, string>> {
   // Big O (n * m * l): (n = amount of tokens, m = amount of active themes, l = amount of tokenSets)
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
   });
-  const activeThemes =  themeInfo.themes
-      .filter((theme) => Object.values(themeInfo.activeTheme).some((v) => v === theme.id))
-      .reverse();
-    
+  const activeThemes = themeInfo.themes
+    .filter((theme) => Object.values(themeInfo.activeTheme).some((v) => v === theme.id))
+    .reverse();
+
   const styleTokens = tokens.map((token) => {
     // When multiple theme has the same active Token set then the last activeTheme wins
-    const activeTheme = selectedTheme ? selectedTheme : activeThemes.find((theme) => Object.entries(theme.selectedTokenSets).some(([tokenSet]) => tokenSet === token.internal__Parent));
+    const activeTheme = selectedTheme || activeThemes.find((theme) => Object.entries(theme.selectedTokenSets).some(([tokenSet]) => tokenSet === token.internal__Parent));
 
     const prefix = settings.prefixStylesWithThemeName && activeTheme ? activeTheme.name : null;
     const slice = settings?.ignoreFirstPartForStyles && token.name.split('.').length > 1 ? 1 : 0;
@@ -41,10 +39,6 @@ export default async function updateStyles(
       styleId: activeTheme?.$figmaStyleReferences ? activeTheme?.$figmaStyleReferences[token.name] : '',
     } as SingleToken<true, { path: string, styleId: string }>;
   }).filter((token) => token.path);
-
-  //console.log("style tokens is", styleTokens);
-  //const foundTokeninstyled = styleTokens.filter((token) => token.name === tokenNameToFind);
-      //console.log("foundtoken is", foundTokeninstyled);
 
   const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<
     typeof styleTokens[number],
@@ -72,7 +66,7 @@ export default async function updateStyles(
     notifyUI('Some styles were ignored due to "Ignore first part of token name" export setting', { error: true });
   }
 
-  console.log("all style ids are", allStyleIds);
+  console.log('all style ids are', allStyleIds);
 
   // Remove styles that aren't in the theme or in the exposed token object
   if (settings.removeStylesAndVariablesWithoutConnection) {

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -177,6 +177,7 @@ export type CreateAnnotationAsyncMessageResult = AsyncMessage<AsyncMessageTypes.
 export type CreateStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.CREATE_STYLES, {
   tokens: AnyTokenList;
   settings: SettingsState;
+  selectedTheme?: ThemeObject;
 }>;
 export type CreateStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.CREATE_STYLES, {
   styleIds: Record<string, string>;


### PR DESCRIPTION
Addresses #3088 - the themes that are now selected in the styles export modal shall be exported as styles.
Resolves #3083  - the 2nd point when multiple themes are enabled, then the styles don't show in Figma

# Description

- When we select the themes in the export modal to be exported as styles, the expectation now would be to export those themes regardless of their active/inactive status.
- When multiple themes are enabled, especially core/global, figma ceased to display the corresponding style token applied. This PR should address that

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] None of the above

# How to test this

1st Issue:

* Create some themes in the plugin.
* Keep them inactive.
* Go to Export Styles&Variables, choose the themes you wish to be exported as styles
* They should be exported irrespective of them being inactive

2nd Issue:

- Create some themes, along with a core/global theme
- Apply light/dark theme, theme switching should work fine, along with the correct styles being applied(and displayed on Figma) without core theme enabled
- As soon you apply core theme, the theme switching should work fine between light/dark or any other themes, along with the pertinent styles being showed in Figma

# Screenshots or video (if necessary):