### PR TITLE
fix override order

### DIFF
--- a/.changeset/purple-chairs-learn.md
+++ b/.changeset/purple-chairs-learn.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue introduced in 2.1.0 that sometimes caused the order of token sets to not be as expected, meaning sets that acted as overrides didn't correctly get calculated.

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/attachLocalVariablesToTheme.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/attachLocalVariablesToTheme.ts
@@ -15,7 +15,7 @@ export const attachLocalVariablesToTheme: AsyncMessageChannelHandlers[AsyncMessa
   );
   if (collection && mode) {
     const collectionVariableIds: Record<string, string> = {};
-    const tokensToCreateVariablesFor = generateTokensToCreate(theme, tokens);
+    const tokensToCreateVariablesFor = generateTokensToCreate({ theme, tokens });
     tokensToCreateVariablesFor.forEach((token) => {
       const variable = figmaVariableMaps.get(token.name.split('.').join('/'));
       if (variable) {

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
@@ -9,6 +9,7 @@ import { notifyUI } from './notifiers';
 import { mergeVariableReferencesWithLocalVariables } from './mergeVariableReferences';
 import { findCollectionAndModeIdForTheme } from './findCollectionAndModeIdForTheme';
 import { createNecessaryVariableCollections } from './createNecessaryVariableCollections';
+import { getOverallConfig } from '@/utils/tokenHelpers';
 
 export type LocalVariableInfo = {
   collectionId: string;
@@ -40,6 +41,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
 
   const checkSetting = !settings.variablesBoolean && !settings.variablesColor && !settings.variablesNumber && !settings.variablesString;
   if (!checkSetting && selectedThemes && selectedThemes.length > 0) {
+    const overallConfig = getOverallConfig(themeInfo.themes, selectedThemes);
     const collections = await createNecessaryVariableCollections(themeInfo.themes, selectedThemes);
 
     await Promise.all(selectedThemeObjects.map(async (theme) => {
@@ -48,7 +50,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
       if (!collection || !modeId) return;
 
       const allVariableObj = await updateVariables({
-        collection, mode: modeId, theme, tokens, settings,
+        collection, mode: modeId, theme, tokens, settings, overallConfig,
       });
       figmaVariablesAfterCreate += allVariableObj.removedVariables.length;
       if (Object.keys(allVariableObj.variableIds).length > 0) {

--- a/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.test.ts
@@ -2,6 +2,7 @@ import { generateTokensToCreate } from './generateTokensToCreate';
 import { ThemeObject } from '@/types';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { AnyTokenList } from '@/types/tokens';
 
 describe('generateTokensToCreate', () => {
   const theme: ThemeObject = {
@@ -9,7 +10,7 @@ describe('generateTokensToCreate', () => {
     name: 'Light',
     selectedTokenSets: { core: TokenSetStatus.ENABLED, source: TokenSetStatus.SOURCE, disabled: TokenSetStatus.DISABLED },
   };
-  const tokens = {
+  const tokens: Record<string, AnyTokenList> = {
     core: [
       {
         name: 'primary.red',
@@ -30,7 +31,7 @@ describe('generateTokensToCreate', () => {
   };
 
   it('returns the correct tokens for enabled sets', () => {
-    const result = generateTokensToCreate(theme, tokens);
+    const result = generateTokensToCreate({ theme, tokens });
 
     expect(result).toEqual([
       {
@@ -44,17 +45,18 @@ describe('generateTokensToCreate', () => {
   });
 
   it('does not create tokens if their type is not in tokenTypesToCreateVariable', () => {
-    const tokensWithInvalidType = {
+    const tokensWithInvalidType: Record<string, AnyTokenList> = {
       core: [
         {
           name: 'primary.red',
           value: '#ff0000',
+          // @ts-expect-error - invalid type on purpose
           type: 'INVALID_TYPE',
         },
       ],
     };
 
-    const result = generateTokensToCreate(theme, tokensWithInvalidType);
+    const result = generateTokensToCreate({ theme, tokens: tokensWithInvalidType });
 
     expect(result).toEqual([]);
   });

--- a/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.ts
@@ -1,16 +1,26 @@
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
-import { ThemeObject } from '@/types';
+import { ThemeObject, UsedTokenSetsMap } from '@/types';
 import { AnyTokenList } from '@/types/tokens';
 import { defaultTokenResolver } from '@/utils/TokenResolver';
 import { mergeTokenGroups } from '@/utils/tokenHelpers';
 
-export function generateTokensToCreate(theme: ThemeObject, tokens: Record<string, AnyTokenList>, filterByTokenSet?: string) {
+export function generateTokensToCreate({
+  theme,
+  tokens,
+  filterByTokenSet,
+  overallConfig = {},
+}: {
+  theme: ThemeObject;
+  tokens: Record<string, AnyTokenList>;
+  filterByTokenSet?: string;
+  overallConfig?: UsedTokenSetsMap;
+}) {
   // Big O(resolveTokenValues * mergeTokenGroups)
   const enabledTokenSets = Object.entries(theme.selectedTokenSets)
     .filter(([name, status]) => status === TokenSetStatus.ENABLED && (!filterByTokenSet || name === filterByTokenSet))
     .map(([tokenSet]) => tokenSet);
-  const resolved = defaultTokenResolver.setTokens(mergeTokenGroups(tokens, theme.selectedTokenSets));
+  const resolved = defaultTokenResolver.setTokens(mergeTokenGroups(tokens, theme.selectedTokenSets, overallConfig));
   return resolved.filter(
     (token) => ((!token.internal__Parent || enabledTokenSets.includes(token.internal__Parent)) && tokenTypesToCreateVariable.includes(token.type)), // filter out SOURCE tokens
   );

--- a/packages/tokens-studio-for-figma/src/plugin/setNumberValuesOnVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setNumberValuesOnVariable.ts
@@ -5,6 +5,6 @@ export default function setNumberValuesOnVariable(variable: Variable, mode: stri
     }
     variable.setValueForMode(mode, value);
   } catch (e) {
-    console.error('Error setting numberVariable', e);
+    console.error('Error setting numberVariable on variable', variable.name, e);
   }
 }

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -1,6 +1,6 @@
 import { AnyTokenList, SingleToken } from '@/types/tokens';
 import { generateTokensToCreate } from './generateTokensToCreate';
-import { ThemeObject } from '@/types';
+import { ThemeObject, UsedTokenSetsMap } from '@/types';
 import { SettingsState } from '@/app/store/models/settings';
 import checkIfTokenCanCreateVariable from '@/utils/checkIfTokenCanCreateVariable';
 import setValuesOnVariable from './setValuesOnVariable';
@@ -13,14 +13,17 @@ export type CreateVariableTypes = {
   tokens: Record<string, AnyTokenList>;
   settings: SettingsState;
   filterByTokenSet?: string;
+  overallConfig: UsedTokenSetsMap;
 };
 
 export type VariableToken = SingleToken<true, { path: string, variableId: string }>;
 
 export default async function updateVariables({
-  collection, mode, theme, tokens, settings, filterByTokenSet,
+  collection, mode, theme, tokens, settings, filterByTokenSet, overallConfig,
 }: CreateVariableTypes) {
-  const tokensToCreate = generateTokensToCreate(theme, tokens, filterByTokenSet);
+  const tokensToCreate = generateTokensToCreate({
+    theme, tokens, filterByTokenSet, overallConfig,
+  });
   const variablesInCollection = figma.variables.getLocalVariables().filter((v) => v.variableCollectionId === collection.id);
   const variablesToCreate: VariableToken[] = [];
   tokensToCreate.forEach((token) => {

--- a/packages/tokens-studio-for-figma/src/types/ExportTokenSet.ts
+++ b/packages/tokens-studio-for-figma/src/types/ExportTokenSet.ts
@@ -1,6 +1,6 @@
-import { TokenSetStatus } from "@/constants/TokenSetStatus";
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
 
 export type ExportTokenSet = {
   set: string;
   status: TokenSetStatus
-}
+};

--- a/packages/tokens-studio-for-figma/src/utils/getTokenSetsOrder.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/getTokenSetsOrder.test.ts
@@ -1,0 +1,127 @@
+import { getTokenSetsOrder } from './getTokenSetsOrder';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { SingleToken } from '@/types/tokens';
+import { UsedTokenSetsMap } from '@/types';
+
+describe('getTokenSetsOrder', () => {
+  it('orders token sets correctly with enabled, source, and disabled statuses', () => {
+    const tokens: Record<string, SingleToken[]> = {
+      global: [],
+      brand: [],
+      'mode/light': [],
+      'mode/dark': [],
+      'spacing/small': [],
+      'spacing/large': [],
+      'color/primary': [],
+      'typography/heading': [],
+    };
+
+    const usedSets: UsedTokenSetsMap = {
+      global: TokenSetStatus.ENABLED,
+      brand: TokenSetStatus.ENABLED,
+      'mode/light': TokenSetStatus.SOURCE,
+      'mode/dark': TokenSetStatus.DISABLED,
+      'spacing/small': TokenSetStatus.DISABLED,
+      'spacing/large': TokenSetStatus.ENABLED,
+      'color/primary': TokenSetStatus.DISABLED,
+      'typography/heading': TokenSetStatus.DISABLED,
+    };
+
+    const overallConfig: UsedTokenSetsMap = {
+      global: TokenSetStatus.ENABLED,
+      brand: TokenSetStatus.ENABLED,
+      'mode/light': TokenSetStatus.SOURCE,
+      'mode/dark': TokenSetStatus.SOURCE,
+      'spacing/small': TokenSetStatus.ENABLED,
+      'spacing/large': TokenSetStatus.ENABLED,
+      'color/primary': TokenSetStatus.DISABLED,
+      'typography/heading': TokenSetStatus.DISABLED,
+    };
+
+    const activeTokenSet = 'mode/light';
+
+    const result = getTokenSetsOrder(tokens, usedSets, overallConfig, activeTokenSet);
+
+    expect(result).toEqual({
+      tokenSetsOrder: ['color/primary', 'typography/heading', 'mode/dark', 'spacing/small', 'global', 'brand', 'spacing/large', 'mode/light'],
+      usedSetsList: ['global', 'brand', 'spacing/large', 'mode/light'],
+      overallSets: ['color/primary', 'typography/heading', 'mode/dark', 'spacing/small'],
+    });
+  });
+
+  it('places the active token set at the end of the used sets list', () => {
+    const tokens: Record<string, SingleToken[]> = {
+      base: [],
+      theme: [],
+    };
+
+    const usedSets: UsedTokenSetsMap = {
+      base: TokenSetStatus.ENABLED,
+      theme: TokenSetStatus.ENABLED,
+    };
+
+    const overallConfig: UsedTokenSetsMap = {
+      base: TokenSetStatus.ENABLED,
+      theme: TokenSetStatus.ENABLED,
+    };
+
+    const activeTokenSet = 'base';
+
+    const result = getTokenSetsOrder(tokens, usedSets, overallConfig, activeTokenSet);
+
+    expect(result).toEqual({
+      tokenSetsOrder: ['theme', 'base'],
+      usedSetsList: ['theme', 'base'],
+      overallSets: [],
+    });
+  });
+
+  it('respects the overallConfig order for sets not in usedSetsList', () => {
+    const tokens: Record<string, SingleToken[]> = {
+      fonts: [],
+      colors: [],
+      'mode/light': [],
+      'mode/dark': [],
+      unused: [],
+    };
+
+    const usedSets: UsedTokenSetsMap = {
+      fonts: TokenSetStatus.DISABLED,
+      colors: TokenSetStatus.DISABLED,
+      'mode/light': TokenSetStatus.SOURCE,
+      'mode/dark': TokenSetStatus.ENABLED,
+    };
+
+    const overallConfig: UsedTokenSetsMap = {
+      fonts: TokenSetStatus.ENABLED,
+      colors: TokenSetStatus.ENABLED,
+      'mode/light': TokenSetStatus.SOURCE,
+      'mode/dark': TokenSetStatus.SOURCE,
+      unused: TokenSetStatus.DISABLED,
+    };
+
+    const result = getTokenSetsOrder(tokens, usedSets, overallConfig);
+
+    expect(result).toEqual({
+      tokenSetsOrder: ['unused', 'fonts', 'colors', 'mode/light', 'mode/dark'],
+      usedSetsList: ['mode/light', 'mode/dark'],
+      overallSets: ['unused', 'fonts', 'colors'],
+    });
+  });
+
+  it('handles empty tokens input gracefully', () => {
+    const tokens: Record<string, SingleToken[]> = {};
+
+    const usedSets: UsedTokenSetsMap = {};
+
+    const overallConfig: UsedTokenSetsMap = {};
+
+    const result = getTokenSetsOrder(tokens, usedSets, overallConfig);
+
+    expect(result).toEqual({
+      tokenSetsOrder: [],
+      usedSetsList: [],
+      overallSets: [],
+    });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/getTokenSetsOrder.ts
+++ b/packages/tokens-studio-for-figma/src/utils/getTokenSetsOrder.ts
@@ -1,0 +1,25 @@
+import { TokenSetStatus } from "@/constants/TokenSetStatus";
+import { UsedTokenSetsMap } from "@/types";
+import { SingleToken } from "@/types/tokens";
+import { sortSets } from "./sortSets";
+
+export function getTokenSetsOrder(
+  tokens: Record<string, SingleToken[]>,
+  usedSets: UsedTokenSetsMap,
+  overallConfig: UsedTokenSetsMap,
+  activeTokenSet?: string): { tokenSetsOrder: string[]; usedSetsList: string[]; overallSets: string[]; } {
+  const originalTokenSetOrder = Object.keys(tokens);
+  const usedSetsList = originalTokenSetOrder.filter((key) => usedSets[key] === TokenSetStatus.ENABLED || usedSets[key] === TokenSetStatus.SOURCE);
+  const overallSets = originalTokenSetOrder
+    .filter((set) => !usedSetsList.includes(set))
+    .sort((a, b) => sortSets(a, b, overallConfig));
+
+  if (activeTokenSet) {
+    usedSetsList.splice(usedSetsList.indexOf(activeTokenSet), 1);
+    usedSetsList.push(activeTokenSet);
+  }
+
+  const tokenSetsOrder = [...overallSets, ...usedSetsList];
+
+  return { tokenSetsOrder, usedSetsList, overallSets };
+}

--- a/packages/tokens-studio-for-figma/src/utils/getTokenSetsOrder.ts
+++ b/packages/tokens-studio-for-figma/src/utils/getTokenSetsOrder.ts
@@ -1,13 +1,14 @@
-import { TokenSetStatus } from "@/constants/TokenSetStatus";
-import { UsedTokenSetsMap } from "@/types";
-import { SingleToken } from "@/types/tokens";
-import { sortSets } from "./sortSets";
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { UsedTokenSetsMap } from '@/types';
+import { SingleToken } from '@/types/tokens';
+import { sortSets } from './sortSets';
 
 export function getTokenSetsOrder(
   tokens: Record<string, SingleToken[]>,
   usedSets: UsedTokenSetsMap,
   overallConfig: UsedTokenSetsMap,
-  activeTokenSet?: string): { tokenSetsOrder: string[]; usedSetsList: string[]; overallSets: string[]; } {
+  activeTokenSet?: string,
+): { tokenSetsOrder: string[]; usedSetsList: string[]; overallSets: string[]; } {
   const originalTokenSetOrder = Object.keys(tokens);
   const usedSetsList = originalTokenSetOrder.filter((key) => usedSets[key] === TokenSetStatus.ENABLED || usedSets[key] === TokenSetStatus.SOURCE);
   const overallSets = originalTokenSetOrder

--- a/packages/tokens-studio-for-figma/src/utils/sortSets.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/sortSets.test.ts
@@ -1,0 +1,39 @@
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { UsedTokenSetsMap } from '@/types';
+import { sortSets } from './sortSets';
+
+describe('sortSets', () => {
+  const config: UsedTokenSetsMap = {
+    source: TokenSetStatus.SOURCE,
+    enabled: TokenSetStatus.ENABLED,
+    disabled: TokenSetStatus.DISABLED,
+  };
+
+  it('should prioritize DISABLED over ENABLED and SOURCE', () => {
+    expect(sortSets('disabled', 'enabled', config)).toBe(-1);
+    expect(sortSets('enabled', 'disabled', config)).toBe(1);
+    expect(sortSets('disabled', 'source', config)).toBe(-1);
+    expect(sortSets('source', 'disabled', config)).toBe(1);
+  });
+
+  it('should maintain order for same status', () => {
+    expect(sortSets('source', 'source', config)).toBe(0);
+    expect(sortSets('enabled', 'enabled', config)).toBe(0);
+    expect(sortSets('disabled', 'disabled', config)).toBe(0);
+  });
+
+  it('should handle sets not in config', () => {
+    expect(sortSets('unknown1', 'unknown2', config)).toBe(0);
+    expect(sortSets('disabled', 'unknown', config)).toBe(0); // DISABLED is treated as DISABLED
+    expect(sortSets('unknown', 'disabled', config)).toBe(0); // DISABLED is treated as DISABLED
+    expect(sortSets('unknown', 'enabled', config)).toBe(-1);
+    expect(sortSets('enabled', 'unknown', config)).toBe(1);
+    expect(sortSets('unknown', 'source', config)).toBe(-1);
+    expect(sortSets('source', 'unknown', config)).toBe(1);
+  });
+
+  it('should not prioritize between ENABLED and SOURCE', () => {
+    expect(sortSets('enabled', 'source', config)).toBe(0);
+    expect(sortSets('source', 'enabled', config)).toBe(0);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/sortSets.ts
+++ b/packages/tokens-studio-for-figma/src/utils/sortSets.ts
@@ -1,0 +1,19 @@
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { UsedTokenSetsMap } from '@/types';
+
+// Helper function to sort token sets based on their status in the configuration. Basically, ENABLED and SOURCE sets are treated equally and come before DISABLED.
+export function sortSets(a: string, b: string, config: UsedTokenSetsMap) {
+  // Get the status of each set, defaulting to DISABLED if not found in config
+  const statusA = config[a] || TokenSetStatus.DISABLED;
+  const statusB = config[b] || TokenSetStatus.DISABLED;
+
+  // If both sets have the same status, maintain their original order
+  if (statusA === statusB) return 0;
+
+  // DISABLED sets should come before ENABLED and SOURCE, which are treated equally
+  if (statusA === TokenSetStatus.DISABLED && (statusB === TokenSetStatus.ENABLED || statusB === TokenSetStatus.SOURCE)) return -1;
+  if ((statusA === TokenSetStatus.ENABLED || statusA === TokenSetStatus.SOURCE) && statusB === TokenSetStatus.DISABLED) return 1;
+
+  // If we reach here, it means both are ENABLED or SOURCE, or both are DISABLED
+  return 0;
+}


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/3139

When we're merging token sets, we weren't ordering token sets as they should. Instead, we were relying on the ordering that existed in the themes. This caused any variable creation or merging of token sets to not respect overrides coming later.

This PR fixes this. In addition, this PR fixes a bug when exporting tokens via Sets - given they both were using that same function I fixed that along the way. Basically, if you exported sets that had math calculations inside, we didnt properly calculate those, as we were only passing in the current set tokens, and not the whole tokens when resolving.

### Before

<img width="1349" alt="image" src="https://github.com/user-attachments/assets/e44df162-91be-4dad-a6c6-97c2345f17a7">

<img width="1290" alt="CleanShot 2024-09-14 at 18 14 36@2x" src="https://github.com/user-attachments/assets/cd101145-b0d4-4a1a-bbbd-f81e71a15751">


### After

<img width="1355" alt="CleanShot 2024-09-14 at 17 59 38@2x" src="https://github.com/user-attachments/assets/3882f93b-5afb-4117-ad02-6623cf6b2755">

<img width="1297" alt="CleanShot 2024-09-14 at 18 15 02@2x" src="https://github.com/user-attachments/assets/461366f5-3ab3-44f2-ad73-81b6980a9b66">

### Testing this change

Load the .JSON linked in the Issue (single file import). Try to create before and after.

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
