### PR TITLE
fix: prevent falsy error when pushing to remote (GitLab & ADO)

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -117,9 +117,8 @@ export const useADO = () => {
     }
 
     return {
-      status: 'success',
-      tokens: {},
-      themes: [],
+      status: 'failure',
+      errorMessage: 'Push to remote cancelled!',
     };
   }, [
     dispatch,
@@ -255,16 +254,6 @@ export const useADO = () => {
       }
       const data = await syncTokensWithADO(context);
 
-      // User cancelled pushing to the remote
-      if (data.status === 'success' && data.themes.length === 0) {
-        dispatch.uiState.setLocalApiState({ ...context, branch: previousBranch, filePath: previousFilePath });
-
-        return {
-          status: 'failure',
-          errorMessage: 'Push to remote cancelled!',
-        };
-      }
-
       if (data.status === 'success') {
         AsyncMessageChannel.ReactInstance.message({
           type: AsyncMessageTypes.CREDENTIALS,
@@ -274,6 +263,8 @@ export const useADO = () => {
           notifyToUI('No tokens stored on remote');
         }
       } else {
+        // Go back to the previous setup if the user cancelled pushing to the remote or there was an error
+        dispatch.uiState.setLocalApiState({ ...context, branch: previousBranch, filePath: previousFilePath });
         return {
           status: 'failure',
           errorMessage: data.errorMessage,

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -127,10 +127,8 @@ export function useGitLab() {
       }
     }
     return {
-      status: 'success',
-      tokens: {},
-      themes: [],
-      metadata: {},
+      status: 'failure',
+      errorMessage: 'Push to remote cancelled!',
     };
   }, [
     dispatch,
@@ -276,15 +274,6 @@ export function useGitLab() {
     }
     const data = await syncTokensWithGitLab(context);
 
-    // User cancelled pushing to the remote
-    if (data.status === 'success' && data.themes.length === 0) {
-      dispatch.uiState.setLocalApiState({ ...context, branch: previousBranch, filePath: previousFilePath });
-
-      return {
-        status: 'failure',
-        errorMessage: 'Push to remote cancelled!',
-      };
-    }
 
     if (data.status === 'success') {
       AsyncMessageChannel.ReactInstance.message({
@@ -295,6 +284,8 @@ export function useGitLab() {
         notifyToUI('No tokens stored on remote');
       }
     } else {
+      // Go back to the previous setup if the user cancelled pushing to the remote or there was an error
+      dispatch.uiState.setLocalApiState({ ...context, branch: previousBranch, filePath: previousFilePath });
       return {
         status: 'failure',
         errorMessage: data.errorMessage,

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.test.ts
@@ -792,20 +792,11 @@ describe('remoteTokens', () => {
           Promise.resolve(true)
         ));
         await waitFor(() => { result.current.addNewProviderItem(context as StorageTypeCredentials); });
-        if (context !== adoContext && context !== gitLabContext) {
           expect(notifyToUI).toBeCalledTimes(2);
           expect(notifyToUI).toBeCalledWith('No tokens stored on remote');
           expect(await result.current.addNewProviderItem(context as StorageTypeCredentials)).toEqual({
             status: 'success',
           });
-        } else {
-          expect(notifyToUI).toBeCalledTimes(1);
-          expect(notifyToUI).toBeCalledWith(`Pulled tokens from ${contextName}`);
-          expect(await result.current.addNewProviderItem(context as StorageTypeCredentials)).toEqual({
-            status: 'failure',
-            errorMessage: 'Push to remote cancelled!',
-          });
-        }
       });
     } else {
       it(`Add newProviderItem to ${context.provider}, should pull tokens and return error message if there is no tokens on remote`, async () => {


### PR DESCRIPTION
### Why does this PR exist?

👀 Original community thread: https://tokens-studio.slack.com/archives/C02DLQXNY6Q/p1724944973329479

When users were pushing to GitLab, an error saying "Push to remote cancelled!" appeared on the modal, although it all works as expected.

### What does this pull request do?

For GitLab & ADO, pushing to remote will actually fail, not showing this falsy error. 

### Testing this change
* Edit details in GitLab / ADO as a provider
* Follow the push to remote flow
* See successful edits in remote OR see error if you cancel the flow

#### ✅ SUCCESS

https://github.com/user-attachments/assets/b091aef2-98c5-44c1-879f-ccd7b502668e

#### ❌ ERROR

https://github.com/user-attachments/assets/2af8d67c-b38d-41b2-b574-427c1cc5efa7

