### PR TITLE
update isSameCredentials check to prefer internalId when available

### DIFF
--- a/.changeset/heavy-colts-look.md
+++ b/.changeset/heavy-colts-look.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue where sometimes duplicate sync providers would show up

--- a/packages/tokens-studio-for-figma/src/utils/isSameCredentials.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/isSameCredentials.test.ts
@@ -16,6 +16,16 @@ describe('isSameCredentials', () => {
       branch: 'main',
       internalId: '123',
     };
+    const storedSupernova = {
+      id: '456',
+      provider: StorageProviderType.SUPERNOVA,
+      designSystemUrl: 'https://example.com',
+      mapping: { foo: 'bar' },
+    };
+    const storedTokensStudio = {
+      id: '789',
+      provider: StorageProviderType.TOKENS_STUDIO,
+    };
     const correctCredentials = {
       id: '123',
       provider: StorageProviderType.JSONBIN,
@@ -39,6 +49,20 @@ describe('isSameCredentials', () => {
       branch: 'default',
       internalId: '123',
     };
+    const correctSupernovaCredentials = {
+      id: '456',
+      provider: StorageProviderType.SUPERNOVA,
+      secret: 'def',
+      name: 'supernova',
+      designSystemUrl: 'https://example.com',
+      mapping: { foo: 'bar' },
+    };
+    const correctTokensStudioCredentials = {
+      id: '789',
+      provider: StorageProviderType.TOKENS_STUDIO,
+      secret: 'ghi',
+      name: 'tokensstudio',
+    };
 
     expect(isSameCredentials(correctCredentials, storedJSONBin)).toBe(true);
     expect(isSameCredentials({ ...correctCredentials, id: '456' }, storedJSONBin)).toBe(false);
@@ -46,5 +70,44 @@ describe('isSameCredentials', () => {
     expect(isSameCredentials({ ...correctGitHubCredentials, filePath: 'tokens2.json' }, storedGitHub)).toBe(false);
     expect(isSameCredentials({ ...correctGitHubCredentials, branch: 'next' }, storedGitHub)).toBe(false);
     expect(isSameCredentials(gitHubCredentialsWithDifferentBranch, storedGitHub)).toBe(true);
+    expect(isSameCredentials(correctSupernovaCredentials, storedSupernova)).toBe(true);
+    expect(isSameCredentials({ ...correctSupernovaCredentials, designSystemUrl: 'https://different.com' }, storedSupernova)).toBe(false);
+    expect(isSameCredentials({ ...correctSupernovaCredentials, mapping: { baz: 'qux' } }, storedSupernova)).toBe(false);
+    expect(isSameCredentials(correctTokensStudioCredentials, storedTokensStudio)).toBe(true);
+    expect(isSameCredentials({ ...correctTokensStudioCredentials, id: '987' }, storedTokensStudio)).toBe(false);
+  });
+
+  it('should use internalId for comparison when available', () => {
+    const storedWithInternalId = {
+      id: 'old-id',
+      provider: StorageProviderType.GITHUB,
+      filePath: 'old-path.json',
+      branch: 'old-branch',
+      internalId: 'internal-123',
+    };
+    const credentialWithInternalId = {
+      id: 'new-id',
+      provider: StorageProviderType.GITHUB,
+      filePath: 'new-path.json',
+      branch: 'new-branch',
+      internalId: 'internal-123',
+    };
+
+    expect(isSameCredentials(credentialWithInternalId, storedWithInternalId)).toBe(true);
+  });
+
+  it('should return false for unsupported provider types', () => {
+    const unsupportedProvider = {
+      id: '999',
+      provider: 'UNSUPPORTED' as StorageProviderType,
+    };
+    const credential = {
+      id: '999',
+      provider: 'UNSUPPORTED' as StorageProviderType,
+      secret: 'xyz',
+      name: 'unsupported',
+    };
+
+    expect(isSameCredentials(credential, unsupportedProvider)).toBe(false);
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
+++ b/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
@@ -5,14 +5,16 @@ function isSameCredentials(
   credential: StorageTypeCredentials,
   stored: StorageType | StorageTypeFormValues<false>,
 ): boolean {
+  // If the internalId is present, we use it to check for equality
+  if (stored.provider !== StorageProviderType.LOCAL && credential.internalId && stored.internalId) {
+    return credential.internalId === stored.internalId;
+  }
+
   switch (stored.provider) {
     case StorageProviderType.GITHUB:
     case StorageProviderType.GITLAB:
     case StorageProviderType.ADO:
     case StorageProviderType.BITBUCKET: {
-      if (credential.internalId && stored.internalId && credential.internalId === stored.internalId) {
-        return true;
-      }
       return (
         credential.id === stored.id
         && credential.provider === stored.provider
@@ -30,6 +32,7 @@ function isSameCredentials(
         credential.id === stored.id
         && credential.provider === stored.provider
         && credential.designSystemUrl === stored.designSystemUrl
+        && JSON.stringify(credential.mapping) === JSON.stringify(stored.mapping)
       );
     case StorageProviderType.TOKENS_STUDIO:
       return (


### PR DESCRIPTION
### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/3069

Our check for if a sync provider is active was missing logic to compare the unique `internalId` when available for some sync providers. This PR elevates that to always check for those, if present. Also updates tests.

Note: The `internalId` was something that we added 2 years back now or so. So we should in *most* cases have it, it might just be the case for _really_ old examples that we dont have it.

### What does this pull request do?

- Add tests
- Update logic of uniqueness check

### Testing this change

Add a Studio sync provider with two different API keys.
Old version = shows up twice
New version = active state shown properly

<img width="439" alt="image" src="https://github.com/user-attachments/assets/072617d6-7288-478a-98cc-0b650837c706">
