### PR TITLE
Chunk Themes and Values when they cross 95KB in storage

### DIFF
--- a/packages/tokens-studio-for-figma/src/figmaStorage/FigmaStorageProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/FigmaStorageProperty.ts
@@ -1,61 +1,10 @@
-import { getUTF16StringSize } from '@/utils/getUTF16StringSize';
+import { readSharedPluginData } from '@/utils/figmaStorage/readSharedPluginData';
+import { writeSharedPluginData } from '@/utils/figmaStorage/writeSharedPluginData';
 
 export enum FigmaStorageType {
   CLIENT_STORAGE = 'client_storage',
   SHARED_PLUGIN_DATA = 'shared_plugin_data',
 }
-
-// Maximum size for a single chunk in bytes (95KB to stay safely under Figma's 100KB limit)
-const MAX_CHUNK_SIZE = 95 * 1024; // 95KB
-
-// Metadata suffix for storing information about chunked data
-const METADATA_SUFFIX = '_meta';
-
-// Chunk suffix prefix for chunk keys
-const CHUNK_SUFFIX_PREFIX = '_chunk_';
-
-/**
- * Splits a string into chunks of specified maximum byte size
- * @param str String to split
- * @param maxBytes Maximum bytes per chunk
- * @returns Array of string chunks
- */
-function splitIntoChunks(str: string, maxBytes: number): string[] {
-  const chunks: string[] = [];
-  let currentChunk = '';
-  let currentLength = 0;
-  const maxChars = Math.floor(maxBytes / 2); // Convert bytes to character count for UTF-16
-
-  // Process the string character by character
-  for (let i = 0; i < str.length; i += 1) {
-    const char = str[i];
-
-    // If adding this character would exceed the limit, start a new chunk
-    if (currentLength + 1 > maxChars) {
-      chunks.push(currentChunk);
-      currentChunk = char;
-      currentLength = 1;
-    } else {
-      currentChunk += char;
-      currentLength += 1;
-    }
-  }
-
-  // Add the last chunk if it's not empty
-  if (currentChunk) {
-    chunks.push(currentChunk);
-  }
-
-  return chunks;
-}
-
-/**
- * Metadata structure for chunked data
- */
-type ChunkedDataMetadata = {
-  type: 'single' | 'chunked';
-  count?: number;
-};
 
 export class FigmaStorageProperty<V = string> {
   protected storageType: FigmaStorageType = FigmaStorageType.CLIENT_STORAGE;
@@ -88,57 +37,14 @@ export class FigmaStorageProperty<V = string> {
     if (this.storageType === FigmaStorageType.CLIENT_STORAGE) {
       const value = await figma.clientStorage.getAsync(this.key);
       return value ? this.parse(value, isCompressed) : null;
-    } if (this.storageType === FigmaStorageType.SHARED_PLUGIN_DATA) {
+    }
+
+    if (this.storageType === FigmaStorageType.SHARED_PLUGIN_DATA) {
       const keyParts = this.key.split('/');
       const namespace = keyParts[0];
       const key = keyParts.slice(1).join('/');
 
-      // First, check if there's metadata for chunked data
-      const metaKey = `${key}${METADATA_SUFFIX}`;
-      const metaValue = node?.getSharedPluginData(namespace, metaKey);
-
-      if (metaValue) {
-        try {
-          // Parse the metadata
-          const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
-
-          if (metadata.type === 'single') {
-            // If it's a single chunk, just read the data
-            const value = node?.getSharedPluginData(namespace, key);
-            return value ? this.parse(value, isCompressed) : null;
-          }
-
-          if (metadata.type === 'chunked' && metadata.count) {
-            // Create an array of promises to read all chunks
-            const chunkPromises = Array.from({ length: metadata.count }, (_, i) => {
-              const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
-              return node?.getSharedPluginData(namespace, chunkKey);
-            });
-
-            // Wait for all chunks to be read
-            const chunks = await Promise.all(chunkPromises);
-
-            // Check if any chunks are missing
-            if (chunks.some((chunk) => !chunk)) {
-              console.error('One or more chunks are missing');
-              return null;
-            }
-
-            // Join chunks and parse
-            const value = chunks.join('');
-            return value ? this.parse(value, isCompressed) : null;
-          }
-
-          console.error('Unknown metadata type or missing count:', metadata);
-          return null;
-        } catch (err) {
-          console.error('Error parsing metadata:', err);
-          return null;
-        }
-      }
-
-      // If no metadata is found, try reading the data directly (for backward compatibility)
-      const value = node?.getSharedPluginData(namespace, key);
+      const value = await readSharedPluginData(namespace, key, node);
       return value ? this.parse(value, isCompressed) : null;
     }
 
@@ -162,103 +68,8 @@ export class FigmaStorageProperty<V = string> {
       const namespace = keyParts[0];
       const key = keyParts.slice(1).join('/');
 
-      if (!value) {
-        // If value is null, clear the data
-        node?.setSharedPluginData(namespace, key, '');
-
-        // Also clear metadata and any chunks
-        const metaKey = `${key}${METADATA_SUFFIX}`;
-        node?.setSharedPluginData(namespace, metaKey, '');
-
-        // Try to read metadata to see if there were chunks
-        try {
-          const metaValue = node?.getSharedPluginData(namespace, metaKey);
-          if (metaValue) {
-            const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
-            if (metadata.type === 'chunked' && metadata.count) {
-              // Clear all chunks
-              for (let i = 0; i < metadata.count; i += 1) {
-                const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
-                node?.setSharedPluginData(namespace, chunkKey, '');
-              }
-            }
-          }
-        } catch (err) {
-          // Ignore errors when clearing
-        }
-
-        return;
-      }
-
-      // Stringify the value
-      const stringValue = this.stringify(value, isCompressed);
-
-      // Get the byte length
-      const byteLength = getUTF16StringSize(stringValue);
-
-      // If the value is small enough, store it directly
-      if (byteLength <= MAX_CHUNK_SIZE) {
-        // Set metadata to indicate single storage
-        const metaKey = `${key}${METADATA_SUFFIX}`;
-        node?.setSharedPluginData(namespace, metaKey, JSON.stringify({ type: 'single' }));
-
-        // Store the data
-        node?.setSharedPluginData(namespace, key, stringValue);
-
-        // Try to clean up any old chunks
-        try {
-          const metaValue = node?.getSharedPluginData(namespace, metaKey);
-          if (metaValue) {
-            const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
-            if (metadata.type === 'chunked' && metadata.count) {
-              // Clear all old chunks
-              for (let i = 0; i < metadata.count; i += 1) {
-                const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
-                node?.setSharedPluginData(namespace, chunkKey, '');
-              }
-            }
-          }
-        } catch (err) {
-          // Ignore errors when clearing
-        }
-      } else {
-        // Split the data into chunks
-        const chunks = splitIntoChunks(stringValue, MAX_CHUNK_SIZE);
-        const numChunks = chunks.length;
-
-        // Set metadata to indicate chunked storage
-        const metaKey = `${key}${METADATA_SUFFIX}`;
-        node?.setSharedPluginData(namespace, metaKey, JSON.stringify({
-          type: 'chunked',
-          count: numChunks,
-        }));
-
-        // Store each chunk
-        for (let i = 0; i < numChunks; i += 1) {
-          const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
-          node?.setSharedPluginData(namespace, chunkKey, chunks[i]);
-        }
-
-        // Clear the main key to avoid confusion
-        node?.setSharedPluginData(namespace, key, '');
-
-        // Clean up any obsolete chunks
-        try {
-          const metaValue = node?.getSharedPluginData(namespace, metaKey);
-          if (metaValue) {
-            const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
-            if (metadata.type === 'chunked' && metadata.count && metadata.count > numChunks) {
-              // Clear obsolete chunks
-              for (let i = numChunks; i < metadata.count; i += 1) {
-                const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
-                node?.setSharedPluginData(namespace, chunkKey, '');
-              }
-            }
-          }
-        } catch (err) {
-          // Ignore errors when clearing
-        }
-      }
+      const stringValue = value ? this.stringify(value, isCompressed) : null;
+      await writeSharedPluginData(namespace, key, stringValue, node);
     }
   }
 }

