### PR TITLE
Change default of update styles to false, update copy

### DIFF
--- a/packages/tokens-studio-for-figma/src/i18n/lang/en/tokens.json
+++ b/packages/tokens-studio-for-figma/src/i18n/lang/en/tokens.json
@@ -82,8 +82,8 @@
       "description": "Swap themes by just changing styles, requires Themes"
     },
     "shouldUpdateStyles": {
-      "title": "Update styles",
-      "description": "Update styles when tokens or themes change"
+      "title": "Update Figma Styles on apply",
+      "description": "Updates local Figma Styles when themes change or whenever applied"
     }
   },
   "tools": "Tools",

--- a/packages/tokens-studio-for-figma/src/utils/__tests__/uiSettings.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/__tests__/uiSettings.test.ts
@@ -78,7 +78,7 @@ describe('uiSettings', () => {
       updateRemote: true,
       updateOnChange: true,
       applyVariablesStylesOrRawValue: ApplyVariablesStylesOrRawValues.VARIABLES_STYLES,
-      shouldUpdateStyles: true,
+      shouldUpdateStyles: false,
       variablesColor: true,
       variablesNumber: true,
       variablesString: true,

--- a/packages/tokens-studio-for-figma/src/utils/uiSettings.ts
+++ b/packages/tokens-studio-for-figma/src/utils/uiSettings.ts
@@ -87,7 +87,7 @@ export async function getUISettings(notify = true): Promise<SavedSettings> {
       updateRemote = typeof data.updateRemote === 'undefined' ? true : data.updateRemote;
       updateOnChange = typeof data.updateOnChange === 'undefined' ? true : data.updateOnChange;
       applyVariablesStylesOrRawValue = typeof data.applyVariablesStylesOrRawValue === 'undefined' ? ApplyVariablesStylesOrRawValues.VARIABLES_STYLES : data.applyVariablesStylesOrRawValue;
-      shouldUpdateStyles = typeof data.shouldUpdateStyles === 'undefined' ? true : data.shouldUpdateStyles;
+      shouldUpdateStyles = typeof data.shouldUpdateStyles === 'undefined' ? false : data.shouldUpdateStyles;
       variablesColor = typeof data.variablesColor === 'undefined' ? true : data.variablesColor;
       variablesBoolean = typeof data.variablesBoolean === 'undefined' ? true : data.variablesBoolean;
       variablesNumber = typeof data.variablesNumber === 'undefined' ? true : data.variablesNumber;


### PR DESCRIPTION
This PR changes behavior of `Update styles` to be `false` by default, as per internal feedback.

Also changes the copy to be a bit easier to understand what's happening when this setting is on.

<img width="337" alt="image" src="https://github.com/user-attachments/assets/9155b7c1-fc84-46c8-b9f1-097323644eac">