### PR TITLE
Raise limit for tokens sets when syncing to TS provider

### DIFF
--- a/.changeset/heavy-sheep-float.md
+++ b/.changeset/heavy-sheep-float.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Raise limit for token sets to 100 when syncing with Tokens Studio provider

--- a/packages/tokens-studio-for-figma/src/storage/TokensStudioTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/TokensStudioTokenStorage.ts
@@ -61,6 +61,12 @@ async function getProjectData(id: string, orgId: string, client: any): Promise<P
     }
 
     const tokenSets = data.data.project.branch.tokenSets.data as TokensSet[];
+    const { totalPages } = data.data.project.branch.tokenSets;
+
+    // TODO: This is a temporary solution until we implement pagination
+    if (totalPages > 1) {
+      notifyToUI('We are currently supporting up to 100 sets, if you encounter this issue and need even more sets please reach out to us on slack or featurebase.', { error: true });
+    }
 
     const returnData = tokenSets.reduce(
       (acc, tokenSet) => {

--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getProjectDataQuery.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getProjectDataQuery.ts
@@ -4,7 +4,7 @@ export const GET_PROJECT_DATA_QUERY = gql`
   query Branch($projectId: String!, $organization: String!, $name: String) {
     project(id: $projectId, organization: $organization) {
       branch(name: $name) {
-        tokenSets {
+        tokenSets(limit: 100) {
           data {
             name
             orderIndex
@@ -17,6 +17,7 @@ export const GET_PROJECT_DATA_QUERY = gql`
               value
             }
           }
+          totalPages
         }
         themeGroups {
           data {


### PR DESCRIPTION
When pulling token sets from the TS provider in the plugin there is a default limit to 25 items per page. We raised that limit to 100 and will focus on getting all the pages at once in a future PR

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->


### What does this pull request do?
Raises the limit to 100 and shows an error message if there are more token sets.

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
