### PR TITLE
fix numerical family names

### DIFF
--- a/.changeset/silver-experts-sin.md
+++ b/.changeset/silver-experts-sin.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue where if your font family was a number we'd be stuck generating variables

--- a/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/convertFontFamilyToFigma.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/convertFontFamilyToFigma.ts
@@ -1,7 +1,13 @@
 export function convertFontFamilyToFigma(value: string, shouldOutputForVariables = false) {
-  if (shouldOutputForVariables) {
-    const fontFamilies = value.split(',');
-    return fontFamilies[0].trim().replace(/['"]/g, '');
+  const stringValue = value.toString();
+  try {
+    if (shouldOutputForVariables) {
+      const fontFamilies = stringValue.split(',');
+      return fontFamilies[0].trim().replace(/['"]/g, '');
+    }
+    return stringValue;
+  } catch (e) {
+    console.error('font family err', stringValue, e);
+    return stringValue;
   }
-  return value;
 }


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/3331

Before we were relying on font family to be a string, however some users have numerical family names.

### What does this pull request do?

Converts to string before we trim