### PR TITLE
fix size check indicator on plugin load

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
@@ -6,6 +6,7 @@ import type { TokenState } from '../../tokenState';
 import removeIdPropertyFromTokens from '@/utils/removeIdPropertyFromTokens';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { TokenStore } from '@/types/tokens';
+import { checkStorageSize } from '@/utils/checkStorageSize';
 
 export function setTokenData(state: TokenState, payload: SetTokenDataPayload): TokenState {
   if (payload.values.length === 0) {
@@ -17,6 +18,9 @@ export function setTokenData(state: TokenState, payload: SetTokenDataPayload): T
   } else {
     values = parseTokenValues(payload.values);
   }
+
+  const tokensSize = payload.values ? checkStorageSize(payload.values) : state.tokensSize;
+  const themesSize = payload.themes ? checkStorageSize(payload.themes) : state.themesSize;
 
   const allAvailableTokenSets = Object.keys(values);
   const usedTokenSets = Object.fromEntries(
@@ -55,5 +59,7 @@ export function setTokenData(state: TokenState, payload: SetTokenDataPayload): T
         activeTokenSet: Array.isArray(payload.values) ? 'global' : Object.keys(payload.values)[0],
       }),
     usedTokenSet: Array.isArray(payload.values) ? { global: TokenSetStatus.ENABLED } : usedTokenSets,
+    tokensSize,
+    themesSize,
   };
 }


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

When the plugin loads, the indicator displays the indicator if the tokens/themes size is greater than 100KB.

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
