### PR TITLE
Fix padding in export sets and add gap between sets

### DIFF
--- a/.changeset/cyan-fireants-sparkle.md
+++ b/.changeset/cyan-fireants-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Add missing padding to list of token sets in Export Token Sets Tab

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
@@ -1,6 +1,6 @@
 import { FileDirectoryIcon } from '@primer/octicons-react';
 import {
-  Tabs, Stack, Heading, Button, Link,
+  Tabs, Stack, Heading, Button,
 } from '@tokens-studio/ui';
 import React, { useMemo } from 'react';
 import { useDispatch, useSelector, useStore } from 'react-redux';

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
@@ -145,6 +145,7 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
       <Modal
         size="fullscreen"
         full
+        compact
         isOpen={showChangeSets}
         close={handleCancelChangeSets}
         backArrow
@@ -160,10 +161,7 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
           </Stack>
           )}
       >
-        <Heading css={{
-          padding: '$3 $4 $2 $4',
-        }}
-        >
+        <Heading>
           {t('exportSetsTab.changeSetsHeading')}
         </Heading>
         {/* Commenting until we have docs <Link target="_blank" href={docsLinks.sets}>{`${t('generic.learnMore')} – ${t('docs.referenceOnlyMode')}`}</Link> */}
@@ -172,7 +170,6 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
           gap={1}
           css={{
             marginBlockStart: '$4',
-            padding: '$3 $4 $3 $4',
           }}
         >
           <TokenSetTreeContent items={setsTree} renderItemContent={TokenSetThemeItemInput} keyPosition="end" />

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ExportSetsTab.tsx
@@ -160,12 +160,19 @@ export default function ExportSetsTab({ selectedSets, setSelectedSets }: { selec
           </Stack>
           )}
       >
-        <Heading>{t('exportSetsTab.changeSetsHeading')}</Heading>
+        <Heading css={{
+          padding: '$3 $4 $2 $4',
+        }}
+        >
+          {t('exportSetsTab.changeSetsHeading')}
+        </Heading>
         {/* Commenting until we have docs <Link target="_blank" href={docsLinks.sets}>{`${t('generic.learnMore')} – ${t('docs.referenceOnlyMode')}`}</Link> */}
         <Stack
           direction="column"
+          gap={1}
           css={{
             marginBlockStart: '$4',
+            padding: '$3 $4 $3 $4',
           }}
         >
           <TokenSetTreeContent items={setsTree} renderItemContent={TokenSetThemeItemInput} keyPosition="end" />


### PR DESCRIPTION
Small fix to a missing padding issue in Export Sets Tab

Before:
<img width="409" alt="Screenshot 2024-08-30 at 18 53 51" src="https://github.com/user-attachments/assets/7c5979e9-7d4a-400b-ab81-a4a8d722ec83">

After:
<img width="412" alt="Screenshot 2024-08-30 at 18 51 40" src="https://github.com/user-attachments/assets/62e32a5d-865c-4b17-bdf7-0a01a1183903">
