### PR TITLE
fixes an issue from zombie variables on variable create

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.test.ts
@@ -26,6 +26,17 @@ describe('updateVariables', () => {
     variableCollectionId: 'VariableCollectionId:1:0',
   }]);
 
+  figma.variables.getLocalVariables = jest.fn().mockReturnValue([{
+    name: 'existing/color',
+    remote: false,
+    resolvedType: 'COLOR',
+    setValueForMode: mockSetValueForMode,
+    remove: jest.fn(),
+    description: '',
+    key: 'VariableID:1:toremove',
+    variableCollectionId: 'VariableCollectionId:1:0',
+  }]);
+
   figma.variables.getLocalVariableCollectionsAsync = jest.fn().mockResolvedValue([{
     id: 'VariableCollectionId:1:0',
     name: 'Collection 1',

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -25,7 +25,15 @@ export default async function updateVariables({
   const tokensToCreate = generateTokensToCreate({
     theme, tokens, filterByTokenSet, overallConfig,
   });
-  const variablesInCollection = (await getVariablesWithoutZombies()).filter((v) => v.variableCollectionId === collection.id);
+
+  // Do not use getVariablesWithoutZombies. It's not working.
+  // There seems to be a bug with getLocalVariablesAsync. It's not returning the variables in the collection - when they're being created.
+  // We could also get the current collection with figma.variables.getVariableCollectionByIdAsync(collection.id) and then fetch each variable,
+  // but that feels costly? We might need to double check this though.
+  // e.g. this wont work.
+  // const variablesInCollection = (await figma.variables.getLocalVariablesAsync()).filter((v) => v.variableCollectionId === collection.id);
+  const variablesInCollection = figma.variables.getLocalVariables().filter((v) => v.variableCollectionId === collection.id);
+
   const variablesToCreate: VariableToken[] = [];
   tokensToCreate.forEach((token) => {
     if (checkIfTokenCanCreateVariable(token, settings)) {


### PR DESCRIPTION
fixes an issue i discovered during release that didnt properly populate the list of available variables when creating

## before:

<img width="737" alt="image" src="https://github.com/user-attachments/assets/2c87815f-f925-4bce-ae48-a206042b5316">


## after:

<img width="745" alt="CleanShot 2024-09-19 at 09 00 01@2x" src="https://github.com/user-attachments/assets/75ae2de8-c3b9-4b56-8224-56b1f043cf12">