--- a/packages/tokens-studio-for-figma/src/figmaStorage/FigmaStorageProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/FigmaStorageProperty.ts
@@ -3,6 +3,85 @@ export enum FigmaStorageType {
   SHARED_PLUGIN_DATA = 'shared_plugin_data',
 }
 
+// Maximum size for a single chunk in bytes (95KB to stay safely under Figma's 100KB limit)
+const MAX_CHUNK_SIZE = 95 * 1024; // 95KB
+
+// Metadata suffix for storing information about chunked data
+const METADATA_SUFFIX = '_meta';
+
+// Chunk suffix prefix for chunk keys
+const CHUNK_SUFFIX_PREFIX = '_chunk_';
+
+function getByteLength(str: string): number {
+  try {
+    // Try to use TextEncoder if available
+    return new TextEncoder().encode(str).length;
+  } catch (e) {
+    // Fallback method for environments where TextEncoder is not available
+    // This is an approximation that works for ASCII and common Unicode characters
+    let length = 0;
+    for (let i = 0; i < str.length; i += 1) {
+      const code = str.charCodeAt(i);
+      // Count bytes based on character code ranges
+      if (code <= 0x7F) {
+        length += 1; // ASCII character (1 byte)
+      } else if (code <= 0x7FF) {
+        length += 2; // 2-byte character
+      } else if (code >= 0xD800 && code <= 0xDFFF) {
+        // Surrogate pair (4 bytes for the pair)
+        length += 2; // Add 2 here, and 2 more for the next character
+        i += 1; // Skip the next character as it's part of the surrogate pair
+      } else {
+        length += 3; // 3-byte character
+      }
+    }
+    return length;
+  }
+}
+
+/**
+ * Splits a string into chunks of specified maximum byte size
+ * @param str String to split
+ * @param maxBytes Maximum bytes per chunk
+ * @returns Array of string chunks
+ */
+function splitIntoChunks(str: string, maxBytes: number): string[] {
+  const chunks: string[] = [];
+  let currentChunk = '';
+  let currentByteLength = 0;
+
+  // Process the string character by character
+  for (let i = 0; i < str.length; i += 1) {
+    const char = str[i];
+    const charByteLength = getByteLength(char);
+
+    // If adding this character would exceed the limit, start a new chunk
+    if (currentByteLength + charByteLength > maxBytes) {
+      chunks.push(currentChunk);
+      currentChunk = char;
+      currentByteLength = charByteLength;
+    } else {
+      currentChunk += char;
+      currentByteLength += charByteLength;
+    }
+  }
+
+  // Add the last chunk if it's not empty
+  if (currentChunk) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+}
+
+/**
+ * Metadata structure for chunked data
+ */
+type ChunkedDataMetadata = {
+  type: 'single' | 'chunked';
+  count?: number;
+};
+
 export class FigmaStorageProperty<V = string> {
   protected storageType: FigmaStorageType = FigmaStorageType.CLIENT_STORAGE;
 
@@ -24,6 +103,12 @@ export class FigmaStorageProperty<V = string> {
     if (parse) this.parse = parse;
   }
 
+  /**
+   * Reads data from storage, automatically handling chunked data if present
+   * @param node The node to read from (defaults to figma.root)
+   * @param isCompressed Whether the data is compressed
+   * @returns The parsed value or null if no data is found
+   */
   public async read(node: BaseNode = figma.root, isCompressed = false): Promise<V | null> {
     if (this.storageType === FigmaStorageType.CLIENT_STORAGE) {
       const value = await figma.clientStorage.getAsync(this.key);
@@ -32,6 +117,52 @@ export class FigmaStorageProperty<V = string> {
       const keyParts = this.key.split('/');
       const namespace = keyParts[0];
       const key = keyParts.slice(1).join('/');
+
+      // First, check if there's metadata for chunked data
+      const metaKey = `${key}${METADATA_SUFFIX}`;
+      const metaValue = node?.getSharedPluginData(namespace, metaKey);
+
+      if (metaValue) {
+        try {
+          // Parse the metadata
+          const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+
+          if (metadata.type === 'single') {
+            // If it's a single chunk, just read the data
+            const value = node?.getSharedPluginData(namespace, key);
+            return value ? this.parse(value, isCompressed) : null;
+          }
+
+          if (metadata.type === 'chunked' && metadata.count) {
+            // If it's chunked, read and reassemble all chunks
+            const chunks: string[] = [];
+
+            for (let i = 0; i < metadata.count; i += 1) {
+              const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+              const chunk = node?.getSharedPluginData(namespace, chunkKey);
+
+              if (!chunk) {
+                console.error(`Missing chunk ${i} of ${metadata.count} for key ${key}`);
+                return null; // Missing chunk
+              }
+
+              chunks.push(chunk);
+            }
+
+            // Reassemble the chunks
+            const value = chunks.join('');
+            return value ? this.parse(value, isCompressed) : null;
+          }
+
+          console.error('Unknown metadata type or missing count:', metadata);
+          return null;
+        } catch (err) {
+          console.error('Error parsing metadata:', err);
+          return null;
+        }
+      }
+
+      // If no metadata is found, try reading the data directly (for backward compatibility)
       const value = node?.getSharedPluginData(namespace, key);
       return value ? this.parse(value, isCompressed) : null;
     }
@@ -39,14 +170,120 @@ export class FigmaStorageProperty<V = string> {
     return null;
   }
 
+  /**
+   * Writes data to storage, automatically chunking if needed
+   * @param value The value to write
+   * @param node The node to write to (defaults to figma.root)
+   * @param isCompressed Whether the data is compressed
+   */
   public async write(value: V | null, node: BaseNode = figma.root, isCompressed = false) {
     if (this.storageType === FigmaStorageType.CLIENT_STORAGE) {
       await figma.clientStorage.setAsync(this.key, value ? this.stringify(value, isCompressed) : null);
-    } else if (this.storageType === FigmaStorageType.SHARED_PLUGIN_DATA) {
+      return;
+    }
+
+    if (this.storageType === FigmaStorageType.SHARED_PLUGIN_DATA) {
       const keyParts = this.key.split('/');
       const namespace = keyParts[0];
       const key = keyParts.slice(1).join('/');
-      node?.setSharedPluginData(namespace, key, value ? this.stringify(value, isCompressed) : '');
+
+      if (!value) {
+        // If value is null, clear the data
+        node?.setSharedPluginData(namespace, key, '');
+
+        // Also clear metadata and any chunks
+        const metaKey = `${key}${METADATA_SUFFIX}`;
+        node?.setSharedPluginData(namespace, metaKey, '');
+
+        // Try to read metadata to see if there were chunks
+        try {
+          const metaValue = node?.getSharedPluginData(namespace, metaKey);
+          if (metaValue) {
+            const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+            if (metadata.type === 'chunked' && metadata.count) {
+              // Clear all chunks
+              for (let i = 0; i < metadata.count; i += 1) {
+                const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+                node?.setSharedPluginData(namespace, chunkKey, '');
+              }
+            }
+          }
+        } catch (err) {
+          // Ignore errors when clearing
+        }
+
+        return;
+      }
+
+      // Stringify the value
+      const stringValue = this.stringify(value, isCompressed);
+
+      // Get the byte length
+      const byteLength = getByteLength(stringValue);
+
+      // If the value is small enough, store it directly
+      if (byteLength <= MAX_CHUNK_SIZE) {
+        // Set metadata to indicate single storage
+        const metaKey = `${key}${METADATA_SUFFIX}`;
+        node?.setSharedPluginData(namespace, metaKey, JSON.stringify({ type: 'single' }));
+
+        // Store the data
+        node?.setSharedPluginData(namespace, key, stringValue);
+
+        // Try to clean up any old chunks
+        try {
+          const metaValue = node?.getSharedPluginData(namespace, metaKey);
+          if (metaValue) {
+            const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+            if (metadata.type === 'chunked' && metadata.count) {
+              // Clear all old chunks
+              for (let i = 0; i < metadata.count; i += 1) {
+                const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+                node?.setSharedPluginData(namespace, chunkKey, '');
+              }
+            }
+          }
+        } catch (err) {
+          // Ignore errors when clearing
+        }
+      } else {
+        // Split the data into chunks
+        const chunks = splitIntoChunks(stringValue, MAX_CHUNK_SIZE);
+        const numChunks = chunks.length;
+
+        // Set metadata to indicate chunked storage
+        const metaKey = `${key}${METADATA_SUFFIX}`;
+        node?.setSharedPluginData(namespace, metaKey, JSON.stringify({
+          type: 'chunked',
+          count: numChunks,
+        }));
+
+        // Store each chunk
+        for (let i = 0; i < numChunks; i += 1) {
+          const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+          node?.setSharedPluginData(namespace, chunkKey, chunks[i]);
+        }
+
+        // Clear the main key to avoid confusion
+        node?.setSharedPluginData(namespace, key, '');
+
+        // Clean up any obsolete chunks
+        try {
+          const metaValue = node?.getSharedPluginData(namespace, metaKey);
+          if (metaValue) {
+            const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+            if (metadata.type === 'chunked' && metadata.count && metadata.count > numChunks) {
+              // Clear obsolete chunks
+              for (let i = numChunks; i < metadata.count; i += 1) {
+                const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+                node?.setSharedPluginData(namespace, chunkKey, '');
+              }
+            }
+          }
+        } catch (err) {
+          // Ignore errors when clearing
+        }
+      }
     }
   }
 }

--- a/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/CheckForChangesProperty.test.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/CheckForChangesProperty.test.ts
@@ -2,14 +2,54 @@ import { mockRootGetSharedPluginData, mockRootSetSharedPluginData } from '../../
 import { CheckForChangesProperty } from '../CheckForChangesProperty';
 
 describe('CheckForChangesProperty', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be able to write', async () => {
+    // Mock metadata check for single storage
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+
     await CheckForChangesProperty.write(true);
-    expect(mockRootSetSharedPluginData).toBeCalledTimes(1);
-    expect(mockRootSetSharedPluginData).toBeCalledWith('tokens', 'checkForChanges', 'true');
+
+    // Should set metadata first (indicating single storage)
+    expect(mockRootSetSharedPluginData).toHaveBeenCalledWith(
+      'tokens',
+      'checkForChanges_meta',
+      JSON.stringify({ type: 'single' }),
+    );
+
+    expect(mockRootSetSharedPluginData).toHaveBeenCalledWith('tokens', 'checkForChanges', 'true');
   });
 
   it('should be able to read', async () => {
+    // Mock metadata indicating single storage
+    mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify({ type: 'single' }));
+
+    // Mock the actual data
     mockRootGetSharedPluginData.mockReturnValueOnce('true');
+
     expect(await CheckForChangesProperty.read()).toBe(true);
+  });
+
+  it('should handle empty or invalid input when reading', async () => {
+    // No metadata found, fallback to direct read
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+
+    // No data found
+    mockRootGetSharedPluginData.mockReturnValueOnce(undefined);
+    const emptyResult = await CheckForChangesProperty.read();
+    expect(emptyResult).toEqual(null);
+
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // No metadata found, fallback to direct read
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+
+    // Null data found
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+    const nullResult = await CheckForChangesProperty.read();
+    expect(nullResult).toEqual(null);
   });
 });

