### PR TITLE
compress shared Plugin Data token values

### DIFF
--- a/.changeset/metal-mangos-fold.md
+++ b/.changeset/metal-mangos-fold.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+We now compress Figma's shared plugin data for tokens and themes values stored on the document, significantly reducing file sizes for very large token sets.

--- a/packages/tokens-studio-for-figma/package.json
+++ b/packages/tokens-studio-for-figma/package.json
@@ -106,6 +106,7 @@
     "launchdarkly-js-client-sdk": "^2.24.2",
     "launchdarkly-react-client-sdk": "^2.28.0",
     "lodash.debounce": "^4.0.8",
+    "lz-string": "^1.5.0",
     "mixpanel-figma": "^2.0.1",
     "ml-matrix": "^6.9.0",
     "monaco-editor": "^0.38.0",

--- a/packages/tokens-studio-for-figma/src/constants/SharedPluginDataKeys.ts
+++ b/packages/tokens-studio-for-figma/src/constants/SharedPluginDataKeys.ts
@@ -14,6 +14,7 @@ export const SharedPluginDataKeys = Object.freeze({
     themes: 'themes',
     collapsedTokenSets: 'collapsedTokenSets',
     tokenFormat: 'tokenFormat',
+    isCompressed: 'isCompressed',
     ...Properties,
   },
 });

