### PR TITLE
Disable cache for Bitbucket

### DIFF
--- a/.changeset/old-pots-yell.md
+++ b/.changeset/old-pots-yell.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Disable cache for Bitbucket

--- a/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts
@@ -149,6 +149,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
       headers: {
         Authorization: `Basic ${btoa(`${this.username}:${this.secret}`)}`,
       },
+      cache: 'no-cache',
     });
 
     if (!response.ok) {
@@ -184,6 +185,7 @@ export class BitbucketTokenStorage extends GitTokenStorage {
             headers: {
               Authorization: `Basic ${btoa(`${this.username}:${this.secret}`)}`,
             },
+            cache: 'no-cache',
           }).then((rsp) => rsp.text())),
       );
         // Process the content of each JSON file

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/BitbucketTokenStorage.test.ts
@@ -167,6 +167,7 @@ describe('BitbucketTokenStorage', () => {
         headers: {
           Authorization: `Basic ${btoa('myusername:mock-secret')}`,
         },
+        cache: 'no-cache',
       },
     );
   });


### PR DESCRIPTION
### Why does this PR exist?

We're not able to pull updates in Figma app for 15 minutes due to Cache-Control header.
![image](https://github.com/user-attachments/assets/8d7733bd-d28c-491e-b13e-52494c4c7fb8)

### What does this pull request do?

Disables cache for Bitbucket requests

### Testing this change

Open plugin in Figma app and check if pulling is cached