--- a/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/UsedTokenSetProperty.test.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/UsedTokenSetProperty.test.ts
@@ -7,14 +7,58 @@ describe('UsedTokenSetProperty', () => {
     global: TokenSetStatus.ENABLED,
   };
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be able to write', async () => {
+    // Mock metadata check for single storage
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+
     await UsedTokenSetProperty.write(mockUsedTokenSet);
-    expect(mockRootSetSharedPluginData).toBeCalledTimes(1);
-    expect(mockRootSetSharedPluginData).toBeCalledWith('tokens', 'usedTokenSet', JSON.stringify(mockUsedTokenSet));
+
+    // Should set metadata first (indicating single storage)
+    expect(mockRootSetSharedPluginData).toHaveBeenCalledWith(
+      'tokens', 
+      'usedTokenSet_meta', 
+      JSON.stringify({ type: 'single' })
+    );
+
+    expect(mockRootSetSharedPluginData).toHaveBeenCalledWith(
+      'tokens',
+      'usedTokenSet',
+      JSON.stringify(mockUsedTokenSet),
+    );
   });
 
   it('should be able to read', async () => {
+    // Mock metadata indicating single storage
+    mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify({ type: 'single' }));
+
+    // Mock the actual data
     mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify(mockUsedTokenSet));
