### PR TITLE
Fix duplicate display studio sync

### DIFF
--- a/.changeset/shy-ants-dance.md
+++ b/.changeset/shy-ants-dance.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+fixed an issue where the studio sync provider was mistakenly displayed twice upon setting up the connection

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/TokensStudioForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/TokensStudioForm.tsx
@@ -58,7 +58,7 @@ export default function TokensStudioForm({
           ...validationResult.data,
           internalId: validationResult.data.internalId || generateId(24),
         } as ValidatedFormValues;
-        setIsLoading(true); 
+        setIsLoading(true);
 
         onSubmit(formFields);
 
@@ -80,21 +80,22 @@ export default function TokensStudioForm({
     setShowTeaser(false);
   }, []);
 
-    return showTeaser ? (
-      <Stack direction="column" align="start" gap={5}>
-        <StyledTokensStudioWord />
-        <Stack direction="column" gap={3}>
-          <Heading size="large">A dedicated design tokens management platform</Heading>
-          <Box>We are working a dedicated design tokens management platform built on our powerful node-based graph engine including plug and play token transformation - suitable for enterprises! Still in early access, sign up for the waitlist!</Box>
-          <Link href="https://tokens.studio/studio" target="_blank" rel="noreferrer">Learn more</Link>
-        </Stack>
-        <Button onClick={handleDismissTeaser}>Already got access?</Button>
+  return showTeaser ? (
+    <Stack direction="column" align="start" gap={5}>
+      <StyledTokensStudioWord />
+      <Stack direction="column" gap={3}>
+        <Heading size="large">A dedicated design tokens management platform</Heading>
+        <Box>We are working a dedicated design tokens management platform built on our powerful node-based graph engine including plug and play token transformation - suitable for enterprises! Still in early access, sign up for the waitlist!</Box>
+        <Link href="https://tokens.studio/studio" target="_blank" rel="noreferrer">Learn more</Link>
       </Stack>
-    ):(
+      <Button onClick={handleDismissTeaser}>Already got access?</Button>
+    </Stack>
+  ) : (
     <form onSubmit={handleSubmit}>
       <Stack direction="column" gap={5}>
-      <Text muted>
-          {t('providers.tokensstudio.descriptionFirstPart')}{' '}
+        <Text muted>
+          {t('providers.tokensstudio.descriptionFirstPart')}
+          {' '}
           <Link
             href="https://q2gsw2tok1e.typeform.com/to/pJCwLVh2?typeform-source=tokens.studio"
             target="_blank"

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/TokensStudioForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/TokensStudioForm.tsx
@@ -35,7 +35,6 @@ export default function TokensStudioForm({
   const syncGuideUrl = 'tokens-studio';
   const [isMasked, setIsMasked] = React.useState(true);
   const [showTeaser, setShowTeaser] = React.useState(true);
-  const [isLoading, setIsLoading] = React.useState(false);
 
   const toggleMask = React.useCallback(() => {
     setIsMasked((prev) => !prev);
@@ -58,13 +57,8 @@ export default function TokensStudioForm({
           ...validationResult.data,
           internalId: validationResult.data.internalId || generateId(24),
         } as ValidatedFormValues;
-        setIsLoading(true);
 
         onSubmit(formFields);
-
-        setTimeout(() => {
-          setIsLoading(false);
-        }, 5000);
       }
     },
     [values, onSubmit],
@@ -146,7 +140,7 @@ export default function TokensStudioForm({
           <Button variant="secondary" onClick={onCancel}>
             {t('cancel')}
           </Button>
-          <Button variant="primary" type="submit" disabled={isLoading || (!values.secret && !values.name)}>
+          <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
             {t('save')}
           </Button>
         </Stack>

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/TokensStudioForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItemForm/TokensStudioForm.tsx
@@ -35,6 +35,7 @@ export default function TokensStudioForm({
   const syncGuideUrl = 'tokens-studio';
   const [isMasked, setIsMasked] = React.useState(true);
   const [showTeaser, setShowTeaser] = React.useState(true);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   const toggleMask = React.useCallback(() => {
     setIsMasked((prev) => !prev);
@@ -57,7 +58,13 @@ export default function TokensStudioForm({
           ...validationResult.data,
           internalId: validationResult.data.internalId || generateId(24),
         } as ValidatedFormValues;
+        setIsLoading(true); 
+
         onSubmit(formFields);
+
+        setTimeout(() => {
+          setIsLoading(false);
+        }, 5000);
       }
     },
     [values, onSubmit],
@@ -138,7 +145,7 @@ export default function TokensStudioForm({
           <Button variant="secondary" onClick={onCancel}>
             {t('cancel')}
           </Button>
-          <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
+          <Button variant="primary" type="submit" disabled={isLoading || (!values.secret && !values.name)}>
             {t('save')}
           </Button>
         </Stack>

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
@@ -121,7 +121,6 @@ const SyncSettings = () => {
 
   const handleProviderClick = React.useCallback(
     (provider: StorageProviderType) => () => {
-      console.log('api providers,', apiProviders);
       setOpen(false);
       setStorageProvider(provider);
       handleShowAddCredentials(provider);

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
@@ -92,10 +92,10 @@ const SyncSettings = () => {
       const uniqueProviders = apiProviders.filter((provider) => {
         const key = `${provider.provider}-${provider.name}`;
         if (uniqueProvidersMap.has(key)) {
-          return false; 
+          return false;
         }
         uniqueProvidersMap.set(key, true);
-        return true; 
+        return true;
       });
 
       if (uniqueProviders.length < apiProviders.length) {
@@ -121,7 +121,7 @@ const SyncSettings = () => {
 
   const handleProviderClick = React.useCallback(
     (provider: StorageProviderType) => () => {
-      console.log("api providers,", apiProviders);
+      console.log('api providers,', apiProviders);
       setOpen(false);
       setStorageProvider(provider);
       handleShowAddCredentials(provider);

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
@@ -85,6 +85,25 @@ const SyncSettings = () => {
     [dispatch.branchState, fetchBranches],
   );
 
+  React.useEffect(() => {
+    if (apiProviders.length > 0) {
+      const uniqueProvidersMap = new Map();
+
+      const uniqueProviders = apiProviders.filter((provider) => {
+        const key = `${provider.provider}-${provider.name}`;
+        if (uniqueProvidersMap.has(key)) {
+          return false; 
+        }
+        uniqueProvidersMap.set(key, true);
+        return true; 
+      });
+
+      if (uniqueProviders.length < apiProviders.length) {
+        dispatch.uiState.setAPIProviders(uniqueProviders);
+      }
+    }
+  }, [apiProviders, dispatch]);
+
   const handleEditClick = React.useCallback(
     (provider: any) => () => {
       track('Edit Credentials');
@@ -102,6 +121,7 @@ const SyncSettings = () => {
 
   const handleProviderClick = React.useCallback(
     (provider: StorageProviderType) => () => {
+      console.log("api providers,", apiProviders);
       setOpen(false);
       setStorageProvider(provider);
       handleShowAddCredentials(provider);


### PR DESCRIPTION
Resolves #3069 

Fixes an error where the Tokens Studio Sync Provider in the plugin was showing up twice.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] None of the above

# How to test this

* Go to Settings Tab
* Click on Add New Sync Provider
* Choose Tokens Studio(Beta)
* Add API key and connection string
* Click on Save
* You should either see and error or a success. If you see an error, check your keys and click on save again. If successful, the Tokens Studio Sync provider should no show up only once in the list of sync providers

# Screenshots or video (if necessary):