### PR TITLE
fix zombie variables

### DIFF
--- a/.changeset/yellow-doors-fail.md
+++ b/.changeset/yellow-doors-fail.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue with "zombie variables". Basically, even though a Figma file shows 0 variables, Figma's plugin API will sometimes tell us there's variables existing - probably ones that existed in the past but should be deleted - Figma seems to report those as existing still. This led to issues around applying and referencing variables where we'd point to those zombies. We now correctly check if the variable's collection still exist, and only then use those as references.

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/getThemeReferences.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/getThemeReferences.test.ts
@@ -62,6 +62,7 @@ describe('getThemeReferences', () => {
       {
         name: 'local/variable1',
         key: 'localVariable1',
+        variableCollectionId: 'VariableCollectionId:1:0',
       },
     ];
     const localPaintStyles = [
@@ -71,6 +72,16 @@ describe('getThemeReferences', () => {
       },
     ];
     jest.spyOn(figma.variables, 'getLocalVariablesAsync').mockResolvedValue(localVariables);
+    jest.spyOn(figma.variables, 'getLocalVariableCollectionsAsync').mockResolvedValue([{
+      id: 'VariableCollectionId:1:0',
+      name: 'Collection 1',
+      remote: false,
+      modes: [
+        { name: 'Default', modeId: '1:0' },
+        { name: 'Dark', modeId: '1:1' },
+        { name: 'Light', modeId: '1:2' },
+      ],
+    } as VariableCollection]);
     jest.spyOn(figma, 'getLocalPaintStyles').mockReturnValue(localPaintStyles);
 
     const result = await getThemeReferences();
@@ -92,9 +103,20 @@ describe('getThemeReferences', () => {
       {
         name: 'token1',
         key: 'variableX',
+        variableCollectionId: 'VariableCollectionId:1:0',
       },
     ];
     jest.spyOn(figma.variables, 'getLocalVariablesAsync').mockResolvedValue(localVariables);
+    jest.spyOn(figma.variables, 'getLocalVariableCollectionsAsync').mockResolvedValue([{
+      id: 'VariableCollectionId:1:0',
+      name: 'Collection 1',
+      remote: false,
+      modes: [
+        { name: 'Default', modeId: '1:0' },
+        { name: 'Dark', modeId: '1:1' },
+        { name: 'Light', modeId: '1:2' },
+      ],
+    } as VariableCollection]);
 
     const result = await getThemeReferences();
 

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/resolveVariableInfo.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/resolveVariableInfo.test.ts
@@ -1,4 +1,6 @@
-import { mockGetLocalVariables, mockImportVariableByKeyAsync } from '../../../../tests/__mocks__/figmaMock';
+import {
+  mockGetLocalVariableCollectionsAsync, mockGetLocalVariablesAsync, mockImportVariableByKeyAsync,
+} from '../../../../tests/__mocks__/figmaMock';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { resolveVariableInfo } from '../resolveVariableInfo';
 
@@ -29,13 +31,24 @@ describe('AttachLocalVariablesToTheme', () => {
         name: 'fg/background',
       },
     ];
+    const mockLocalVariableCollections = [
+      {
+        id: 'VariableCollectionId:12:12345',
+        name: 'fg/default',
+      },
+      {
+        id: 'VariableCollectionId:23:23456',
+        name: 'fg/muted',
+      },
+    ];
     const mockRemoveVariable = {
       id: 'VariableID:3456',
       key: '34567',
       variableCollectionId: 'VariableCollectionId:23:23456',
       name: 'fg/subtle',
     };
-    mockGetLocalVariables.mockImplementationOnce(() => mockLocalVariables);
+    mockGetLocalVariablesAsync.mockImplementationOnce(() => Promise.resolve(mockLocalVariables));
+    mockGetLocalVariableCollectionsAsync.mockImplementationOnce(() => Promise.resolve(mockLocalVariableCollections));
     mockImportVariableByKeyAsync.mockImplementationOnce(() => mockRemoveVariable);
     expect(await resolveVariableInfo({
       type: AsyncMessageTypes.RESOLVE_VARIABLE_INFO,

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/getThemeReferences.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/getThemeReferences.ts
@@ -3,6 +3,7 @@ import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { RawVariableReferenceMap } from '@/types/RawVariableReferenceMap';
 import { defaultTokenValueRetriever } from '../TokenValueRetriever';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { getVariablesWithoutZombies } from '../getVariablesWithoutZombies';
 
 export async function getThemeReferences(prefixStylesWithThemeName?: boolean) {
   defaultTokenValueRetriever.clearCache();
@@ -49,7 +50,7 @@ export async function getThemeReferences(prefixStylesWithThemeName?: boolean) {
   });
 
   // We'll also add local variables to the references in case of where we work with local sets
-  const localVariables = await figma.variables.getLocalVariablesAsync();
+  const localVariables = await getVariablesWithoutZombies();
 
   localVariables.forEach((variable) => {
     const normalizedVariableName = variable.name.split('/').join('.'); // adjusting variable name to match the token name

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/resolveVariableInfo.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/resolveVariableInfo.ts
@@ -7,7 +7,7 @@ export type ResolvedVariableInfo = {
   key: string
 };
 export const resolveVariableInfo: AsyncMessageChannelHandlers[AsyncMessageTypes.RESOLVE_VARIABLE_INFO] = async (msg) => {
-  const localVariableMap = getVariablesMap();
+  const localVariableMap = await getVariablesMap();
   const resolvedValues: Record<string, ResolvedVariableInfo> = {};
   await Promise.all(msg.variableIds.map(async (variableId) => {
     if (localVariableMap[variableId]) {

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
@@ -9,6 +9,7 @@ import { notifyUI } from './notifiers';
 import { mergeVariableReferencesWithLocalVariables } from './mergeVariableReferences';
 import { findCollectionAndModeIdForTheme } from './findCollectionAndModeIdForTheme';
 import { createNecessaryVariableCollections } from './createNecessaryVariableCollections';
+import { getVariablesWithoutZombies } from './getVariablesWithoutZombies';
 
 export type LocalVariableInfo = {
   collectionId: string;
@@ -33,7 +34,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
   let referenceVariableCandidates: ReferenceVariableType[] = [];
   const updatedVariableCollections: VariableCollection[] = [];
   let updatedVariables: Variable[] = [];
-  const figmaVariablesBeforeCreate = figma.variables.getLocalVariables()?.length;
+  const figmaVariablesBeforeCreate = (await getVariablesWithoutZombies())?.length;
   const figmaVariableCollectionsBeforeCreate = figma.variables.getLocalVariableCollections()?.length;
 
   let figmaVariablesAfterCreate = 0;
@@ -68,7 +69,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
     updatedVariables = await updateVariablesToReference(existingVariables, referenceVariableCandidates);
   }
 
-  figmaVariablesAfterCreate += figma.variables.getLocalVariables()?.length ?? 0;
+  figmaVariablesAfterCreate += (await getVariablesWithoutZombies())?.length ?? 0;
   const figmaVariableCollectionsAfterCreate = figma.variables.getLocalVariableCollections()?.length;
 
   if (figmaVariablesAfterCreate === figmaVariablesBeforeCreate) {

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
@@ -11,6 +11,7 @@ import { mergeVariableReferencesWithLocalVariables } from './mergeVariableRefere
 import { LocalVariableInfo } from './createLocalVariablesInPlugin';
 import { findCollectionAndModeIdForTheme } from './findCollectionAndModeIdForTheme';
 import { createNecessaryVariableCollections } from './createNecessaryVariableCollections';
+import { getVariablesWithoutZombies } from './getVariablesWithoutZombies';
 
 /**
 * This function is used to create variables based on token sets, without the use of themes
@@ -27,8 +28,8 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
   let referenceVariableCandidates: ReferenceVariableType[] = [];
   const updatedVariableCollections: VariableCollection[] = [];
   let updatedVariables: Variable[] = [];
-  const figmaVariablesBeforeCreate = figma.variables.getLocalVariables()?.length;
-  const figmaVariableCollectionsBeforeCreate = figma.variables.getLocalVariableCollections()?.length;
+  const figmaVariablesBeforeCreate = (await getVariablesWithoutZombies()).length;
+  const figmaVariableCollectionsBeforeCreate = figma.variables.getLocalVariableCollections().length;
 
   let figmaVariablesAfterCreate = 0;
 
@@ -92,8 +93,8 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
     updatedVariables = await updateVariablesToReference(existingVariables, referenceVariableCandidates);
   }
 
-  figmaVariablesAfterCreate += figma.variables.getLocalVariables()?.length ?? 0;
-  const figmaVariableCollectionsAfterCreate = figma.variables.getLocalVariableCollections()?.length;
+  figmaVariablesAfterCreate += (await getVariablesWithoutZombies()).length;
+  const figmaVariableCollectionsAfterCreate = figma.variables.getLocalVariableCollections().length;
 
   if (figmaVariablesAfterCreate === figmaVariablesBeforeCreate) {
     notifyUI('No variables were created');

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
@@ -93,8 +93,8 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
     updatedVariables = await updateVariablesToReference(existingVariables, referenceVariableCandidates);
   }
 
-  figmaVariablesAfterCreate += (await getVariablesWithoutZombies()).length;
-  const figmaVariableCollectionsAfterCreate = figma.variables.getLocalVariableCollections().length;
+  figmaVariablesAfterCreate += (await getVariablesWithoutZombies())?.length ?? 0;
+  const figmaVariableCollectionsAfterCreate = (await figma.variables.getLocalVariableCollectionsAsync())?.length;
 
   if (figmaVariablesAfterCreate === figmaVariablesBeforeCreate) {
     notifyUI('No variables were created');

--- a/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.test.ts
@@ -1,0 +1,47 @@
+import { getVariablesWithoutZombies } from './getVariablesWithoutZombies';
+import * as notifiers from './notifiers';
+
+describe('getVariablesWithoutZombies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(notifiers, 'notifyException').mockImplementation(() => {});
+  });
+
+  it('should return variables without zombies', async () => {
+    const variables = [
+      { id: 'var1', variableCollectionId: 'col1' },
+      { id: 'var2', variableCollectionId: 'col2' },
+      { id: 'var3', variableCollectionId: 'col3' }, // This variable is not included in the collections
+    ];
+    const collections = [{ id: 'col1' }, { id: 'col2' }];
+
+    (figma.variables.getLocalVariablesAsync as jest.Mock).mockResolvedValue(variables);
+    (figma.variables.getLocalVariableCollectionsAsync as jest.Mock).mockResolvedValue(collections);
+
+    const result = await getVariablesWithoutZombies();
+
+    expect(result).toEqual([
+      { id: 'var1', variableCollectionId: 'col1' },
+      { id: 'var2', variableCollectionId: 'col2' },
+    ]);
+  });
+
+  it('should return an empty array if no variables are available', async () => {
+    (figma.variables.getLocalVariablesAsync as jest.Mock).mockResolvedValue([]);
+    (figma.variables.getLocalVariableCollectionsAsync as jest.Mock).mockResolvedValue([]);
+
+    const result = await getVariablesWithoutZombies();
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle errors and notify exceptions', async () => {
+    const errorMessage = 'An error occurred';
+    (figma.variables.getLocalVariablesAsync as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+    const result = await getVariablesWithoutZombies();
+
+    expect(result).toEqual([]);
+    expect(notifiers.notifyException).toHaveBeenCalledWith(errorMessage);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.ts
@@ -9,7 +9,6 @@ export async function getVariablesWithoutZombies(): Promise<Variable[]> {
     const localVariableCollectionIds = await figma.variables.getLocalVariableCollectionsAsync().then((collections) => collections.map((collection) => collection.id));
     return localVariables.filter((variable) => localVariableCollectionIds.includes(variable.variableCollectionId));
   } catch (error: any) {
-    console.log('ERROR', error);
     notifyException(error?.message ?? 'Unknown error');
     return [];
   }

--- a/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.ts
@@ -6,7 +6,7 @@ import { notifyException } from './notifiers';
 export async function getVariablesWithoutZombies(): Promise<Variable[]> {
   try {
     const localVariables = await figma.variables.getLocalVariablesAsync();
-    const localVariableCollectionIds = await figma.variables.getLocalVariableCollectionsAsync().then((collections) => collections.map((collection) => collection.id));
+    const localVariableCollectionIds = await figma.variables.getLocalVariableCollectionsAsync()?.then((collections) => collections.map((collection) => collection.id));
     return localVariables.filter((variable) => localVariableCollectionIds.includes(variable.variableCollectionId));
   } catch (error: any) {
     notifyException(error?.message ?? 'Unknown error');

--- a/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/getVariablesWithoutZombies.ts
@@ -1,0 +1,16 @@
+// Figma has a weird bug where they return variables in getLocalVariables that dont exist anymore.
+
+import { notifyException } from './notifiers';
+
+// So we need to add another check to see if the variable collection exists - if not, it's a zombie variable and we should ignore it.
+export async function getVariablesWithoutZombies(): Promise<Variable[]> {
+  try {
+    const localVariables = await figma.variables.getLocalVariablesAsync();
+    const localVariableCollectionIds = await figma.variables.getLocalVariableCollectionsAsync().then((collections) => collections.map((collection) => collection.id));
+    return localVariables.filter((variable) => localVariableCollectionIds.includes(variable.variableCollectionId));
+  } catch (error: any) {
+    console.log('ERROR', error);
+    notifyException(error?.message ?? 'Unknown error');
+    return [];
+  }
+}

--- a/packages/tokens-studio-for-figma/src/plugin/mergeVariableReferences.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/mergeVariableReferences.test.ts
@@ -4,8 +4,11 @@ describe('mergeVariableReferencesWithLocalVariables', () => {
   beforeEach(() => {
     // Mock figma.variables.getLocalVariablesAsync
     figma.variables.getLocalVariablesAsync = jest.fn().mockResolvedValue([
-      { name: 'fg/local', key: 'V:123' },
-      { name: 'fg/muted', key: 'V:999' },
+      { name: 'fg/local', key: 'V:123', variableCollectionId: 'coll1' },
+      { name: 'fg/muted', key: 'V:999', variableCollectionId: 'coll1' },
+    ]);
+    figma.variables.getLocalVariableCollectionsAsync = jest.fn().mockResolvedValue([
+      { id: 'coll1' },
     ]);
   });
 

--- a/packages/tokens-studio-for-figma/src/plugin/mergeVariableReferences.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/mergeVariableReferences.ts
@@ -1,11 +1,12 @@
 import { ThemeObject } from '@/types';
+import { getVariablesWithoutZombies } from './getVariablesWithoutZombies';
 
 // Gather references that we should use. Merge current theme references with the ones from all themes as well as local variables
 // Note that this is a bit naive. As the active theme does not have the themes set as active that it should use as a reference, it will not be able to find the correct reference.
 // This is why we also pass in allThemes and merge them together. This is naive because it might be that the reference required is not the "first to detect".
 // We need to refactor this probably. Themes should be able to strictly specify which other theme the references are coming from, like we do for token sets.
 export async function mergeVariableReferencesWithLocalVariables(themes: ThemeObject[] = [], allThemes: ThemeObject[] = []): Promise<Map<string, string>> {
-  const localVariables = await figma.variables.getLocalVariablesAsync();
+  const localVariables = await getVariablesWithoutZombies();
 
   const variables = new Map();
   themes.forEach((theme) => {

--- a/packages/tokens-studio-for-figma/src/plugin/pullVariables.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullVariables.test.ts
@@ -30,11 +30,18 @@ describe('pullStyles', () => {
           { name: 'Custom', modeId: '1:3' },
         ],
       }),
-      getLocalVariables: jest.fn().mockReturnValue([
+      getLocalVariableCollectionsAsync: jest.fn().mockResolvedValue([
+        {
+          id: 'coll1',
+          name: 'Collection 1',
+        },
+      ]),
+      getLocalVariablesAsync: jest.fn().mockResolvedValue([
         {
           name: 'Color',
           remote: false,
           resolvedType: 'COLOR',
+          variableCollectionId: 'coll1',
           valuesByMode: {
             '1:0': {
               r: 1, g: 1, b: 1, a: 1,
@@ -54,6 +61,7 @@ describe('pullStyles', () => {
         {
           name: 'Number1',
           remote: false,
+          variableCollectionId: 'coll1',
           resolvedType: 'FLOAT',
           valuesByMode: {
             '1:0': 24,
@@ -65,6 +73,7 @@ describe('pullStyles', () => {
         {
           name: 'Number2',
           remote: false,
+          variableCollectionId: 'coll1',
           resolvedType: 'FLOAT',
           valuesByMode: {
             '1:0': 16,
@@ -76,6 +85,7 @@ describe('pullStyles', () => {
         {
           name: 'String',
           remote: false,
+          variableCollectionId: 'coll1',
           resolvedType: 'STRING',
           valuesByMode: {
             '1:0': 'Hello',
@@ -88,6 +98,7 @@ describe('pullStyles', () => {
         {
           name: 'Boolean',
           remote: false,
+          variableCollectionId: 'coll1',
           resolvedType: 'BOOLEAN',
           valuesByMode: {
             '1:0': true,
@@ -405,7 +416,7 @@ describe('pullStyles', () => {
   });
 
   it('pulls variables with dimensions in rem if both options are selected', async () => {
-    await pullVariables({ useDimensions: 'true', useRem: 'true' });
+    await pullVariables({ useDimensions: true, useRem: true });
 
     expect(notifyStyleValuesSpy).toHaveBeenCalledWith({
       colors: [

--- a/packages/tokens-studio-for-figma/src/plugin/pullVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullVariables.ts
@@ -24,7 +24,6 @@ export default async function pullVariables(options: PullVariablesOptions): Prom
 
   const localVariables = await getVariablesWithoutZombies();
 
-  // eslint-disable-next-line consistent-return
   localVariables.forEach((variable) => {
     const variableName = variable.name.replace(/\//g, '.');
     try {
@@ -127,9 +126,9 @@ export default async function pullVariables(options: PullVariablesOptions): Prom
             }
           });
           break;
-        default: return null;
+        default:
+          break;
       }
-      return null;
     } catch (error) {
       console.error('Error while processing variable:', variableName, error);
     }

--- a/packages/tokens-studio-for-figma/src/plugin/pullVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullVariables.ts
@@ -4,6 +4,7 @@ import { notifyVariableValues } from './notifiers';
 import { PullVariablesOptions } from '@/types';
 import { VariableToCreateToken } from '@/types/payloads';
 import { TokenTypes } from '@/constants/TokenTypes';
+import { getVariablesWithoutZombies } from './getVariablesWithoutZombies';
 
 export default async function pullVariables(options: PullVariablesOptions): Promise<void> {
   // @TODO should be specifically typed according to their type
@@ -21,8 +22,10 @@ export default async function pullVariables(options: PullVariablesOptions): Prom
     });
   }
 
+  const localVariables = await getVariablesWithoutZombies();
+
   // eslint-disable-next-line consistent-return
-  figma.variables.getLocalVariables().forEach((variable) => {
+  localVariables.forEach((variable) => {
     const variableName = variable.name.replace(/\//g, '.');
     try {
       const collection = figma.variables.getVariableCollectionById(variable.variableCollectionId);

--- a/packages/tokens-studio-for-figma/src/plugin/renameVariablesFromPlugin.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/renameVariablesFromPlugin.test.ts
@@ -1,4 +1,6 @@
-import { mockGetLocalVariables, mockGetVariableById, mockSetValueForMode } from '../../tests/__mocks__/figmaMock';
+import {
+  mockGetLocalVariableCollectionsAsync, mockGetLocalVariablesAsync, mockGetVariableById, mockSetValueForMode,
+} from '../../tests/__mocks__/figmaMock';
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { AsyncMessageTypes, GetThemeInfoMessageResult } from '@/types/AsyncMessages';
@@ -29,7 +31,7 @@ describe('renameVariablesFromPlugin', () => {
   AsyncMessageChannel.ReactInstance.handle(AsyncMessageTypes.GET_THEME_INFO, mockGetThemeInfoHandler);
 
   it('should rename variables', async () => {
-    const mockLocalVariables = [
+    const mockLocalVariablesAsync = [
       {
         id: 'VariableID:1234',
         key: '12345',
@@ -64,8 +66,19 @@ describe('renameVariablesFromPlugin', () => {
         setValueForMode: mockSetValueForMode,
       },
     ];
-    mockGetLocalVariables.mockImplementation(() => mockLocalVariables);
-    mockGetVariableById.mockImplementation(() => mockLocalVariables[2]);
+    const mockLocalVariableCollectionsAsync = [
+      {
+        id: 'VariableCollectionId:12:12345',
+        name: 'Collection 1',
+        remote: false,
+        modes: [
+          { name: 'Default', modeId: '123' },
+        ],
+      },
+    ];
+    mockGetLocalVariablesAsync.mockImplementation(() => mockLocalVariablesAsync);
+    mockGetLocalVariableCollectionsAsync.mockImplementation(() => Promise.resolve(mockLocalVariableCollectionsAsync));
+    mockGetVariableById.mockImplementation(() => mockLocalVariablesAsync[2]);
     expect(await renameVariablesFromPlugin([
       {
         oldName: 'fg.default',
@@ -76,6 +89,6 @@ describe('renameVariablesFromPlugin', () => {
       newName: 'fg.default-rename',
       variableIds: ['12345'],
     }]);
-    expect(mockLocalVariables[0].name).toBe('fg/default-rename');
+    expect(mockLocalVariablesAsync[0].name).toBe('fg/default-rename');
   });
 });

--- a/packages/tokens-studio-for-figma/src/plugin/renameVariablesFromPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/renameVariablesFromPlugin.ts
@@ -7,7 +7,7 @@ export default async function renameVariablesFromPlugin(tokens: TokenToRename[])
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
   });
-  const variableMap = getVariablesMap();
+  const variableMap = await getVariablesMap();
   const renamedVariableToken = tokens.map((token) => {
     const renamedVariableIds: string[] = [];
     const originalVariableIdsToRename = themeInfo.themes.reduce<string[]>((acc, theme) => {

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.test.ts
@@ -15,7 +15,7 @@ const newVariable: Variable = {
 };
 
 describe('updateVariables', () => {
-  figma.variables.getLocalVariables = jest.fn().mockReturnValue([{
+  figma.variables.getLocalVariablesAsync = jest.fn().mockResolvedValue([{
     name: 'existing/color',
     remote: false,
     resolvedType: 'COLOR',
@@ -26,7 +26,18 @@ describe('updateVariables', () => {
     variableCollectionId: 'VariableCollectionId:1:0',
   }]);
 
-  figma.variables.getVariableCollectionById = jest.fn().mockReturnValue({
+  figma.variables.getLocalVariableCollectionsAsync = jest.fn().mockResolvedValue([{
+    id: 'VariableCollectionId:1:0',
+    name: 'Collection 1',
+    remote: false,
+    modes: [
+      { name: 'Default', modeId: '1:0' },
+      { name: 'Dark', modeId: '1:1' },
+      { name: 'Light', modeId: '1:2' },
+    ],
+  }]);
+
+  figma.variables.getVariableCollectionById = jest.fn().mockResolvedValue({
     id: 'VariableCollectionId:1:0',
     name: 'Collection 1',
     remote: false,

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -5,6 +5,7 @@ import { SettingsState } from '@/app/store/models/settings';
 import checkIfTokenCanCreateVariable from '@/utils/checkIfTokenCanCreateVariable';
 import setValuesOnVariable from './setValuesOnVariable';
 import { mapTokensToVariableInfo } from '@/utils/mapTokensToVariableInfo';
+import { getVariablesWithoutZombies } from './getVariablesWithoutZombies';
 
 export type CreateVariableTypes = {
   collection: VariableCollection;
@@ -21,7 +22,7 @@ export default async function updateVariables({
   collection, mode, theme, tokens, settings, filterByTokenSet,
 }: CreateVariableTypes) {
   const tokensToCreate = generateTokensToCreate(theme, tokens, filterByTokenSet);
-  const variablesInCollection = figma.variables.getLocalVariables().filter((v) => v.variableCollectionId === collection.id);
+  const variablesInCollection = (await getVariablesWithoutZombies()).filter((v) => v.variableCollectionId === collection.id);
   const variablesToCreate: VariableToken[] = [];
   tokensToCreate.forEach((token) => {
     if (checkIfTokenCanCreateVariable(token, settings)) {

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariablesFromPlugin.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariablesFromPlugin.test.ts
@@ -1,4 +1,6 @@
-import { mockGetLocalVariables, mockSetValueForMode } from '../../tests/__mocks__/figmaMock';
+import {
+  mockGetLocalVariableCollectionsAsync, mockGetLocalVariablesAsync, mockSetValueForMode,
+} from '../../tests/__mocks__/figmaMock';
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { AsyncMessageTypes, GetThemeInfoMessageResult } from '@/types/AsyncMessages';
@@ -30,6 +32,12 @@ describe('updateVariablesFromPlugin', () => {
   });
   runAfter.push(AsyncMessageChannel.ReactInstance.connect());
   AsyncMessageChannel.ReactInstance.handle(AsyncMessageTypes.GET_THEME_INFO, mockGetThemeInfoHandler);
+  const mockLocalVariableCollections = [
+    {
+      id: 'VariableCollectionId:12:12345',
+      name: 'fg',
+    },
+  ];
   const mockLocalVariables = [
     {
       id: 'VariableID:1234',
@@ -75,7 +83,8 @@ describe('updateVariablesFromPlugin', () => {
       type: TokenTypes.COLOR,
       value: '#000000',
     };
-    mockGetLocalVariables.mockImplementation(() => mockLocalVariables);
+    mockGetLocalVariablesAsync.mockImplementation(() => mockLocalVariables);
+    mockGetLocalVariableCollectionsAsync.mockImplementation(() => Promise.resolve(mockLocalVariableCollections));
     await updateVariablesFromPlugin(payload);
     expect(setColorValuesOnVariableSpy).toBeCalledWith(
       {
@@ -101,7 +110,8 @@ describe('updateVariablesFromPlugin', () => {
       type: TokenTypes.COLOR,
       value: '#000000',
     };
-    mockGetLocalVariables.mockImplementation(() => mockLocalVariables);
+    mockGetLocalVariablesAsync.mockImplementation(() => Promise.resolve(mockLocalVariables));
+    mockGetLocalVariableCollectionsAsync.mockImplementation(() => Promise.resolve(mockLocalVariableCollections));
     await updateVariablesFromPlugin(payload);
     expect(mockSetValueForMode).toBeCalledWith('modeID:123', {
       type: 'VARIABLE_ALIAS',

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariablesFromPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariablesFromPlugin.ts
@@ -14,8 +14,8 @@ export default async function updateVariablesFromPlugin(payload: UpdateTokenVari
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
   });
-  const variableMap = getVariablesMap();
-  const nameToVariableMap = figma.variables.getLocalVariables().reduce<Record<string, Variable>>((acc, curr) => {
+  const variableMap = await getVariablesMap();
+  const nameToVariableMap = (await figma.variables.getLocalVariablesAsync())?.reduce<Record<string, Variable>>((acc, curr) => {
     acc[curr.name] = curr;
     return acc;
   }, {});

--- a/packages/tokens-studio-for-figma/src/utils/getVariablesMap.ts
+++ b/packages/tokens-studio-for-figma/src/utils/getVariablesMap.ts
@@ -1,5 +1,7 @@
-export function getVariablesMap() {
-  return figma.variables.getLocalVariables().reduce<Record<string, Variable>>((acc, curr) => {
+import { getVariablesWithoutZombies } from '@/plugin/getVariablesWithoutZombies';
+
+export async function getVariablesMap() {
+  return (await getVariablesWithoutZombies()).reduce<Record<string, Variable>>((acc, curr) => {
     acc[curr.key] = curr;
     return acc;
   }, {});

--- a/packages/tokens-studio-for-figma/tests/__mocks__/figmaMock.d.ts
+++ b/packages/tokens-studio-for-figma/tests/__mocks__/figmaMock.d.ts
@@ -22,6 +22,7 @@ export const mockGetNodeById: jest.Mock;
 export const mockScrollAndZoomIntoView: jest.Mock;
 export const mockCreateImage: jest.Mock;
 export const mockGetLocalVariables: jest.Mock;
+export const mockGetLocalVariablesAsync: jest.Mock;
 export const mockCreateVariable: jest.Mock;
 export const mockGetLocalVariableCollections = jest.Mock;
 export const mockGetLocalVariableCollectionsAsync = jest.Mock;

--- a/packages/tokens-studio-for-figma/tests/__mocks__/figmaMock.js
+++ b/packages/tokens-studio-for-figma/tests/__mocks__/figmaMock.js
@@ -73,7 +73,7 @@ module.exports.mockGetNodeById = jest.fn();
 module.exports.mockScrollAndZoomIntoView = jest.fn();
 module.exports.mockCreateImage = jest.fn();
 module.exports.mockGetLocalVariables = jest.fn(() => ([]));
-module.exports.mockGetLocalVariablesAsync = jest.fn(() => ([]));
+module.exports.mockGetLocalVariablesAsync = jest.fn(() => Promise.resolve([]));
 module.exports.mockCreateVariable = jest.fn();
 module.exports.mockGetLocalVariableCollections = jest.fn();
 module.exports.mockGetLocalVariableCollectionsAsync = jest.fn();


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/3140

### What does this pull request do?

This adds a check before we gather variables to use for references or for application, to see if the variable collection of those variables still exists.

### Testing this change

Open a file affected by this bug (hard to replicate). File in DM with `@rbosker` has this: https://hyma-team.slack.com/archives/D03HL8WE738/p1726231101338089 - https://www.figma.com/design/foDPZl0c28gzctr6ztvNfy/Components-Roberto-(Copy)?t=I2ASNxMojuiwTyTv-0

#### Before

<img width="1507" alt="CleanShot 2024-09-14 at 18 20 44@2x" src="https://github.com/user-attachments/assets/9de5340f-7c81-4d10-be65-8ca8714e2b00">

#### After

<img width="1246" alt="CleanShot 2024-09-14 at 18 25 46@2x" src="https://github.com/user-attachments/assets/ddd1bf23-982e-4166-be7d-ea0ae6f793b9">


