### PR TITLE
Fix import issue

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/Initiator.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Initiator.tsx
@@ -119,10 +119,13 @@ export function Initiator() {
           }
 
           case MessageFromPluginTypes.VARIABLES: {
-            const { values } = pluginMessage;
+            const { values, themes } = pluginMessage;
             if (values) {
               dispatch.tokenState.setTokensFromVariables(values);
               dispatch.uiState.setActiveTab(Tabs.TOKENS);
+            }
+            if (themes) {
+              dispatch.tokenState.setThemes(themes);
             }
             break;
           }

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -35,6 +35,8 @@ import { BackgroundJobs } from '@/constants/BackgroundJobs';
 import { defaultTokenResolver } from '@/utils/TokenResolver';
 import { getFormat } from '@/plugin/TokenFormatStoreClass';
 import { ExportTokenSet } from '@/types/ExportTokenSet';
+import { licenseKeySelector } from '@/selectors/licenseKeySelector';
+import { licenseKeyErrorSelector } from '@/selectors/licenseKeyErrorSelector';
 
 type ConfirmResult = ('textStyles' | 'colorStyles' | 'effectStyles' | string)[] | string;
 
@@ -68,6 +70,9 @@ export default function useTokens() {
   const store = useStore<RootState>();
   const tokensContext = useContext(TokensContext);
   const shouldConfirm = useMemo(() => updateMode === UpdateMode.DOCUMENT, [updateMode]);
+  const existingKey = useSelector(licenseKeySelector);
+  const licenseKeyError = useSelector(licenseKeyErrorSelector);
+  const proUser = Boolean(existingKey && !licenseKeyError);
   const VALID_TOKEN_TYPES = [
     TokenTypes.DIMENSION,
     TokenTypes.BORDER_RADIUS,
@@ -205,9 +210,11 @@ export default function useTokens() {
           useDimensions: userDecision.data.includes('useDimensions'),
           useRem: userDecision.data.includes('useRem'),
         },
+        themes,
+        proUser,
       });
     }
-  }, [confirm]);
+  }, [confirm, themes, proUser]);
 
   const removeTokensByValue = useCallback((data: RemoveTokensByValueData) => {
     track('removeTokensByValue', { count: data.length });

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/pullVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/pullVariables.ts
@@ -3,5 +3,5 @@ import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import pullVariablesFn from '../pullVariables';
 
 export const pullVariables: AsyncMessageChannelHandlers[AsyncMessageTypes.PULL_VARIABLES] = async (msg) => {
-  pullVariablesFn(msg.options);
+  pullVariablesFn(msg.options, msg.themes, msg.proUser);
 };

--- a/packages/tokens-studio-for-figma/src/plugin/notifiers.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/notifiers.ts
@@ -12,6 +12,7 @@ import { StorageTypeCredentials } from '@/types/StorageType';
 import { StyleToCreateToken, VariableToCreateToken } from '@/types/payloads';
 import { TokenFormatOptions } from './TokenFormatStoreClass';
 import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
+import { ThemeObjectsList } from '@/types/ThemeObjectsList';
 
 export function notifyUI(msg: string, opts?: NotificationOptions) {
   figma.notify(msg, opts);
@@ -164,8 +165,12 @@ export function notifyStyleValues(values: Record<string, StyleToCreateToken[]>) 
   postToUI({ type: MessageFromPluginTypes.STYLES, values });
 }
 
-export function notifyVariableValues(values: Record<string, VariableToCreateToken[]>) {
-  postToUI({ type: MessageFromPluginTypes.VARIABLES, values });
+export function notifyVariableValues(values: Record<string, VariableToCreateToken[]>, themes?: ThemeObjectsList) {
+  postToUI({
+    type: MessageFromPluginTypes.VARIABLES,
+    values,
+    ...(themes && { themes }),
+  });
 }
 
 export function notifySetTokens(values: TokenStore) {

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -144,7 +144,11 @@ export type SelectNodesMessageAsyncResult = AsyncMessage<AsyncMessageTypes.SELEC
 export type PullStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.PULL_STYLES, { styleTypes: PullStyleOptions; }>;
 export type PullStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.PULL_STYLES>;
 
-export type PullVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.PULL_VARIABLES, { options: PullVariablesOptions; }>;
+export type PullVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.PULL_VARIABLES, {
+  options: PullVariablesOptions;
+  themes: ThemeObjectsList;
+  proUser: boolean;
+}>;
 export type PullVariablesMessageResult = AsyncMessage<AsyncMessageTypes.PULL_VARIABLES>;
 
 export type NotifyAsyncMessage = AsyncMessage<AsyncMessageTypes.NOTIFY, {

--- a/packages/tokens-studio-for-figma/src/types/messages.tsx
+++ b/packages/tokens-studio-for-figma/src/types/messages.tsx
@@ -7,6 +7,7 @@ import type { StorageTypeCredentials } from './StorageType';
 import { StyleToCreateToken, VariableToCreateToken } from './payloads';
 import { TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
 import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
+import type { ThemeObjectsList } from './ThemeObjectsList';
 
 export enum MessageFromPluginTypes {
   SELECTION = 'selection',
@@ -85,6 +86,7 @@ export type StylesFromPluginMessage = {
 export type VariablesFromPluginMessage = {
   type: MessageFromPluginTypes.VARIABLES;
   values?: Record<string, VariableToCreateToken[]>;
+  themes?: ThemeObjectsList;
 };
 
 export type StartJobFromPluginMessage = {


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes #3260 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Currently, when users import variables, the plugin only creates corresponding sets for collections and variables.

This PR adds the feature to create theme groups as well, containing the corresponding sets created as well.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

- Create a variable collection with multiple modes
- Import it in the plugin
- The new sets will be created
- Now, new theme groups and options mapped to those sets will also be created

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
