### PR TITLE
fix json file deletion for single file tokens storage commits

### DIFF
--- a/.changeset/cold-fishes-attend.md
+++ b/.changeset/cold-fishes-attend.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix unintended JSON file deletion during gitlab single file tokens sync

--- a/packages/tokens-studio-for-figma/src/storage/GitlabTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/GitlabTokenStorage.ts
@@ -289,7 +289,7 @@ export class GitlabTokenStorage extends GitTokenStorage {
       (jsonFile) => !Object.keys(changeset).some((item) => item === jsonFile),
     );
 
-    if (filesToDelete.length > 0) {
+    if (filesToDelete.length > 0 && !this.path.endsWith('.json')) {
       gitlabActions = gitlabActions.concat(
         filesToDelete.map((filePath) => ({
           action: 'delete',


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Fixes #3282 
When a user is syncing tokens in gitlab with a single tokens json file, the commits end up deleting the other json files(like package.json, package-lock.json)

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->
This PR just adds a check before the deletion process in gitlab to check whether the tokens are being stored in a single json file. If yes, then it will not delete any files.

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

- Sync tokens in a gitlab repo with single token json file
- Add another json file like package.json in the same repo
- Push commits to the tokens.json
- It will not delete other files

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
