### PR TITLE
Fix styling issue with prefixed theme name

### DIFF
--- a/.changeset/warm-buses-bathe.md
+++ b/.changeset/warm-buses-bathe.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": minor
+---
+
+Fixed a bug where applying a core theme with a prefixed name interfered with the display of applied styles in Figma

--- a/.changeset/warm-buses-bathe.md
+++ b/.changeset/warm-buses-bathe.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": minor
 ---
 
-Fixed a bug where applying a core theme with a prefixed name interfered with the display of applied styles in Figma
+Fixed a bug where applying themes using "Prefix styles with active theme name" didn't correctly apply the right styles.

--- a/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/TokenValueRetriever.ts
@@ -60,7 +60,7 @@ export class TokenValueRetriever {
       // For styles, we need to ignore the first part of the token name as well as consider theme prefix
       const [adjustedTokenName, adjustedTokenNameWithIgnoreFirstPart] = this.getAdjustedTokenName(token.name);
 
-      const styleId = styleReferences?.get(adjustedTokenName) || styleReferences?.get(adjustedTokenNameWithIgnoreFirstPart);
+      const styleId = styleReferences?.get(adjustedTokenName) || styleReferences?.get(adjustedTokenNameWithIgnoreFirstPart) || styleReferences?.get(token.name);
       const finalAdjustedTokenName = styleReferences?.has(adjustedTokenName) ? adjustedTokenName : adjustedTokenNameWithIgnoreFirstPart;
 
       return [token.name, {


### PR DESCRIPTION
Fixes #3145 

# Description

Fixes a bug around applying styles with prefixed theme name, where if the user applies core theme, then it mangles with the application of styles display in the plugin.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] None of the above

# How to test this

* Create themes in the plugin
* Export them as styles with prefixed theme name
* Apply a color token from a theme, it will reflect the style in Figma
* Now disable core style and it should work then

# Screenshots or video (if necessary):
