### PR TITLE
Fix export sets

### DIFF
--- a/.changeset/orange-donkeys-chew.md
+++ b/.changeset/orange-donkeys-chew.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": minor
+---
+
+Fixes issue where styles are not applied in Figma, when user exports Token Sets as Styles

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -59,7 +59,7 @@ export class TokenValueRetriever {
       const variableId = variableReferences?.get(token.name);
       // For styles, we need to ignore the first part of the token name as well as consider theme prefix
       const [adjustedTokenName, adjustedTokenNameWithIgnoreFirstPart] = this.getAdjustedTokenName(token.name);
-      // console.log("style references is", Array.from(styleReferences?.values() ?? []));
+
       const styleId = styleReferences?.get(adjustedTokenName) || styleReferences?.get(adjustedTokenNameWithIgnoreFirstPart);
       const finalAdjustedTokenName = styleReferences?.has(adjustedTokenName) ? adjustedTokenName : adjustedTokenNameWithIgnoreFirstPart;
 

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -24,9 +24,9 @@ export class TokenValueRetriever {
       ? tokenName.split('.').slice(1).join('.')
       : tokenName;
 
-      const adjustedTokenName = [this.stylePathPrefix, tokenName].filter((n) => n).join('.');
-      const adjustedTokenNameWithIgnoreFirstPart = [this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
-  
+    const adjustedTokenName = [this.stylePathPrefix, tokenName].filter((n) => n).join('.');
+    const adjustedTokenNameWithIgnoreFirstPart = [this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
+
     return [adjustedTokenName, adjustedTokenNameWithIgnoreFirstPart];
   }
 
@@ -59,13 +59,15 @@ export class TokenValueRetriever {
       const variableId = variableReferences?.get(token.name);
       // For styles, we need to ignore the first part of the token name as well as consider theme prefix
       const [adjustedTokenName, adjustedTokenNameWithIgnoreFirstPart] = this.getAdjustedTokenName(token.name);
-     // console.log("style references is", Array.from(styleReferences?.values() ?? []));
-     const styleId = styleReferences?.get(adjustedTokenName) 
-     || styleReferences?.get(adjustedTokenNameWithIgnoreFirstPart);
-    
+      // console.log("style references is", Array.from(styleReferences?.values() ?? []));
+      const styleId = styleReferences?.get(adjustedTokenName) || styleReferences?.get(adjustedTokenNameWithIgnoreFirstPart);
+      const finalAdjustedTokenName = styleReferences?.has(adjustedTokenName) ? adjustedTokenName : adjustedTokenNameWithIgnoreFirstPart;
+
       return [token.name, {
-        ...token, variableId, styleId, 
-        adjustedTokenName: styleId ? (styleReferences?.get(adjustedTokenName) ? adjustedTokenName : adjustedTokenNameWithIgnoreFirstPart) : adjustedTokenName,
+        ...token,
+        variableId,
+        styleId,
+        adjustedTokenName: styleId ? finalAdjustedTokenName : adjustedTokenName,
       }];
     }));
   }

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -25,6 +25,12 @@ export class TokenValueRetriever {
     return withPrefix;
   }
 
+  private getAdjustedTokenNameWithIgnoreFirstPart(tokenName: string): string {
+    const withIgnoredFirstPart = this.ignoreFirstPartForStyles && tokenName.split('.').length > 1 ? tokenName.split('.').slice(1).join('.') : tokenName;
+    const withPrefix = [this.stylePathPrefix, withIgnoredFirstPart].filter((n) => n).join('.');
+    return withPrefix;
+  }
+
   public initiate({
     tokens,
     variableReferences,
@@ -54,7 +60,17 @@ export class TokenValueRetriever {
       const variableId = variableReferences?.get(token.name);
       // For styles, we need to ignore the first part of the token name as well as consider theme prefix
       const adjustedTokenName = this.getAdjustedTokenName(token.name);
-      const styleId = styleReferences?.get(token.name);
+      const adjustedTokenNameWithIgnoreFirstPart = this.getAdjustedTokenNameWithIgnoreFirstPart(token.name);
+     // console.log("style references is", Array.from(styleReferences?.values() ?? []));
+     let styleId = styleReferences?.get(token.name);
+    
+     // If styleId is not found, try with the adjusted token name that ignores the first part
+     if (!styleId) {
+       styleId = styleReferences?.get(adjustedTokenNameWithIgnoreFirstPart);
+       return [token.name, {
+        ...token, variableId, styleId, adjustedTokenNameWithIgnoreFirstPart,
+      }]
+     }     
       return [token.name, {
         ...token, variableId, styleId, adjustedTokenName,
       }];

--- a/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
@@ -333,7 +333,7 @@ describe('Can set values on node', () => {
         },
       },
     );
-    expect(setTextValuesOnTargetSpy).toHaveBeenCalled();
+    expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
     expect(textNodeMock).toEqual({ ...textNodeMock });
   });
 
@@ -453,8 +453,8 @@ describe('Can set values on node', () => {
         },
       },
     );
-    expect(setEffectValuesOnTargetSpy).toHaveBeenCalled();
-    expect(solidNodeMock).toEqual({ ...solidNodeMock, effectStyleId: '' });
+    expect(setEffectValuesOnTargetSpy).not.toHaveBeenCalled();
+    expect(solidNodeMock).toEqual({ ...solidNodeMock, effectStyleId: '123' });
   });
 
   it('sets fillStyle if matching Style', async () => {

--- a/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
@@ -334,7 +334,7 @@ describe('Can set values on node', () => {
       },
     );
     expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
-    expect(textNodeMock).toEqual({ ...textNodeMock });
+    expect(textNodeMock).toEqual({ ...textNodeMock, textStyleId: '456' });
   });
 
   it('sets effectStyle if matching Style is found', async () => {


### PR DESCRIPTION
Follow Up PR to fix styling issue where styles are not being applied when sets are being exported as styles(with ignore first part of token names for styles selected)

# Description

Fixes the issue where styles are not being applied when sets are being exported as styles (with ignore first part of token names for styles selected)

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] None of the above

# How to test this

- Create some themes with enabled sets in the plugin
- Export selected sets as styles
- Make sure to check the 'Ignore First Part of token name for Styles' option
- Choose the sets to export as styles and export to Figma
- Apply token from a the active theme where the set belongs
- The corresponding style should now be applied

# Screenshots or video (if necessary):
<!--
  Add any other context or screenshots about the pull request
-->
