### PR TITLE
fix variable id assigned to themes created from variable import

### DIFF
--- a/.changeset/wet-jeans-approve.md
+++ b/.changeset/wet-jeans-approve.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix mapping of variables to theme when themes are created via import of variables.

--- a/packages/tokens-studio-for-figma/src/plugin/pullVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullVariables.ts
@@ -189,7 +189,7 @@ export default async function pullVariables(options: PullVariablesOptions, theme
 
         const variableReferences = collectionVariables.reduce((acc, variable) => ({
           ...acc,
-          [normalizeVariableName(variable.name)]: variable.id,
+          [normalizeVariableName(variable.name)]: variable.key,
         }), {});
 
         themesToCreate.push({


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

When a user imports variables, and themes are created from that variable, the correct token applied is not working when a particular theme is applied.

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->
This PR simply links the correct variable id to the theme and set, which enables figma to detect the right variable applied

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

- Import variable collections
- Select any theme
- Apply a token to a frame
- It should now display the correct corresponding variable applied.

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
