### PR TITLE
Tokens Studio sync - Raise sets limit to 1000

### DIFF
--- a/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getProjectDataQuery.ts
+++ b/packages/tokens-studio-for-figma/src/storage/tokensStudio/graphql/getProjectDataQuery.ts
@@ -4,7 +4,7 @@ export const GET_PROJECT_DATA_QUERY = gql`
   query Branch($projectId: String!, $organization: String!, $name: String) {
     project(id: $projectId, organization: $organization) {
       branch(name: $name) {
-        tokenSets(limit: 100) {
+        tokenSets(limit: 1000) {
           data {
             name
             orderIndex


### PR DESCRIPTION
### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

Current maximum limit of token sets synced from Tokens Studio provider has been raised from 100 to 1000

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
