### PR TITLE
fix multi user sync local storage

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/Initiator.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Initiator.tsx
@@ -176,6 +176,7 @@ export function Initiator() {
                 newActiveTheme: typeof pluginMessage.activeTheme === 'string'
                   ? { [INTERNAL_THEMES_NO_GROUP]: pluginMessage.activeTheme }
                   : pluginMessage.activeTheme ?? {},
+                shouldUpdateDocument: !pluginMessage.isExternalChange, // if the change is external, we don't want to update the document as it would trigger a loop
               });
               dispatch.tokenState.setThemes(pluginMessage.themes ?? []);
               dispatch.tokenState.setTokenFormat((pluginMessage.tokenFormat as TokenFormatOptions) ?? 'json');

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setActiveTheme.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setActiveTheme.ts
@@ -2,7 +2,9 @@ import type { RematchDispatch } from '@rematch/core';
 import type { RootModel } from '@/types/RootModel';
 
 export function setActiveTheme(dispatch: RematchDispatch<RootModel>) {
-  return (payload: { themeId: string, shouldUpdateNodes?: boolean }): void => {
-    dispatch.tokenState.updateDocument({ updateRemote: false, shouldUpdateNodes: payload.shouldUpdateNodes });
+  return (payload: { themeId: string, shouldUpdateNodes?: boolean, shouldUpdateDocument?: boolean }): void => {
+    if (payload.shouldUpdateDocument) {
+      dispatch.tokenState.updateDocument({ updateRemote: false, shouldUpdateNodes: payload.shouldUpdateNodes });
+    }
   };
 }

--- a/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setActiveTheme.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setActiveTheme.ts
@@ -3,7 +3,7 @@ import type { TokenState } from '../../tokenState';
 
 // Needed to add a flag if all nodes should be updated, as otherwise all nodes are updated when we launch the plugin which we dont want to do. Feel free to refactor this.
 // This flag is only needed in the effects file, but we're declaring properties here
-export function setActiveTheme(state: TokenState, { newActiveTheme }: { newActiveTheme: Record<string, string>, shouldUpdateNodes?: boolean }): TokenState {
+export function setActiveTheme(state: TokenState, { newActiveTheme }: { newActiveTheme: Record<string, string>, shouldUpdateNodes?: boolean, shouldUpdateDocument?: boolean }): TokenState {
   // Filter activeThemes
   const activeThemeObjectList = state.themes.filter((theme) => Object.values(newActiveTheme).some((v) => v === theme.id));
   // Store all activeTokenSets through all activeThemes

--- a/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
@@ -268,7 +268,6 @@ export const settings = createModel<RootModel>()({
     },
     setBaseFontSize: (payload, rootState) => {
       setUI(rootState.settings);
-      dispatch.tokenState.updateDocument({ shouldUpdateNodes: false, updateRemote: false });
     },
     setAliasBaseFontSize: (payload, rootState) => {
       setUI(rootState.settings);

--- a/packages/tokens-studio-for-figma/src/figmaStorage/LastModifiedBy.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/LastModifiedBy.ts
@@ -1,6 +1,6 @@
 import { FigmaStorageProperty, FigmaStorageType } from './FigmaStorageProperty';
 
 export const LastModifiedByProperty = new FigmaStorageProperty<string>(
-  FigmaStorageType.CLIENT_STORAGE,
+  FigmaStorageType.SHARED_PLUGIN_DATA,
   'lastModifiedBy',
 );

--- a/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
@@ -43,12 +43,15 @@ export function useChangedState() {
   }, [remoteData, tokens, themes, storageType]);
 
   const hasChanges = useMemo(() => {
+    if (storageType.provider === StorageProviderType.LOCAL) {
+      return false;
+    }
     const hasChanged = !compareLastSyncedState(tokens, themes, lastSyncedState, tokenFormat);
 
     dispatch.tokenState.updateCheckForChanges(hasChanged);
 
     return hasChanged;
-  }, [tokens, themes, lastSyncedState, tokenFormat, dispatch.tokenState]);
+  }, [storageType.provider, tokens, themes, lastSyncedState, tokenFormat, dispatch.tokenState]);
 
   return { changedPushState, changedPullState, hasChanges };
 }

--- a/packages/tokens-studio-for-figma/src/plugin/sendDocumentChange.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/sendDocumentChange.ts
@@ -2,55 +2,26 @@ import { sendSelectionChange } from './sendSelectionChange';
 import { ValuesProperty } from '@/figmaStorage/ValuesProperty';
 import { postToUI } from './notifiers';
 import { MessageFromPluginTypes } from '@/types/messages';
-import { CheckForChangesProperty } from '@/figmaStorage/CheckForChangesProperty';
 import { ThemesProperty } from '@/figmaStorage/ThemesProperty';
 import { TokenFormatProperty } from '@/figmaStorage/TokenFormatProperty';
 import { ThemeObjectsList } from '@/types/ThemeObjectsList';
 import { LastModifiedByProperty } from '@/figmaStorage/LastModifiedBy';
-import { UpdatedAtProperty } from '@/figmaStorage/UpdatedAtProperty';
 
 export async function sendDocumentChange(event: DocumentChangeEvent) {
   const relevantChanges = event.documentChanges.filter((change) => change.type === 'PROPERTY_CHANGE'
     && change.origin === 'REMOTE'
     && change.properties?.includes('pluginData'));
 
-  console.log('updatedAT before return ', await UpdatedAtProperty.read());
-
-  if (relevantChanges.length === 0) return;
-
   const { currentUser } = figma;
 
-  const hasChanges = await CheckForChangesProperty.read();
-  console.log('updatedAT ', await UpdatedAtProperty.read());
+  if (relevantChanges.length === 0) return;
 
   const sourceUserId = await LastModifiedByProperty.read();
   const targetUserId = currentUser?.id;
 
-  console.log('Change detection:', {
-    sourceUserId,
-    targetUserId,
-    origin: event.documentChanges[0].origin,
-    hasChanges,
-    changes: relevantChanges.map((c) => ({
-      type: c.type,
-      ...(c.type === 'PROPERTY_CHANGE' ? { properties: c.properties } : {}),
-    })),
-  });
-
-  if (hasChanges
-    && relevantChanges.length > 2
-    && event.documentChanges[0].origin === 'REMOTE'
-    && event.documentChanges[0].type === 'PROPERTY_CHANGE'
-    && event.documentChanges[0].properties?.includes('pluginData')) {
-    console.log('Plugin data change detected:', {
-      sourceUserId,
-      targetUserId,
-      properties: event.documentChanges[0].properties,
-    });
-
+  // If the source is any other user, we need to sync tokens
+  if (sourceUserId !== targetUserId) {
     const sharedTokens = await ValuesProperty.read();
-
-    await CheckForChangesProperty.write(null);
 
     postToUI({
       type: MessageFromPluginTypes.SYNC_TOKENS,
@@ -58,9 +29,8 @@ export async function sendDocumentChange(event: DocumentChangeEvent) {
       values: await ValuesProperty.read() ?? { global: [] },
       themes: (await ThemesProperty.read() as ThemeObjectsList) ?? [],
       tokenFormat: await TokenFormatProperty.read() ?? 'json',
+      isExternalChange: true,
     });
-
-    return;
   }
 
   if (event.documentChanges.length === 1 && event.documentChanges[0].type === 'PROPERTY_CHANGE' && event.documentChanges[0].id === '0:0') {

--- a/packages/tokens-studio-for-figma/src/types/messages.tsx
+++ b/packages/tokens-studio-for-figma/src/types/messages.tsx
@@ -138,6 +138,7 @@ export type SyncTokensFromPluginMessage = {
   activeTheme?: string | Record<string, string>
   themes?: ThemeObjectsList;
   tokenFormat?: string;
+  isExternalChange?: boolean;
 };
 
 export type PostToUIMessage =


### PR DESCRIPTION
Key changes:

- packages/tokens-studio-for-figma/src/figmaStorage/LastModifiedBy.ts: correctly reads and sets property on shared plugin space, not on client storage (this was the cause why it was always showing the current user)
- packages/tokens-studio-for-figma/src/app/components/Initiator.tsx and other `setActiveTheme` related code: made sure to pass along a prop to not cause updateDocument to appear when its an external change
- packages/tokens-studio-for-figma/src/app/store/models/settings.tsx: baseFontSize kept being called. This property is stored on client storage - there's no need to update document when that changes, fixed that.
- packages/tokens-studio-for-figma/src/hooks/useChangedState.ts: fixed change state detection to not trigger if we're on local storage