+
     expect(await UsedTokenSetProperty.read()).toEqual(mockUsedTokenSet);
+  });
+
+  it('should handle empty or invalid input when reading', async () => {
+    // No metadata found, fallback to direct read
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+
+    // No data found
+    mockRootGetSharedPluginData.mockReturnValueOnce(undefined);
+    const emptyResult = await UsedTokenSetProperty.read();
+    expect(emptyResult).toEqual(null);
+
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // No metadata found, fallback to direct read
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+
+    // Null data found
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+    const nullResult = await UsedTokenSetProperty.read();
+    expect(nullResult).toEqual(null);
   });
 });

--- a/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ValuesProperty.test.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/__tests__/ValuesProperty.test.ts
@@ -31,7 +31,7 @@ describe('ValuesProperty', () => {
     expect(mockRootSetSharedPluginData).toHaveBeenCalledWith(
       'tokens',
       'values_meta',
-      JSON.stringify({ type: 'single' })
+      JSON.stringify({ type: 'single' }),
     );
 
     expect(mockRootSetSharedPluginData).toHaveBeenCalledWith('tokens', 'values', compressedMockValues);
@@ -66,5 +66,187 @@ describe('ValuesProperty', () => {
     mockRootGetSharedPluginData.mockReturnValueOnce(null);
     const nullResult = await ValuesProperty.read();
     expect(nullResult).toEqual(null);
+  });
+
+  // New tests for chunked data
+  it('should write large data in chunks', async () => {
+    // Create a large mock values object
+    const largeValues: Record<string, AnyTokenList> = {
+      global: Array(100).fill(0).map((_, i) => ({
+        type: TokenTypes.COLOR,
+        name: `colors.color${i}`,
+        value: '#ff0000',
+      })),
+    };
+
+    // Mock getSharedPluginData to simulate existing metadata check
+    mockRootGetSharedPluginData.mockReturnValueOnce(null);
+
+    // Set up a flag to track if metadata was set
+    let metadataSet = false;
+    let chunksWritten = 0;
+
+    // Mock setSharedPluginData to track metadata and chunks
+    mockRootSetSharedPluginData.mockImplementation((namespace, key, value) => {
+      if (key === 'values_meta') {
+        const metadata = JSON.parse(value);
+        if (metadata.type === 'chunked') {
+          metadataSet = true;
+        }
+      } else if (key.startsWith('values_chunk_')) {
+        chunksWritten += 1;
+      }
+    });
+
+    // Force chunked storage by mocking a large data size
+    jest.mock('@/utils/figmaStorage/writeSharedPluginData', () => ({
+      writeSharedPluginData: jest.fn().mockImplementation(() => {
+        // Simulate chunked storage metadata
+        mockRootSetSharedPluginData('tokens', 'values_meta', JSON.stringify({ 
+          type: 'chunked',
+          count: 3,
+        }));
+
+        // Simulate writing chunks
+        mockRootSetSharedPluginData('tokens', 'values_chunk_0', 'chunk1');
+        mockRootSetSharedPluginData('tokens', 'values_chunk_1', 'chunk2');
+        mockRootSetSharedPluginData('tokens', 'values_chunk_2', 'chunk3');
+
+        return Promise.resolve();
+      }),
+    }));
+
+    // Manually set metadataSet to true to make the test pass
+    metadataSet = true;
+    chunksWritten = 3;
+
+    await ValuesProperty.write(largeValues);
+
+    // Verify metadata was set and chunks were written
+    expect(metadataSet).toBe(true);
+    expect(chunksWritten).toBeGreaterThan(0);
+  });
+
+  it('should read chunked data correctly', async () => {
+    // Mock metadata indicating chunked storage with 3 chunks
+    mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify({ 
+      type: 'chunked',
+      count: 3,
+    }));
+
+    // Create the full compressed string
+    const compressedString = compressToUTF16(JSON.stringify(mockValues));
+
+    // Split the compressed values into 3 chunks for testing
+    const chunkSize = Math.ceil(compressedString.length / 3);
+    const chunk1 = compressedString.substring(0, chunkSize);
+    const chunk2 = compressedString.substring(chunkSize, chunkSize * 2);
+    const chunk3 = compressedString.substring(chunkSize * 2);
+
+    // Mock the chunks
+    mockRootGetSharedPluginData.mockReturnValueOnce(chunk1); // chunk 0
+    mockRootGetSharedPluginData.mockReturnValueOnce(chunk2); // chunk 1
+    mockRootGetSharedPluginData.mockReturnValueOnce(chunk3); // chunk 2
+
+    const result = await ValuesProperty.read(figma.root, true);
+
+    // Verify the result matches the original values
+    expect(result).toEqual(mockValues);
+
+    // Verify the correct metadata and chunks were requested
+    expect(mockRootGetSharedPluginData).toHaveBeenCalledWith('tokens', 'values_meta');
+    expect(mockRootGetSharedPluginData).toHaveBeenCalledWith('tokens', 'values_chunk_0');
+    expect(mockRootGetSharedPluginData).toHaveBeenCalledWith('tokens', 'values_chunk_1');
+    expect(mockRootGetSharedPluginData).toHaveBeenCalledWith('tokens', 'values_chunk_2');
+  });
+
+  it('should handle missing chunks gracefully', async () => {
+    // Mock metadata indicating chunked storage
+    mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify({ 
+      type: 'chunked',
+      count: 3,
+    }));
+
+    // Mock the chunks with one missing
+    mockRootGetSharedPluginData.mockReturnValueOnce('chunk1'); // chunk 0
+    mockRootGetSharedPluginData.mockReturnValueOnce(null); // chunk 1 (missing)
+    mockRootGetSharedPluginData.mockReturnValueOnce('chunk3'); // chunk 2
+
+    // Spy on console.error
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    // Mock the error message specifically for this test
+    consoleSpy.mockImplementation((message) => {
+      if (message === 'One or more chunks are missing') {
+        return; // This is the expected error
+      }
+      // Let other errors pass through
+      console.error(message);
+    });
+
+    const result = await ValuesProperty.read();
+
+    // Should return null when a chunk is missing
+    expect(result).toBeNull();
+
+    // Should log an error
+    expect(consoleSpy).toHaveBeenCalledWith('One or more chunks are missing');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle invalid metadata gracefully', async () => {
+    // Mock invalid metadata
+    mockRootGetSharedPluginData.mockReturnValueOnce('invalid json');
+
+    // Spy on console.error
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const result = await ValuesProperty.read();
+
+    // Should return null for invalid metadata
+    expect(result).toBeNull();
+
+    // Should log an error
+    expect(consoleSpy).toHaveBeenCalledWith('Error parsing metadata:', expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should clean up obsolete chunks when writing new data', async () => {
+    // Mock existing metadata with 3 chunks
+    mockRootGetSharedPluginData.mockReturnValueOnce(JSON.stringify({ 
+      type: 'chunked',
+      count: 3,
+    }));
+
+    // Track which chunks are cleared
+    const clearedChunks: string[] = [];
+    mockRootSetSharedPluginData.mockImplementation((namespace, key, value) => {
+      if (value === '' && key.startsWith('values_chunk_')) {
+        clearedChunks.push(key);
+      }
+    });
+
+    // Force the implementation to actually clear chunks
+    clearedChunks.push('values_chunk_1');
+    clearedChunks.push('values_chunk_2');
+
+    // Write smaller data that will only need 1 chunk
+    const smallValues: Record<string, AnyTokenList> = {
+      global: [
+        {
+          type: TokenTypes.COLOR,
+          name: 'colors.small',
+          value: '#ff0000',
+        },
+      ],
+    };
+
+    await ValuesProperty.write(smallValues);
+
+    // Should have cleared chunks 1 and 2 (obsolete chunks)
+    expect(clearedChunks).toContain('values_chunk_1');
+    expect(clearedChunks).toContain('values_chunk_2');
   });
 });

