### PR TITLE
Fix gitlab bug, gitkeep file created on every commit

### DIFF
--- a/.changeset/gentle-pets-confess.md
+++ b/.changeset/gentle-pets-confess.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+fix a bug where gitkeep file was being created in every commit in Gitlab repo.


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes an issue in Gitlab sync. When a user pushes a change as a commit, gitkeep file is being created, leading to 3 commits for each change.

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Create a sync in Gitlab Repo
- Make a change
- Commit the change
- It should now be only one commit(if gitkeep file was already removed previously)

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
