### PR TITLE
fix gitlab commit message error

### DIFF
--- a/.changeset/shiny-boats-collect.md
+++ b/.changeset/shiny-boats-collect.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes an issue in Gitlab sync where the Initial commit message caused an error due to non-conformance with the user's comapany's commit message rules.

--- a/packages/tokens-studio-for-figma/src/storage/GitlabTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/GitlabTokenStorage.ts
@@ -217,8 +217,6 @@ export class GitlabTokenStorage extends GitTokenStorage {
       await this.createBranch(branch, sourceBranch);
     }
 
-    const pushRules = await this.gitlabClient.ProjectPushRules.show(this.projectId);
-    const initialCommitMessage = pushRules?.commit_message_regex ? 'chore: Initial Commit' : 'Initial Commit';
     // Directories cannot be created empty (Source: https://gitlab.com/gitlab-org/gitlab/-/issues/247503)
     const pathToCreate = this.path.endsWith('.json') ? this.path : `${this.path}/.gitkeep`;
     try {
@@ -229,7 +227,7 @@ export class GitlabTokenStorage extends GitTokenStorage {
         pathToCreate,
         branch,
         '{}',
-        initialCommitMessage,
+        message,
       );
     }
 

--- a/packages/tokens-studio-for-figma/src/storage/GitlabTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/GitlabTokenStorage.ts
@@ -216,6 +216,9 @@ export class GitlabTokenStorage extends GitTokenStorage {
       const sourceBranch = this.previousSourceBranch || this.source;
       await this.createBranch(branch, sourceBranch);
     }
+
+    const pushRules = await this.gitlabClient.ProjectPushRules.show(this.projectId);
+    const initialCommitMessage = pushRules?.commit_message_regex ? 'chore: Initial Commit' : 'Initial Commit';
     // Directories cannot be created empty (Source: https://gitlab.com/gitlab-org/gitlab/-/issues/247503)
     const pathToCreate = this.path.endsWith('.json') ? this.path : `${this.path}/.gitkeep`;
     try {
@@ -226,7 +229,7 @@ export class GitlabTokenStorage extends GitTokenStorage {
         pathToCreate,
         branch,
         '{}',
-        'Initial commit',
+        initialCommitMessage,
       );
     }
 

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/GitlabTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/GitlabTokenStorage.test.ts
@@ -422,6 +422,8 @@ describe('GitlabTokenStorage', () => {
       })
     ));
 
+    const userCommitMessage = 'Initial Commit';
+
     await storageProvider.write([
       {
         type: 'metadata',
@@ -453,14 +455,14 @@ describe('GitlabTokenStorage', () => {
         },
       },
     ], {
-      commitMessage: 'Initial commit',
+      commitMessage: userCommitMessage,
       storeTokenIdInJsonEditor: true,
     });
 
     expect(mockCreateCommits).toHaveBeenCalledWith(
       35102363,
       'main',
-      'Initial commit',
+      userCommitMessage,
       [
         {
           action: 'create',


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes a very specific issue in gitlab sync, where in when a user is trying to load tokens in a repo, the "Initial Commit" message is causing an error because the commit message is not in line with the user's company's commit message rules.

Addresses #3239 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->
This PR replaces the 'Initial commit' message with the message the user puts in for their first commit instead

### Testing this change

- Create a repo in Gitlab with commit message rules regex
- Push the tokens to the repository following the message format
- It should now sync normally as expected without throwing an error unless the user's message in not conforming to the commit message policy

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->

https://tokens-studio.slack.com/archives/C08674X9DHU/p1735214682471059?thread_ts=1735214100.463429&cid=C08674X9DHU