--- a/packages/tokens-studio-for-figma/src/figmaStorage/FigmaStorageProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/FigmaStorageProperty.ts
@@ -8,15 +8,15 @@ export class FigmaStorageProperty<V = string> {
 
   protected key: string;
 
-  protected stringify: (value: V) => string = (value) => String(value);
+  protected stringify: (value: V, isCompressed?: boolean) => string = (value) => String(value);
 
-  protected parse: (value: string) => V | null = (value) => value as unknown as V;
+  protected parse: (value: string, isCompressed?: boolean) => V | null = (value) => value as unknown as V;
 
   constructor(
     storageType: FigmaStorageType,
     key: string,
-    stringify?: (value: V) => string,
-    parse?: (value: string) => V | null,
+    stringify?: (value: V, isCompressed?: boolean) => string,
+    parse?: (value: string, isCompressed?: boolean) => V | null,
   ) {
     this.storageType = storageType;
     this.key = key;
@@ -24,29 +24,29 @@ export class FigmaStorageProperty<V = string> {
     if (parse) this.parse = parse;
   }
 
-  public async read(node: BaseNode = figma.root): Promise<V | null> {
+  public async read(node: BaseNode = figma.root, isCompressed = false): Promise<V | null> {
     if (this.storageType === FigmaStorageType.CLIENT_STORAGE) {
       const value = await figma.clientStorage.getAsync(this.key);
-      return value ? this.parse(value) : null;
+      return value ? this.parse(value, isCompressed) : null;
     } if (this.storageType === FigmaStorageType.SHARED_PLUGIN_DATA) {
       const keyParts = this.key.split('/');
       const namespace = keyParts[0];
       const key = keyParts.slice(1).join('/');
       const value = node?.getSharedPluginData(namespace, key);
-      return value ? this.parse(value) : null;
+      return value ? this.parse(value, isCompressed) : null;
     }
 
     return null;
   }
 
-  public async write(value: V | null, node: BaseNode = figma.root) {
+  public async write(value: V | null, node: BaseNode = figma.root, isCompressed = false) {
     if (this.storageType === FigmaStorageType.CLIENT_STORAGE) {
-      await figma.clientStorage.setAsync(this.key, value ? this.stringify(value) : null);
+      await figma.clientStorage.setAsync(this.key, value ? this.stringify(value, isCompressed) : null);
     } else if (this.storageType === FigmaStorageType.SHARED_PLUGIN_DATA) {
       const keyParts = this.key.split('/');
       const namespace = keyParts[0];
       const key = keyParts.slice(1).join('/');
-      node?.setSharedPluginData(namespace, key, value ? this.stringify(value) : '');
+      node?.setSharedPluginData(namespace, key, value ? this.stringify(value, isCompressed) : '');
     }
   }
 }

--- a/packages/tokens-studio-for-figma/src/figmaStorage/IsCompressedProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/IsCompressedProperty.ts
@@ -1,0 +1,10 @@
+import { FigmaStorageProperty, FigmaStorageType } from './FigmaStorageProperty';
+import { SharedPluginDataKeys } from '@/constants/SharedPluginDataKeys';
+import { SharedPluginDataNamespaces } from '@/constants/SharedPluginDataNamespaces';
+
+export const IsCompressedProperty = new FigmaStorageProperty<boolean>(
+  FigmaStorageType.SHARED_PLUGIN_DATA,
+  `${SharedPluginDataNamespaces.TOKENS}/${SharedPluginDataKeys.tokens.isCompressed}`,
+  (value) => String(value),
+  (value: string) => value === 'true',
+);

--- a/packages/tokens-studio-for-figma/src/figmaStorage/ThemesProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/ThemesProperty.ts
@@ -1,14 +1,21 @@
+import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
 import { FigmaStorageProperty, FigmaStorageType } from './FigmaStorageProperty';
 import { SharedPluginDataKeys } from '@/constants/SharedPluginDataKeys';
 import { SharedPluginDataNamespaces } from '@/constants/SharedPluginDataNamespaces';
 import { attemptOrFallback } from '@/utils/attemptOrFallback';
+import { ThemeObjectsList } from '@/types';
 
-export const ThemesProperty = new FigmaStorageProperty<string>(
+export const ThemesProperty = new FigmaStorageProperty<ThemeObjectsList>(
   FigmaStorageType.SHARED_PLUGIN_DATA,
   `${SharedPluginDataNamespaces.TOKENS}/${SharedPluginDataKeys.tokens.themes}`,
-  (value) => (typeof value === 'string' ? value : JSON.stringify(value)),
-  (value) => attemptOrFallback<string>(() => {
-    if (!value) return '[]';
-    return typeof value === 'string' ? value : '[]';
-  }, '[]'),
+  (value) => compressToUTF16(JSON.stringify(value)),
+  (value, isCompressed) => attemptOrFallback<ThemeObjectsList>(() => {
+    if (!value) return [];
+    if (!isCompressed) {
+      const parsedValue = value ? JSON.parse(value) : [];
+      return Array.isArray(parsedValue) ? parsedValue : [];
+    }
+    const decompressed = decompressFromUTF16(value);
+    return JSON.parse(decompressed);
+  }, []),
 );

--- a/packages/tokens-studio-for-figma/src/figmaStorage/ThemesProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/ThemesProperty.ts
@@ -1,15 +1,14 @@
-import { ThemeObjectsList } from '@/types';
-import { attemptOrFallback } from '@/utils/attemptOrFallback';
 import { FigmaStorageProperty, FigmaStorageType } from './FigmaStorageProperty';
 import { SharedPluginDataKeys } from '@/constants/SharedPluginDataKeys';
 import { SharedPluginDataNamespaces } from '@/constants/SharedPluginDataNamespaces';
+import { attemptOrFallback } from '@/utils/attemptOrFallback';
 
-export const ThemesProperty = new FigmaStorageProperty<ThemeObjectsList>(
+export const ThemesProperty = new FigmaStorageProperty<string>(
   FigmaStorageType.SHARED_PLUGIN_DATA,
   `${SharedPluginDataNamespaces.TOKENS}/${SharedPluginDataKeys.tokens.themes}`,
-  (value) => JSON.stringify(value),
-  (value) => attemptOrFallback<ThemeObjectsList>(() => {
-    const parsedValue = value ? JSON.parse(value) : [];
-    return Array.isArray(parsedValue) ? parsedValue : [];
-  }, []),
+  (value) => (typeof value === 'string' ? value : JSON.stringify(value)),
+  (value) => attemptOrFallback<string>(() => {
+    if (!value) return '[]';
+    return typeof value === 'string' ? value : '[]';
+  }, '[]'),
 );

--- a/packages/tokens-studio-for-figma/src/figmaStorage/ValuesProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/ValuesProperty.ts
@@ -1,13 +1,18 @@
+import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
 import { attemptOrFallback } from '@/utils/attemptOrFallback';
 import { FigmaStorageProperty, FigmaStorageType } from './FigmaStorageProperty';
 import { SharedPluginDataKeys } from '@/constants/SharedPluginDataKeys';
 import { SharedPluginDataNamespaces } from '@/constants/SharedPluginDataNamespaces';
+import { AnyTokenList } from '@/types/tokens';
 
-export const ValuesProperty = new FigmaStorageProperty<string>(
+export const ValuesProperty = new FigmaStorageProperty<Record<string, AnyTokenList>>(
   FigmaStorageType.SHARED_PLUGIN_DATA,
   `${SharedPluginDataNamespaces.TOKENS}/${SharedPluginDataKeys.tokens.values}`,
-  (value) => JSON.stringify(value),
-  (value) => attemptOrFallback<string>(() => (
-    value ? JSON.parse(value) : {}
-  ), ''),
+  (value) => compressToUTF16(JSON.stringify(value)),
+  (value, isCompressed) => attemptOrFallback<Record<string, AnyTokenList>>(() => {
+    if (!value) return {};
+    if (!isCompressed) return JSON.parse(value);
+    const decompressed = decompressFromUTF16(value);
+    return JSON.parse(decompressed);
+  }, {}),
 );

--- a/packages/tokens-studio-for-figma/src/figmaStorage/ValuesProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/ValuesProperty.ts
@@ -1,14 +1,13 @@
-import { AnyTokenList } from '@/types/tokens';
 import { attemptOrFallback } from '@/utils/attemptOrFallback';
 import { FigmaStorageProperty, FigmaStorageType } from './FigmaStorageProperty';
 import { SharedPluginDataKeys } from '@/constants/SharedPluginDataKeys';
 import { SharedPluginDataNamespaces } from '@/constants/SharedPluginDataNamespaces';
 
-export const ValuesProperty = new FigmaStorageProperty<Record<string, AnyTokenList>>(
+export const ValuesProperty = new FigmaStorageProperty<string>(
   FigmaStorageType.SHARED_PLUGIN_DATA,
   `${SharedPluginDataNamespaces.TOKENS}/${SharedPluginDataKeys.tokens.values}`,
   (value) => JSON.stringify(value),
-  (value) => attemptOrFallback<Record<string, AnyTokenList>>(() => (
+  (value) => attemptOrFallback<string>(() => (
     value ? JSON.parse(value) : {}
-  ), {}),
+  ), ''),
 );

--- a/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ThemesProperty.test.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ThemesProperty.test.ts
@@ -1,3 +1,4 @@
+import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
 import { ThemeObjectsList } from '@/types';
 import { mockRootGetSharedPluginData, mockRootSetSharedPluginData } from '../../../tests/__mocks__/figmaMock';
 import { ThemesProperty } from '../ThemesProperty';
@@ -11,14 +12,28 @@ describe('ThemesProperty', () => {
     },
   ];
 
-  it('should be able to write', async () => {
-    await ThemesProperty.write(mockThemes);
-    expect(mockRootSetSharedPluginData).toBeCalledTimes(1);
-    expect(mockRootSetSharedPluginData).toBeCalledWith('tokens', 'themes', JSON.stringify(mockThemes));
+  it('should be able to write compressed data', async () => {
+    const compressedValue = compressToUTF16(JSON.stringify(mockThemes));
+    await ThemesProperty.write(compressedValue);
+    expect(mockRootSetSharedPluginData).toHaveBeenCalledTimes(1);
+    expect(mockRootSetSharedPluginData).toHaveBeenCalledWith('tokens', 'themes', compressedValue);
   });
 
-  it('should be able to read', async () => {
-    mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify(mockThemes));
-    expect(await ThemesProperty.read()).toEqual(mockThemes);
+  it('should be able to read and decompress data', async () => {
+    const compressedValue = compressToUTF16(JSON.stringify(mockThemes));
+    mockRootGetSharedPluginData.mockReturnValueOnce(compressedValue);
+    const result = await ThemesProperty.read();
+    const decompressedResult = decompressFromUTF16(result);
+    expect(JSON.parse(decompressedResult)).toEqual(mockThemes);
+  });
+
+  it('should handle empty or invalid input when reading', async () => {
+    mockRootGetSharedPluginData.mockReturnValueOnce(undefined);
+    const emptyResult = await ThemesProperty.read();
+    expect(emptyResult).toBe(null);
+
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+    const nullResult = await ThemesProperty.read();
+    expect(nullResult).toBe(null);
   });
 });

--- a/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ThemesProperty.test.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ThemesProperty.test.ts
@@ -1,4 +1,4 @@
-import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
+import { compressToUTF16 } from 'lz-string';
 import { ThemeObjectsList } from '@/types';
 import { mockRootGetSharedPluginData, mockRootSetSharedPluginData } from '../../../tests/__mocks__/figmaMock';
 import { ThemesProperty } from '../ThemesProperty';

--- a/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ThemesProperty.test.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ThemesProperty.test.ts
@@ -12,19 +12,17 @@ describe('ThemesProperty', () => {
     },
   ];
 
+  const compressedMockThemes = compressToUTF16(JSON.stringify(mockThemes));
+
   it('should be able to write compressed data', async () => {
-    const compressedValue = compressToUTF16(JSON.stringify(mockThemes));
-    await ThemesProperty.write(compressedValue);
+    await ThemesProperty.write(mockThemes);
     expect(mockRootSetSharedPluginData).toHaveBeenCalledTimes(1);
-    expect(mockRootSetSharedPluginData).toHaveBeenCalledWith('tokens', 'themes', compressedValue);
+    expect(mockRootSetSharedPluginData).toHaveBeenCalledWith('tokens', 'themes', compressedMockThemes);
   });
 
-  it('should be able to read and decompress data', async () => {
-    const compressedValue = compressToUTF16(JSON.stringify(mockThemes));
-    mockRootGetSharedPluginData.mockReturnValueOnce(compressedValue);
-    const result = await ThemesProperty.read();
-    const decompressedResult = decompressFromUTF16(result);
-    expect(JSON.parse(decompressedResult)).toEqual(mockThemes);
+  it('should be able to read', async () => {
+    mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify(mockThemes));
+    expect(await ThemesProperty.read()).toEqual(mockThemes);
   });
 
   it('should handle empty or invalid input when reading', async () => {

--- a/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ValuesProperty.test.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ValuesProperty.test.ts
@@ -1,3 +1,4 @@
+import { compressToUTF16 } from 'lz-string';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { AnyTokenList } from '@/types/tokens';
 import { mockRootGetSharedPluginData, mockRootSetSharedPluginData } from '../../../tests/__mocks__/figmaMock';
@@ -14,10 +15,12 @@ describe('ValuesProperty', () => {
     ],
   };
 
+  const compressedMockValues = compressToUTF16(JSON.stringify(mockValues));
+
   it('should be able to write', async () => {
     await ValuesProperty.write(mockValues);
     expect(mockRootSetSharedPluginData).toBeCalledTimes(1);
-    expect(mockRootSetSharedPluginData).toBeCalledWith('tokens', 'values', JSON.stringify(mockValues));
+    expect(mockRootSetSharedPluginData).toBeCalledWith('tokens', 'values', compressedMockValues);
   });
 
   it('should be able to read', async () => {

--- a/packages/tokens-studio-for-figma/src/figmaStorage/index.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/index.ts
@@ -20,3 +20,4 @@ export * from './AuthDataProperty';
 export * from './CollapsedTokenSetsProperty';
 export * from './InitialLoadProperty';
 export * from './TokenFormatProperty';
+export * from './IsCompressedProperty';

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/update.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/update.test.ts
@@ -1,6 +1,8 @@
+import { compressToUTF16 } from 'lz-string';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { UpdateMode } from '@/constants/UpdateMode';
+
 import { AsyncMessageTypes, UpdateAsyncMessage } from '@/types/AsyncMessages';
 import { update } from '../update';
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
@@ -84,8 +86,8 @@ describe('update', () => {
 
     await update(mockUpdateMessage);
 
-    expect(ThemesPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.themes);
-    expect(ValuesPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.tokenValues);
+    expect(ThemesPropertyWriteSpy).toBeCalledWith(compressToUTF16(JSON.stringify(mockUpdateMessage.themes)));
+    expect(ValuesPropertyWriteSpy).toBeCalledWith(compressToUTF16(JSON.stringify(mockUpdateMessage.tokenValues)));
     expect(UsedTokenSetPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.usedTokenSet);
     expect(UpdatedAtPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.updatedAt);
     expect(ActiveThemePropertyWriteSpy).toBeCalledWith(mockUpdateMessage.activeTheme);

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/update.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/update.test.ts
@@ -1,4 +1,3 @@
-import { compressToUTF16 } from 'lz-string';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { UpdateMode } from '@/constants/UpdateMode';
@@ -86,8 +85,8 @@ describe('update', () => {
 
     await update(mockUpdateMessage);
 
-    expect(ThemesPropertyWriteSpy).toBeCalledWith(compressToUTF16(JSON.stringify(mockUpdateMessage.themes)));
-    expect(ValuesPropertyWriteSpy).toBeCalledWith(compressToUTF16(JSON.stringify(mockUpdateMessage.tokenValues)));
+    expect(ThemesPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.themes);
+    expect(ValuesPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.tokenValues);
     expect(UsedTokenSetPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.usedTokenSet);
     expect(UpdatedAtPropertyWriteSpy).toBeCalledWith(mockUpdateMessage.updatedAt);
     expect(ActiveThemePropertyWriteSpy).toBeCalledWith(mockUpdateMessage.activeTheme);

--- a/packages/tokens-studio-for-figma/src/plugin/node.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/node.ts
@@ -1,3 +1,4 @@
+import { decompressFromUTF16 } from 'lz-string';
 import compact from 'just-compact';
 import { CollapsedTokenSetsProperty } from '@/figmaStorage/CollapsedTokenSetsProperty';
 import { NodeTokenRefMap } from '@/types/NodeTokenRefMap';
@@ -14,6 +15,7 @@ import {
 import { ColorModifierTypes } from '@/constants/ColorModifierTypes';
 import { Properties } from '@/constants/Properties';
 import { TokenFormatOptions } from './TokenFormatStoreClass';
+import { IsCompressedProperty } from '@/figmaStorage/isCompressedProperty';
 
 // @TODO fix typings
 
@@ -107,7 +109,10 @@ export async function getTokenData(): Promise<{
   tokenFormat: TokenFormatOptions | null
 } | null> {
   try {
-    const values = await ValuesProperty.read(figma.root) ?? {};
+    const isCompressed = await IsCompressedProperty.read(figma.root) ?? false;
+    const compressedValues = await ValuesProperty.read(figma.root) ?? '';
+    const values = isCompressed ? JSON.parse(decompressFromUTF16(compressedValues) ?? '{}') : compressedValues;
+    // const compressedThemes = await ThemesProperty.read(figma.root) ?? '';
     const themes = await ThemesProperty.read(figma.root) ?? [];
     const activeTheme = await ActiveThemeProperty.read(figma.root) ?? {};
     const version = await VersionProperty.read(figma.root);

--- a/packages/tokens-studio-for-figma/src/plugin/node.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/node.ts
@@ -10,12 +10,11 @@ import { TokenTypes } from '@/constants/TokenTypes';
 import { StorageProviderType } from '@/constants/StorageProviderType';
 import { StorageType } from '@/types/StorageType';
 import {
-  ActiveThemeProperty, CheckForChangesProperty, StorageTypeProperty, ThemesProperty, UpdatedAtProperty, ValuesProperty, VersionProperty, OnboardingExplainerSetsProperty, OnboardingExplainerInspectProperty, OnboardingExplainerSyncProvidersProperty, TokenFormatProperty, OnboardingExplainerExportSetsProperty,
+  ActiveThemeProperty, CheckForChangesProperty, StorageTypeProperty, ThemesProperty, UpdatedAtProperty, ValuesProperty, VersionProperty, OnboardingExplainerSetsProperty, OnboardingExplainerInspectProperty, OnboardingExplainerSyncProvidersProperty, TokenFormatProperty, OnboardingExplainerExportSetsProperty, IsCompressedProperty,
 } from '@/figmaStorage';
 import { ColorModifierTypes } from '@/constants/ColorModifierTypes';
 import { Properties } from '@/constants/Properties';
 import { TokenFormatOptions } from './TokenFormatStoreClass';
-import { IsCompressedProperty } from '@/figmaStorage/isCompressedProperty';
 
 // @TODO fix typings
 
@@ -112,8 +111,8 @@ export async function getTokenData(): Promise<{
     const isCompressed = await IsCompressedProperty.read(figma.root) ?? false;
     const compressedValues = await ValuesProperty.read(figma.root) ?? '';
     const values = isCompressed ? JSON.parse(decompressFromUTF16(compressedValues) ?? '{}') : compressedValues;
-    // const compressedThemes = await ThemesProperty.read(figma.root) ?? '';
-    const themes = await ThemesProperty.read(figma.root) ?? [];
+    const compressedThemes = await ThemesProperty.read(figma.root) ?? '[]';
+    const themes: ThemeObjectsList = isCompressed ? JSON.parse(decompressFromUTF16(compressedThemes) ?? '[]') : JSON.parse(compressedThemes);
     const activeTheme = await ActiveThemeProperty.read(figma.root) ?? {};
     const version = await VersionProperty.read(figma.root);
     const updatedAt = await UpdatedAtProperty.read(figma.root);

--- a/packages/tokens-studio-for-figma/src/plugin/node.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/node.ts
@@ -1,4 +1,3 @@
-import { decompressFromUTF16 } from 'lz-string';
 import compact from 'just-compact';
 import { CollapsedTokenSetsProperty } from '@/figmaStorage/CollapsedTokenSetsProperty';
 import { NodeTokenRefMap } from '@/types/NodeTokenRefMap';
@@ -109,10 +108,8 @@ export async function getTokenData(): Promise<{
 } | null> {
   try {
     const isCompressed = await IsCompressedProperty.read(figma.root) ?? false;
-    const compressedValues = await ValuesProperty.read(figma.root) ?? '';
-    const values = isCompressed ? JSON.parse(decompressFromUTF16(compressedValues) ?? '{}') : compressedValues;
-    const compressedThemes = await ThemesProperty.read(figma.root) ?? '[]';
-    const themes: ThemeObjectsList = isCompressed ? JSON.parse(decompressFromUTF16(compressedThemes) ?? '[]') : JSON.parse(compressedThemes);
+    const values = await ValuesProperty.read(figma.root, isCompressed) ?? {};
+    const themes = await ThemesProperty.read(figma.root, isCompressed) ?? [];
     const activeTheme = await ActiveThemeProperty.read(figma.root) ?? {};
     const version = await VersionProperty.read(figma.root);
     const updatedAt = await UpdatedAtProperty.read(figma.root);

--- a/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
@@ -1,3 +1,4 @@
+import { compressToUTF16 } from 'lz-string';
 import * as pjs from '../../../package.json';
 import { ThemeObjectsList, UsedTokenSetsMap } from '@/types';
 import { AnyTokenList } from '@/types/tokens';
@@ -8,6 +9,7 @@ import {
 } from '@/figmaStorage';
 import { CollapsedTokenSetsProperty } from '@/figmaStorage/CollapsedTokenSetsProperty';
 import { TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
+import { IsCompressedProperty } from '@/figmaStorage/isCompressedProperty';
 
 type Payload = {
   tokens: Record<string, AnyTokenList>
@@ -23,7 +25,8 @@ type Payload = {
 export async function updateLocalTokensData(payload: Payload) {
   await VersionProperty.write(pjs.version);
   await ThemesProperty.write(payload.themes);
-  await ValuesProperty.write(payload.tokens);
+  await ValuesProperty.write(compressToUTF16(JSON.stringify(payload.tokens)));
+  await IsCompressedProperty.write(true);
   await UsedTokenSetProperty.write(payload.usedTokenSets);
   await UpdatedAtProperty.write(payload.updatedAt);
   await ActiveThemeProperty.write(payload.activeTheme);

--- a/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
@@ -1,4 +1,3 @@
-import { compressToUTF16 } from 'lz-string';
 import * as pjs from '../../../package.json';
 import { ThemeObjectsList, UsedTokenSetsMap } from '@/types';
 import { AnyTokenList } from '@/types/tokens';
@@ -23,9 +22,9 @@ type Payload = {
 
 export async function updateLocalTokensData(payload: Payload) {
   await VersionProperty.write(pjs.version);
-  await ValuesProperty.write(compressToUTF16(JSON.stringify(payload.tokens)));
-  await ThemesProperty.write(compressToUTF16(JSON.stringify(payload.themes)));
   await IsCompressedProperty.write(true);
+  await ThemesProperty.write(payload.themes);
+  await ValuesProperty.write(payload.tokens);
   await UsedTokenSetProperty.write(payload.usedTokenSets);
   await UpdatedAtProperty.write(payload.updatedAt);
   await ActiveThemeProperty.write(payload.activeTheme);

--- a/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
@@ -9,7 +9,6 @@ import {
 } from '@/figmaStorage';
 import { CollapsedTokenSetsProperty } from '@/figmaStorage/CollapsedTokenSetsProperty';
 import { TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
-// import { IsCompressedProperty } from '@/figmaStorage/isCompressedProperty';
 
 type Payload = {
   tokens: Record<string, AnyTokenList>

--- a/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
@@ -5,11 +5,11 @@ import { AnyTokenList } from '@/types/tokens';
 import {
   ActiveThemeProperty,
   CheckForChangesProperty,
-  ThemesProperty, TokenFormatProperty, UpdatedAtProperty, UsedTokenSetProperty, ValuesProperty, VersionProperty,
+  ThemesProperty, TokenFormatProperty, UpdatedAtProperty, UsedTokenSetProperty, ValuesProperty, VersionProperty, IsCompressedProperty,
 } from '@/figmaStorage';
 import { CollapsedTokenSetsProperty } from '@/figmaStorage/CollapsedTokenSetsProperty';
 import { TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
-import { IsCompressedProperty } from '@/figmaStorage/isCompressedProperty';
+// import { IsCompressedProperty } from '@/figmaStorage/isCompressedProperty';
 
 type Payload = {
   tokens: Record<string, AnyTokenList>
@@ -24,8 +24,8 @@ type Payload = {
 
 export async function updateLocalTokensData(payload: Payload) {
   await VersionProperty.write(pjs.version);
-  await ThemesProperty.write(payload.themes);
   await ValuesProperty.write(compressToUTF16(JSON.stringify(payload.tokens)));
+  await ThemesProperty.write(compressToUTF16(JSON.stringify(payload.themes)));
   await IsCompressedProperty.write(true);
   await UsedTokenSetProperty.write(payload.usedTokenSets);
   await UpdatedAtProperty.write(payload.updatedAt);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,7 +3415,19 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@radix-ui/react-dismissable-layer@1.0.4", "@radix-ui/react-dismissable-layer@1.0.5":
+"@radix-ui/react-dismissable-layer@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.4.tgz#883a48f5f938fa679427aa17fcba70c5494c6978"
+  integrity sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
+
+"@radix-ui/react-dismissable-layer@1.0.5":
   version "1.0.5"
   resolved "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz"
   integrity sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==
@@ -15718,7 +15730,7 @@ lru_map@^0.3.3:
 
 lz-string@^1.5.0:
   version "1.5.0"
-  resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 magic-string@0.27.0:
@@ -18561,7 +18573,7 @@ react-window@^1.8.8:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^18, react@^18.2.0:
+react@^18.2.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #3328 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

This PR compresses the data(mainly tokens and themes), using lz-string, while storing it in the localSharedPluginData of a user's file. While reading it decompresses it first.

Also, for legacy data, or users opening the plugin after a long time, it will still check whether their data is compressed or not, using a key added in this PR called `isCompressed`, which is also stored in the sharedPluginData, which once set to true,i.e the user is now storing compressed data, cannot be set to false again

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

- Testing this is tricky and not straightforward
- Pull this branch, open the plugin, preferably with data and check if it opens fine
- then run this on the console to see if the data is compressed or not
- `figma.root.getSharedPluginData('tokens','themes');` - should return unreadable data(indicating that the string has been compressed), before pulling the branch it should return normal readable token values
- `figma.root.getSharedPluginData('tokens','values');`- should return unreadable data(indicating that the string has been compressed), before pulling the branch it should return normal readable themes dataa
- `figma.root.getSharedPluginData('tokens','isCompressed');` - should return empty/null before opening the plugin, and once plugin is opened, always `true`

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
