### PR TITLE
apply linear gradient incase variable reference not resolved

### DIFF
--- a/.changeset/twenty-days-relate.md
+++ b/.changeset/twenty-days-relate.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue where referencing a gradient would result in an empty color style; now the style correctly resolves to the gradient.

--- a/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
@@ -115,8 +115,8 @@ export default async function setColorValuesOnTarget({
           newPaint = { color, opacity, type: 'SOLID' };
         }
 
-        applyPaintIfNotEqual(key, existingPaint, newPaint, target)
         await unbindVariableFromTarget(target, key, newPaint);
+        applyPaintIfNotEqual(key, existingPaint, newPaint, target);
       }
     }
     if (description && 'description' in target) {

--- a/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setColorValuesOnTarget.ts
@@ -17,7 +17,7 @@ const applyPaintIfNotEqual = (key, existingPaint, newPaint, target) => {
     if (key === 'fills' && 'fills' in target) target.fills = [newPaint];
     if (key === 'strokes' && 'strokes' in target) target.strokes = [newPaint];
   }
-}
+};
 
 const getLinearGradientPaint = async (fallbackValue, token) => {
   const { gradientStops, gradientTransform } = convertStringToFigmaGradient(fallbackValue);
@@ -53,7 +53,7 @@ const getLinearGradientPaint = async (fallbackValue, token) => {
     gradientStops: gradientStopsWithReferences,
   };
   return newPaint;
-}
+};
 
 export default async function setColorValuesOnTarget({
   target, token, key, givenValue,


### PR DESCRIPTION
### Why does this PR exist?

Fixes #3150  <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

Steps to reproduce the behavior:

1. Create a gradient, for example: `linear-gradient(45deg, #ff00ff 0%, #ff0000 100%)`

2. Reference this gradient in another token (in the same or other set)

3. Export these as Styles in Figma

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

**Before**

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/1eb5ff24-4561-4053-948f-fb975ac06eff">


**After**

<img width="1098" alt="image" src="https://github.com/user-attachments/assets/c388d5fd-087c-4be3-b2d6-1d3ca4623c79">


<!--
  Add any other context or screenshots about the pull request
-->
