### PR TITLE
Fix bitbucket empty sets

### DIFF
--- a/.changeset/spotty-games-sin.md
+++ b/.changeset/spotty-games-sin.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": minor
+---
+
+Resolved an issue with Bitbucket sync where deleted sets were still being reflected in the tokens repository.

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -296,7 +296,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
 
     const url = `https://api.bitbucket.org/2.0/repositories/${owner}/${repo}/src/${branch}/`;
     const existingFiles = await this.fetchJsonFilesFromDirectory(url);
-  
+
     const existingTokenSets: Record<string, boolean> = {};
     if (Array.isArray(existingFiles)) {
       existingFiles.forEach((file) => {
@@ -310,7 +310,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
     const localTokenSets = Object.keys(files);
 
     const deletedTokenSets = Object.keys(existingTokenSets).filter(
-      (tokenSet) => !localTokenSets.includes(tokenSet) && !tokenSet.startsWith('$')
+      (tokenSet) => !localTokenSets.includes(tokenSet) && !tokenSet.startsWith('$'),
     );
 
     // @README the files object is Record<string, string> here
@@ -328,7 +328,6 @@ export class BitbucketTokenStorage extends GitTokenStorage {
     deletedTokenSets.forEach((tokenSet) => {
       data.append('files', `${tokenSet}.json`); // Mark for deletion
     });
-
 
     const response = await this.bitbucketClient.repositories.createSrcFileCommit({
       _body: data,


### PR DESCRIPTION
# Description

Fixes #3117 

# Description

Fixes a bug with Bitbucket sync issue where a deleted set's json still reflects in the repo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How to test this

* Sync Tokens with Bitbucket
* Delete a token set in the plugin
* Sync again with bitbucket
* The json file of the deleted set should now be removed.

# Screenshots or video (if necessary):