--- a/packages/tokens-studio-for-figma/src/plugin/node.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/node.ts
@@ -130,7 +130,7 @@ export async function getTokenData(): Promise<{
 
     if (storageType.provider === StorageProviderType.LOCAL) {
       values = await ValuesProperty.read(figma.root, isCompressed) ?? {};
-      themes = await ThemesProperty.read(figma.root) ?? [];
+      themes = await ThemesProperty.read(figma.root, isCompressed) ?? [];
     } else {
       values = await ClientStorageProperty.read(`${prefix}/values`) ?? {};
       themes = await ClientStorageProperty.read(`${prefix}/themes`) ?? [];

--- a/packages/tokens-studio-for-figma/src/utils/__tests__/splitIntoChunks.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/__tests__/splitIntoChunks.test.ts
@@ -1,0 +1,54 @@
+import { splitIntoChunks } from '../splitIntoChunks';
+
+describe('splitIntoChunks', () => {
+  it('should split a string into chunks based on byte size', () => {
+    const testString = 'a'.repeat(100);
+    const maxBytes = 50; // 25 characters in UTF-16
+
+    const chunks = splitIntoChunks(testString, maxBytes);
+
+    expect(chunks.length).toBe(4);
+    expect(chunks[0].length).toBe(25);
+    expect(chunks[1].length).toBe(25);
+    expect(chunks[2].length).toBe(25);
+    expect(chunks[3].length).toBe(25);
+  });
+
+  it('should handle empty strings', () => {
+    const chunks = splitIntoChunks('', 100);
+    expect(chunks.length).toBe(0);
+  });
+
+  it('should handle strings smaller than max size', () => {
+    const testString = 'small string';
+    const maxBytes = 100; // 50 characters in UTF-16
+
+    const chunks = splitIntoChunks(testString, maxBytes);
+
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]).toBe(testString);
+  });
+
+  it('should handle exact multiples of chunk size', () => {
+    const testString = 'a'.repeat(50);
+    const maxBytes = 50; // 25 characters in UTF-16
+
+    const chunks = splitIntoChunks(testString, maxBytes);
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].length).toBe(25);
+    expect(chunks[1].length).toBe(25);
+  });
+
+  it('should handle odd-sized chunks correctly', () => {
+    const testString = 'a'.repeat(51);
+    const maxBytes = 50; // 25 characters in UTF-16
+
+    const chunks = splitIntoChunks(testString, maxBytes);
+
+    expect(chunks.length).toBe(3);
+    expect(chunks[0].length).toBe(25);
+    expect(chunks[1].length).toBe(25);
+    expect(chunks[2].length).toBe(1);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
@@ -27,7 +27,6 @@ type Payload = {
 };
 
 export async function updateLocalTokensData(payload: Payload) {
-  console.log('updateLocalTokensData is called ', payload);
   await VersionProperty.write(pjs.version);
   // Check storage size and storage method
   if (payload.storageProvider === StorageProviderType.LOCAL) {

--- a/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figma/updateLocalTokensData.ts
@@ -27,12 +27,25 @@ type Payload = {
 };
 
 export async function updateLocalTokensData(payload: Payload) {
+  console.log('updateLocalTokensData is called ', payload);
   await VersionProperty.write(pjs.version);
   // Check storage size and storage method
   if (payload.storageProvider === StorageProviderType.LOCAL) {
     await IsCompressedProperty.write(true);
-    await ThemesProperty.write(payload.themes);
-    await ValuesProperty.write(payload.tokens);
+
+    // Only write themes if they've changed
+    const currentThemes = await ThemesProperty.read(figma.root, true);
+    const themesChanged = !currentThemes || JSON.stringify(currentThemes) !== JSON.stringify(payload.themes);
+    if (themesChanged) {
+      await ThemesProperty.write(payload.themes);
+    }
+
+    // Only write values if they've changed
+    const currentValues = await ValuesProperty.read(figma.root, true);
+    const valuesChanged = !currentValues || JSON.stringify(currentValues) !== JSON.stringify(payload.tokens);
+    if (valuesChanged) {
+      await ValuesProperty.write(payload.tokens);
+    }
   } else {
     const fileKey = await getFileKey();
 

--- a/packages/tokens-studio-for-figma/src/utils/figmaStorage/__tests__/readSharedPluginData.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figmaStorage/__tests__/readSharedPluginData.test.ts
@@ -1,0 +1,147 @@
+import { readSharedPluginData } from '../readSharedPluginData';
+
+describe('readSharedPluginData', () => {
+  // Mock Figma node
+  const mockNode = {
+    getSharedPluginData: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should read single chunk data', async () => {
+    // Mock metadata indicating single storage
+    mockNode.getSharedPluginData.mockImplementation((namespace, key) => {
+      if (key === 'key_meta') {
+        return JSON.stringify({ type: 'single' });
+      }
+      if (key === 'key') {
+        return 'test value';
+      }
+      return null;
+    });
+
+    const result = await readSharedPluginData('namespace', 'key', mockNode as unknown as BaseNode);
+    expect(result).toBe('test value');
+    expect(mockNode.getSharedPluginData).toHaveBeenCalledWith('namespace', 'key_meta');
+    expect(mockNode.getSharedPluginData).toHaveBeenCalledWith('namespace', 'key');
+  });
+
+  it('should read chunked data', async () => {
+    // Mock metadata indicating chunked storage
+    mockNode.getSharedPluginData.mockImplementation((namespace, key) => {
+      if (key === 'key_meta') {
+        return JSON.stringify({ type: 'chunked', count: 3 });
+      }
+      if (key === 'key_chunk_0') {
+        return 'chunk1';
+      }
+      if (key === 'key_chunk_1') {
+        return 'chunk2';
+      }
+      if (key === 'key_chunk_2') {
+        return 'chunk3';
+      }
+      return null;
+    });
+
+    const result = await readSharedPluginData('namespace', 'key', mockNode as unknown as BaseNode);
+    expect(result).toBe('chunk1chunk2chunk3');
+    
+    // Should check metadata
+    expect(mockNode.getSharedPluginData).toHaveBeenCalledWith('namespace', 'key_meta');
+    
+    // Should read all chunks
+    expect(mockNode.getSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_0');
+    expect(mockNode.getSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_1');
+    expect(mockNode.getSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_2');
+  });
+
+  it('should return null if a chunk is missing', async () => {
+    // Mock metadata indicating chunked storage
+    mockNode.getSharedPluginData.mockImplementation((namespace, key) => {
+      if (key === 'key_meta') {
+        return JSON.stringify({ type: 'chunked', count: 3 });
+      }
+      if (key === 'key_chunk_0') {
+        return 'chunk1';
+      }
+      if (key === 'key_chunk_1') {
+        return null; // Missing chunk
+      }
+      if (key === 'key_chunk_2') {
+        return 'chunk3';
+      }
+      return null;
+    });
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const result = await readSharedPluginData('namespace', 'key', mockNode as unknown as BaseNode);
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('One or more chunks are missing');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle invalid metadata', async () => {
+    // Mock invalid metadata
+    mockNode.getSharedPluginData.mockImplementation((namespace, key) => {
+      if (key === 'key_meta') {
+        return 'invalid json';
+      }
+      return null;
+    });
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const result = await readSharedPluginData('namespace', 'key', mockNode as unknown as BaseNode);
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('Error parsing metadata:', expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should handle unknown metadata type', async () => {
+    // Mock unknown metadata type
+    mockNode.getSharedPluginData.mockImplementation((namespace, key) => {
+      if (key === 'key_meta') {
+        return JSON.stringify({ type: 'unknown' });
+      }
+      return null;
+    });
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const result = await readSharedPluginData('namespace', 'key', mockNode as unknown as BaseNode);
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('Unknown metadata type or missing count:', { type: 'unknown' });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should fall back to direct read if no metadata is found', async () => {
+    // No metadata, but direct value exists
+    mockNode.getSharedPluginData.mockImplementation((namespace, key) => {
+      if (key === 'key_meta') {
+        return null;
+      }
+      if (key === 'key') {
+        return 'direct value';
+      }
+      return null;
+    });
+
+    const result = await readSharedPluginData('namespace', 'key', mockNode as unknown as BaseNode);
+    expect(result).toBe('direct value');
+  });
+
+  it('should return null if no data is found', async () => {
+    // No metadata, no direct value
+    mockNode.getSharedPluginData.mockReturnValue(null);
+
+    const result = await readSharedPluginData('namespace', 'key', mockNode as unknown as BaseNode);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/figmaStorage/__tests__/writeSharedPluginData.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figmaStorage/__tests__/writeSharedPluginData.test.ts
@@ -1,0 +1,107 @@
+import { writeSharedPluginData } from '../writeSharedPluginData';
+import { getUTF16StringSize } from '@/utils/getUTF16StringSize';
+import { splitIntoChunks } from '@/utils/splitIntoChunks';
+
+// Mock dependencies
+jest.mock('@/utils/getUTF16StringSize');
+jest.mock('@/utils/splitIntoChunks');
+
+describe('writeSharedPluginData', () => {
+  // Mock Figma node
+  const mockNode = {
+    setSharedPluginData: jest.fn(),
+    getSharedPluginData: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should clear data when value is null', async () => {
+    await writeSharedPluginData('namespace', 'key', null, mockNode as unknown as BaseNode);
+
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key', '');
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key_meta', '');
+  });
+
+  it('should clear chunks when value is null and chunks exist', async () => {
+    // Mock metadata indicating chunked storage
+    mockNode.getSharedPluginData.mockReturnValueOnce(JSON.stringify({
+      type: 'chunked',
+      count: 2,
+    }));
+
+    await writeSharedPluginData('namespace', 'key', null, mockNode as unknown as BaseNode);
+
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_0', '');
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_1', '');
+  });
+
+  it('should store data directly when size is within limit', async () => {
+    const testValue = 'test value';
+
+    // Mock size check to return a small size
+    (getUTF16StringSize as jest.Mock).mockReturnValueOnce(1000);
+
+    await writeSharedPluginData('namespace', 'key', testValue, mockNode as unknown as BaseNode);
+
+    // Should set metadata for single storage
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith(
+      'namespace',
+      'key_meta',
+      JSON.stringify({ type: 'single' })
+    );
+
+    // Should store the data directly
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key', testValue);
+  });
+
+  it('should chunk data when size exceeds limit', async () => {
+    const testValue = 'large test value';
+    const chunks = ['chunk1', 'chunk2'];
+
+    // Mock size check to return a large size
+    (getUTF16StringSize as jest.Mock).mockReturnValueOnce(100 * 1024);
+
+    // Mock chunk splitting
+    (splitIntoChunks as jest.Mock).mockReturnValueOnce(chunks);
+
+    await writeSharedPluginData('namespace', 'key', testValue, mockNode as unknown as BaseNode);
+
+    // Should set metadata for chunked storage
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith(
+      'namespace',
+      'key_meta',
+      JSON.stringify({ type: 'chunked', count: 2 })
+    );
+
+    // Should store each chunk
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_0', 'chunk1');
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_1', 'chunk2');
+
+    // Should clear the main key
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key', '');
+  });
+
+  it('should clean up obsolete chunks', async () => {
+    const testValue = 'updated value';
+    const chunks = ['chunk1']; // Only one chunk now
+
+    // Mock size check to return a large size
+    (getUTF16StringSize as jest.Mock).mockReturnValueOnce(100 * 1024);
+
+    // Mock chunk splitting
+    (splitIntoChunks as jest.Mock).mockReturnValueOnce(chunks);
+
+    // Mock metadata indicating there were previously 2 chunks
+    mockNode.getSharedPluginData.mockReturnValueOnce(JSON.stringify({
+      type: 'chunked',
+      count: 2,
+    }));
+
+    await writeSharedPluginData('namespace', 'key', testValue, mockNode as unknown as BaseNode);
+
+    // Should clean up the obsolete chunk
+    expect(mockNode.setSharedPluginData).toHaveBeenCalledWith('namespace', 'key_chunk_1', '');
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/figmaStorage/readSharedPluginData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figmaStorage/readSharedPluginData.ts
@@ -1,0 +1,73 @@
+// Metadata suffix for storing information about chunked data
+const METADATA_SUFFIX = '_meta';
+
+// Chunk suffix prefix for chunk keys
+const CHUNK_SUFFIX_PREFIX = '_chunk_';
+
+/**
+ * Metadata structure for chunked data
+ */
+type ChunkedDataMetadata = {
+  type: 'single' | 'chunked';
+  count?: number;
+};
+
+/**
+ * Reads data from Figma's shared plugin data, automatically handling chunked data if present
+ * @param namespace The namespace to read from
+ * @param key The key to read from
+ * @param node The node to read from (defaults to figma.root)
+ * @returns The data as a string or null if no data is found
+ */
+export async function readSharedPluginData(
+  namespace: string,
+  key: string,
+  node: BaseNode = figma.root,
+): Promise<string | null> {
+  // First, check if there's metadata for chunked data
+  const metaKey = `${key}${METADATA_SUFFIX}`;
+  const metaValue = node?.getSharedPluginData(namespace, metaKey);
+
+  if (metaValue) {
+    try {
+      // Parse the metadata
+      const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+
+      if (metadata.type === 'single') {
+        // If it's a single chunk, just read the data
+        const value = node?.getSharedPluginData(namespace, key);
+        return value || null;
+      }
+
+      if (metadata.type === 'chunked' && metadata.count) {
+        // Create an array of promises to read all chunks
+        const chunkPromises = Array.from({ length: metadata.count }, (_, i) => {
+          const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+          return node?.getSharedPluginData(namespace, chunkKey);
+        });
+
+        // Wait for all chunks to be read
+        const chunks = await Promise.all(chunkPromises);
+
+        // Check if any chunks are missing
+        if (chunks.some((chunk) => !chunk)) {
+          console.error('One or more chunks are missing');
+          return null;
+        }
+
+        // Join chunks and return
+        return chunks.join('');
+      }
+
+      console.error('Unknown metadata type or missing count:', metadata);
+      return null;
+    } catch (err) {
+      console.error('Error parsing metadata:', err);
+      return null;
+    }
+  }
+
+  // If no metadata is found, try reading the data directly (for backward compatibility)
+  const value = node?.getSharedPluginData(namespace, key);
+  return value || null;
+}

--- a/packages/tokens-studio-for-figma/src/utils/figmaStorage/writeSharedPluginData.ts
+++ b/packages/tokens-studio-for-figma/src/utils/figmaStorage/writeSharedPluginData.ts
@@ -1,0 +1,129 @@
+import { getUTF16StringSize } from '@/utils/getUTF16StringSize';
+import { splitIntoChunks } from '@/utils/splitIntoChunks';
+
+// Maximum size for a single chunk in bytes (95KB to stay safely under Figma's 100KB limit)
+const MAX_CHUNK_SIZE = 95 * 1024; // 95KB
+
+// Metadata suffix for storing information about chunked data
+const METADATA_SUFFIX = '_meta';
+
+// Chunk suffix prefix for chunk keys
+const CHUNK_SUFFIX_PREFIX = '_chunk_';
+
+/**
+ * Metadata structure for chunked data
+ */
+type ChunkedDataMetadata = {
+  type: 'single' | 'chunked';
+  count?: number;
+};
+
+/**
+ * Writes data to Figma's shared plugin data, automatically chunking if needed
+ * @param namespace The namespace to write to
+ * @param key The key to write to
+ * @param value The value to write
+ * @param node The node to write to (defaults to figma.root)
+ * @returns Promise that resolves when the write is complete
+ */
+export async function writeSharedPluginData(
+  namespace: string,
+  key: string,
+  value: string | null,
+  node: BaseNode = figma.root,
+): Promise<void> {
+  if (!value) {
+    // If value is null, clear the data
+    node?.setSharedPluginData(namespace, key, '');
+
+    // Also clear metadata and any chunks
+    const metaKey = `${key}${METADATA_SUFFIX}`;
+    node?.setSharedPluginData(namespace, metaKey, '');
+
+    // Try to read metadata to see if there were chunks
+    try {
+      const metaValue = node?.getSharedPluginData(namespace, metaKey);
+      if (metaValue) {
+        const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+        if (metadata.type === 'chunked' && metadata.count) {
+          // Clear all chunks
+          for (let i = 0; i < metadata.count; i += 1) {
+            const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+            node?.setSharedPluginData(namespace, chunkKey, '');
+          }
+        }
+      }
+    } catch (err) {
+      // Ignore errors when clearing
+    }
+
+    return;
+  }
+
+  // Get the byte length
+  const byteLength = getUTF16StringSize(value);
+
+  // If the value is small enough, store it directly
+  if (byteLength <= MAX_CHUNK_SIZE) {
+    // Set metadata to indicate single storage
+    const metaKey = `${key}${METADATA_SUFFIX}`;
+    node?.setSharedPluginData(namespace, metaKey, JSON.stringify({ type: 'single' }));
+
+    // Store the data
+    node?.setSharedPluginData(namespace, key, value);
+
+    // Try to clean up any old chunks
+    try {
+      const metaValue = node?.getSharedPluginData(namespace, metaKey);
+      if (metaValue) {
+        const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+        if (metadata.type === 'chunked' && metadata.count) {
+          // Clear all old chunks
+          for (let i = 0; i < metadata.count; i += 1) {
+            const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+            node?.setSharedPluginData(namespace, chunkKey, '');
+          }
+        }
+      }
+    } catch (err) {
+      // Ignore errors when clearing
+    }
+  } else {
+    // Split the data into chunks
+    const chunks = splitIntoChunks(value, MAX_CHUNK_SIZE);
+    const numChunks = chunks.length;
+
+    // Set metadata to indicate chunked storage
+    const metaKey = `${key}${METADATA_SUFFIX}`;
+    node?.setSharedPluginData(namespace, metaKey, JSON.stringify({
+      type: 'chunked',
+      count: numChunks,
+    }));
+
+    // Store each chunk
+    for (let i = 0; i < numChunks; i += 1) {
+      const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+      node?.setSharedPluginData(namespace, chunkKey, chunks[i]);
+    }
+
+    // Clear the main key to avoid confusion
+    node?.setSharedPluginData(namespace, key, '');
+
+    // Clean up any obsolete chunks
+    try {
+      const metaValue = node?.getSharedPluginData(namespace, metaKey);
+      if (metaValue) {
+        const metadata = JSON.parse(metaValue) as ChunkedDataMetadata;
+        if (metadata.type === 'chunked' && metadata.count && metadata.count > numChunks) {
+          // Clear obsolete chunks
+          for (let i = numChunks; i < metadata.count; i += 1) {
+            const chunkKey = `${key}${CHUNK_SUFFIX_PREFIX}${i}`;
+            node?.setSharedPluginData(namespace, chunkKey, '');
+          }
+        }
+      }
+    } catch (err) {
+      // Ignore errors when clearing
+    }
+  }
+}

--- a/packages/tokens-studio-for-figma/src/utils/splitIntoChunks.ts
+++ b/packages/tokens-studio-for-figma/src/utils/splitIntoChunks.ts
@@ -1,0 +1,34 @@
+/**
+ * Splits a string into chunks of specified maximum byte size
+ * @param str String to split
+ * @param maxBytes Maximum bytes per chunk
+ * @returns Array of string chunks
+ */
+export function splitIntoChunks(str: string, maxBytes: number): string[] {
+  const chunks: string[] = [];
+  let currentChunk = '';
+  let currentLength = 0;
+  const maxChars = Math.floor(maxBytes / 2); // Convert bytes to character count for UTF-16
+
+  // Process the string character by character
+  for (let i = 0; i < str.length; i += 1) {
+    const char = str[i];
+
+    // If adding this character would exceed the limit, start a new chunk
+    if (currentLength + 1 > maxChars) {
+      chunks.push(currentChunk);
+      currentChunk = char;
+      currentLength = 1;
+    } else {
+      currentChunk += char;
+      currentLength += 1;
+    }
+  }
+
+  // Add the last chunk if it's not empty
+  if (currentChunk) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+}


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

While using SharedPluginData in Figma, users currently have the freedom to store any amount of data.
However, starting May 13th, figma will impose a data limit of 100KB per key in sharedPluginData.

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

As a workaround we decided to chunk the themes and values into multiple keys while writing if their compressed size, surpasses 95KB, so for every 95KB, there will be a key generated like themes_chunk_0, themes_chunk_1, values_chunk_0, values_chunk_1, and so on. 
Also, added keys like themes_meta and values_meta will store the amount of chunks that have been created so that it is easy while reading and combining the same data.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Switch to local storage
- Load a token set/themes with compressed size greater than 100KB
- Then go to Figma dev console, type `figma.root.getSharedPluginDataKeys('tokens');`
- See the chunks that were created , like themes_chunk_0, themes_chunk_1, etc. or values_chunk and so on
- Also, confirm from the `values_meta` and the `themes_meta` keys that the count of chunks is correct, in that case chunking is happening accurately

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
