### PR TITLE
display size check indicator for themes above 100KB as well

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/Footer.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Footer.tsx
@@ -18,6 +18,7 @@ import {
   activeThemeSelector,
   uiStateSelector,
   tokensSizeSelector,
+  themesSizeSelector,
 } from '@/selectors';
 import DocsIcon from '@/icons/docs.svg';
 import RefreshIcon from '@/icons/refresh.svg';
@@ -41,6 +42,7 @@ export default function Footer() {
   const localApiState = useSelector(localApiStateSelector);
   const usedTokenSet = useSelector(usedTokenSetSelector);
   const tokensSize = useSelector(tokensSizeSelector);
+  const themesSize = useSelector(themesSizeSelector);
   const projectURL = useSelector(projectURLSelector);
   const uiState = useSelector(uiStateSelector, isEqual);
   const { pullTokens, pushTokens, checkRemoteChange } = useRemoteTokens();
@@ -76,7 +78,7 @@ export default function Footer() {
       }}
     >
       <Stack direction="row" align="center" gap={2}>
-        {tokensSize > 100 && (
+        {(tokensSize > 100 || themesSize > 100) && (
           <Box
             css={{
               fontSize: '$xsmall',
@@ -89,7 +91,7 @@ export default function Footer() {
             onClick={handleBadgeClick}
           >
             <WarningTriangleSolid />
-            {`${tokensSize} KB`}
+            {`${tokensSize > 100 ? tokensSize : themesSize} KB`}
           </Box>
         )}
         {((isGitProvider(localApiState) && localApiState.branch) || storageType.provider === StorageProviderType.SUPERNOVA) && (

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -85,6 +85,7 @@ export interface TokenState {
   compressedTokens: string;
   compressedThemes: string;
   tokensSize: number;
+  themesSize: number;
 }
 
 export const tokenState = createModel<RootModel>()({
@@ -128,11 +129,16 @@ export const tokenState = createModel<RootModel>()({
     compressedTokens: '',
     compressedThemes: '',
     tokensSize: 0,
+    themesSize: 0,
   } as unknown as TokenState,
   reducers: {
     setTokensSize: (state, size: number) => ({
       ...state,
       tokensSize: size,
+    }),
+    setThemesSize: (state, size: number) => ({
+      ...state,
+      themesSize: size,
     }),
     setStringTokens: (state, payload: string) => ({
       ...state,
@@ -862,10 +868,16 @@ export const tokenState = createModel<RootModel>()({
       if (!rootState) return;
       try {
         const tokensSize = checkStorageSize(rootState.tokenState.tokens);
+        const themesSize = checkStorageSize(rootState.tokenState.themes);
 
         // Update the tokensSize in state if it has changed
         if (rootState.tokenState.tokensSize !== tokensSize) {
           dispatch.tokenState.setTokensSize(tokensSize);
+        }
+
+        // Update the themesSize in state if it has changed
+        if (rootState.tokenState.themesSize !== themesSize) {
+          dispatch.tokenState.setThemesSize(Number(themesSize.toFixed(1)));
         }
 
         wrapTransaction(
@@ -883,6 +895,7 @@ export const tokenState = createModel<RootModel>()({
               transaction.setMeasurement('tokenSets', Object.keys(rootState.tokenState.tokens).length, '');
               transaction.setMeasurement('themes', rootState.tokenState.themes.length, '');
               transaction.setMeasurement('tokensSize', tokensSize, 'KB');
+              transaction.setMeasurement('themesSize', themesSize, 'KB');
             },
           },
           () => {
@@ -918,7 +931,8 @@ export const tokenState = createModel<RootModel>()({
               storeTokenIdInJsonEditor: rootState.settings.storeTokenIdInJsonEditor,
               dispatch,
               tokenFormat: rootState.tokenState.tokenFormat,
-              tokensSize: rootState.tokenStatetokensSize,
+              tokensSize: rootState.tokenState.tokensSize,
+              themesSize: rootState.tokenState.themesSize,
             });
           },
         );

--- a/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
@@ -49,6 +49,7 @@ type UpdateTokensOnSourcesPayload = {
   dispatch: Dispatch
   tokenFormat: TokenFormatOptions
   tokensSize: number
+  themesSize: number
 };
 
 async function updateRemoteTokens({

--- a/packages/tokens-studio-for-figma/src/selectors/index.ts
+++ b/packages/tokens-studio-for-figma/src/selectors/index.ts
@@ -74,3 +74,4 @@ export * from './stylesEffectSelector';
 export * from './createStylesWithVariableReferencesSelector';
 export * from './importedThemesSelector';
 export * from './tokensSizeSelector';
+export * from './themesSizeSelector';

--- a/packages/tokens-studio-for-figma/src/selectors/themesSizeSelector.ts
+++ b/packages/tokens-studio-for-figma/src/selectors/themesSizeSelector.ts
@@ -1,0 +1,12 @@
+import { createSelector } from 'reselect';
+import { tokenStateSelector } from './tokenStateSelector';
+
+export const themesSizeSelector = createSelector(
+  tokenStateSelector,
+  (state) => state.themesSize,
+  {
+    memoizeOptions: {
+      resultEqualityCheck: (a, b) => a === b,
+    },
+  },
+);


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?


To display size check indicator for themes size above 100KB as well.
<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

Currently the size check warning indicator is active only when the compressed Tokens size is greater than 100KB
This PR triggers the size indicator for the themes size as well, since the themes can also take up more than 100KB from the shared Plugin Data as well.

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
