### PR TITLE
Fix bitbucket sync

### DIFF
--- a/.changeset/healthy-rabbits-fetch.md
+++ b/.changeset/healthy-rabbits-fetch.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+fixed an issue with pulling token sets from Bitbucket when multi-file sync is enabled, wherein all the token sets were not being pulled.

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-else-return */
-/* eslint-disable @typescript-eslint/indent */
-/* eslint "@typescript-eslint/no-unused-vars": off */
 import { Bitbucket, Schema } from 'bitbucket';
 import compact from 'just-compact';
 import {
@@ -149,36 +146,36 @@ export class BitbucketTokenStorage extends GitTokenStorage {
     let nextPageUrl: string | null = `${url}?pagelen=100`;
 
     while (nextPageUrl) {
-        const response = await fetch(nextPageUrl, {
-            headers: {
-                Authorization: `Basic ${btoa(`${this.username}:${this.secret}`)}`,
-            },
-        });
+      const response = await fetch(nextPageUrl, {
+        headers: {
+          Authorization: `Basic ${btoa(`${this.username}:${this.secret}`)}`,
+        },
+      });
 
-        if (!response.ok) {
-            throw new Error(`Failed to read from Bitbucket: ${response.statusText}`);
-        }
+      if (!response.ok) {
+        throw new Error(`Failed to read from Bitbucket: ${response.statusText}`);
+      }
 
-        const data = await response.json();
-        if (data.values && Array.isArray(data.values)) {
-          const jsonFiles = data.values.filter((file: any) => file.path.endsWith('.json'));
-            allJsonFiles = allJsonFiles.concat(jsonFiles);
+      const data = await response.json();
+      if (data.values && Array.isArray(data.values)) {
+        const jsonFiles = data.values.filter((file: any) => file.path.endsWith('.json'));
+        allJsonFiles = allJsonFiles.concat(jsonFiles);
 
-            // Fetch files from subdirectories recursively
-            const subDirectoryFiles = await Promise.all(
-                data.values
-                    .filter((file: any) => file.type === 'commit_directory')
-                    .map(async (directory: any) => await this.fetchJsonFilesFromDirectory(directory.links.self.href)),
-            );
+        // Fetch files from subdirectories recursively
+        const subDirectoryFiles = await Promise.all(
+          data.values
+            .filter((file: any) => file.type === 'commit_directory')
+            .map(async (directory: any) => await this.fetchJsonFilesFromDirectory(directory.links.self.href)),
+        );
 
-            allJsonFiles = allJsonFiles.concat(...subDirectoryFiles);
-        }
+        allJsonFiles = allJsonFiles.concat(...subDirectoryFiles);
+      }
 
-        nextPageUrl = data.next || null;
+      nextPageUrl = data.next || null;
     }
 
     return allJsonFiles;
-}
+  }
 
   public async read(): Promise<RemoteTokenStorageFile[] | RemoteTokenstorageErrorMessage> {
     const normalizedPath = compact(this.path.split('/')).join('/');
@@ -188,13 +185,13 @@ export class BitbucketTokenStorage extends GitTokenStorage {
       const jsonFiles = await this.fetchJsonFilesFromDirectory(url);
 
       if (Array.isArray(jsonFiles)) {
-      const jsonFileContents = await Promise.all(
-        jsonFiles.map((file: any) => fetch(file.links.self.href, {
+        const jsonFileContents = await Promise.all(
+          jsonFiles.map((file: any) => fetch(file.links.self.href, {
             headers: {
               Authorization: `Basic ${btoa(`${this.username}:${this.secret}`)}`,
             },
           }).then((rsp) => rsp.text())),
-      );
+        );
         // Process the content of each JSON file
         return jsonFileContents.map((fileContent, index) => {
           const { path } = jsonFiles[index];
@@ -226,7 +223,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
             data: parsed as AnyTokenSet<false>,
           };
         });
-      } else if (jsonFiles) {
+      } if (jsonFiles) {
         const parsed = jsonFiles as GitSingleFileObject;
         return [
           {
@@ -236,12 +233,12 @@ export class BitbucketTokenStorage extends GitTokenStorage {
           },
           ...(parsed.$metadata
             ? [
-                {
-                  type: 'metadata' as const,
-                  path: this.path,
-                  data: parsed.$metadata,
-                },
-              ]
+              {
+                type: 'metadata' as const,
+                path: this.path,
+                data: parsed.$metadata,
+              },
+            ]
             : []),
           ...(
             Object.entries(parsed).filter(([key]) => !Object.values<string>(SystemFilenames).includes(key)) as [
@@ -297,8 +294,8 @@ export class BitbucketTokenStorage extends GitTokenStorage {
    * const response = await createOrUpdateFiles(params);
    */
   public async createOrUpdateFiles({
- owner, repo, branch, changes,
-}: CreatedOrUpdatedFileType) {
+    owner, repo, branch, changes,
+  }: CreatedOrUpdatedFileType) {
     const { message, files } = changes[0];
 
     const data = new FormData();

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -145,7 +145,10 @@ export class BitbucketTokenStorage extends GitTokenStorage {
    */
 
   private async fetchJsonFilesFromDirectory(url: string): Promise<FetchJsonResult> {
-    const response = await fetch(url, {
+
+    const paginatedUrl = `${url}?pagelen=100`;
+
+    const response = await fetch(paginatedUrl, {
       headers: {
         Authorization: `Basic ${btoa(`${this.username}:${this.secret}`)}`,
       },

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -145,7 +145,6 @@ export class BitbucketTokenStorage extends GitTokenStorage {
    */
 
   private async fetchJsonFilesFromDirectory(url: string): Promise<FetchJsonResult> {
-
     const paginatedUrl = `${url}?pagelen=100`;
 
     const response = await fetch(paginatedUrl, {

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -161,7 +161,6 @@ export class BitbucketTokenStorage extends GitTokenStorage {
 
         const data = await response.json();
         if (data.values && Array.isArray(data.values)) {
-
           const jsonFiles = data.values.filter((file: any) => file.path.endsWith('.json'));
             allJsonFiles = allJsonFiles.concat(jsonFiles);
 

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
@@ -162,7 +162,7 @@ describe('BitbucketTokenStorage', () => {
     ]);
 
     expect(mockFetch).toBeCalledWith(
-      `https://api.bitbucket.org/2.0/repositories/${storageProvider.owner}/${storageProvider.repository}/src/${storageProvider.branch}/`,
+      `https://api.bitbucket.org/2.0/repositories/${storageProvider.owner}/${storageProvider.repository}/src/${storageProvider.branch}/?pagelen=100`,
       {
         headers: {
           Authorization: `Basic ${btoa('myusername:mock-secret')}`,

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
@@ -113,20 +113,36 @@ describe('BitbucketTokenStorage', () => {
   });
 
   it('can read from Git in single file format', async () => {
-    mockFetch.mockImplementationOnce(() => Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve({ global: { red: { name: 'red', type: 'color', value: '#ff0000' } } }),
-    }));
+    mockFetch
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          values: [
+            { path: '$themes.json', type: 'commit_file', links: { self: { href: 'https://api.bitbucket.org/file/$themes.json' } } },
+            { path: 'global.json', type: 'commit_file', links: { self: { href: 'https://api.bitbucket.org/file/global.json' } } },
+          ],
+          next: null, // No further pagination needed for this test
+        }),
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ $themes: [] })),
+      }))
+      .mockImplementationOnce(() => Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ red: { name: 'red', type: 'color', value: '#ff0000' } })),
+      }));
 
     const result = await storageProvider.read();
+
     expect(result).toEqual([
       {
-        path: '/$themes.json',
+        path: '$themes.json',
         type: 'themes',
-        data: [],
+        data: { $themes: [] },
       },
       {
-        path: '/global.json',
+        path: 'global.json',
         name: 'global',
         type: 'tokenSet',
         data: {
@@ -139,29 +155,7 @@ describe('BitbucketTokenStorage', () => {
       },
     ]);
 
-    storageProvider.changePath('data/core.json');
-
-    expect(result).toEqual([
-      {
-        path: '/$themes.json',
-        type: 'themes',
-        data: [],
-      },
-      {
-        path: '/global.json',
-        name: 'global',
-        type: 'tokenSet',
-        data: {
-          red: {
-            type: 'color',
-            name: 'red',
-            value: '#ff0000',
-          },
-        },
-      },
-    ]);
-
-    expect(mockFetch).toBeCalledWith(
+    expect(mockFetch).toHaveBeenCalledWith(
       `https://api.bitbucket.org/2.0/repositories/${storageProvider.owner}/${storageProvider.repository}/src/${storageProvider.branch}/?pagelen=100`,
       {
         headers: {
@@ -169,7 +163,7 @@ describe('BitbucketTokenStorage', () => {
         },
       },
     );
-  });
+});
 
   it('listBranches should fetch branches as a simple list', async () => {
     mockListBranches.mockImplementationOnce(() =>

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
@@ -163,7 +163,7 @@ describe('BitbucketTokenStorage', () => {
         },
       },
     );
-});
+  });
 
   it('listBranches should fetch branches as a simple list', async () => {
     mockListBranches.mockImplementationOnce(() =>


### PR DESCRIPTION
### Why does this PR exist?

Fixes #3196 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

This PR increases the amount of json files returned to 100, which is the maximum allowed from their API.
The default was 10, hence the users were unable to fetch the set json files, when the number of sets was beyond 10.

### Testing this change

- Create a token set subfolder with more than 10 sets.
- Push it to Bitbucket.
- Then pull it from the same repo.
- Now it will should be pulling all the sets(unless the count is more than 100)

### Additional Notes (if any)
