### PR TITLE
Fix default Token Format for Studio sync as DTCG

### DIFF
--- a/.changeset/rotten-ads-roll.md
+++ b/.changeset/rotten-ads-roll.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes the default format of tokens to DTCG when tokens are synced froM Tokens Studio Platform.

--- a/packages/tokens-studio-for-figma/src/app/components/StorageItem.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/StorageItem.tsx
@@ -133,7 +133,9 @@ const StorageItem = ({ item, onEdit }: Props) => {
       <Box css={{ marginRight: '$1' }}>
         {isActive() ? (
           <Stack gap={2} align="center">
-            <TokenFormatBadge extended />
+            {storageType.provider !== StorageProviderType.TOKENS_STUDIO && (
+              <TokenFormatBadge extended />
+            )}
             <Badge>{t('active')}</Badge>
           </Stack>
         ) : (

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -24,7 +24,7 @@ import { StorageProviderType } from '@/constants/StorageProviderType';
 import { StorageTypeCredentials, StorageTypeFormValues } from '@/types/StorageType';
 import { useGenericVersionedStorage } from './providers/generic/versionedStorage';
 import { RemoteResponseData, RemoteResponseStatus } from '@/types/RemoteResponseData';
-import { getFormat, TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import { getFormat, TokenFormat, TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
 import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { isEqual } from '@/utils/isEqual';
@@ -149,6 +149,7 @@ export default function useRemoteTokens() {
         }
         case StorageProviderType.TOKENS_STUDIO: {
           remoteData = await pullTokensFromTokensStudio(context);
+          dispatch.tokenState.setTokenFormat(TokenFormatOptions.DTCG);
           break;
         }
         default:
@@ -324,6 +325,7 @@ export default function useRemoteTokens() {
         }
         case StorageProviderType.TOKENS_STUDIO: {
           content = await syncTokensWithTokensStudio(context);
+          dispatch.tokenState.setTokenFormat(TokenFormatOptions.DTCG);
           break;
         }
         default:


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Resolves #3259 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Currently, if the local storage or previous sync provider had tokens set in Legacy format, while switching to Tokens Studio Sync provider, it was being set to Leagcy as well, inspite of the tokens beign received from studio in DTCD format.
also, hides the badge of Legacy/DTCG in studio sync storage type as the default will always be DTCG

### Testing this change

- Create a sync provider in the plugin from studio
- Switch to Local Storage, change format to legacy
- Switch back to Tokens Studio storage and it should be set to DTCG by default again

### Additional Notes (if any)

<img width="374" alt="Screenshot 2025-02-14 at 11 03 29 AM" src="https://github.com/user-attachments/assets/73135059-2b82-4a2d-a553-5827b68a6d25" />

