### PR TITLE
Fix read method to return correct data for 'checkForChanges' key

### DIFF
--- a/.changeset/heavy-pugs-divide.md
+++ b/.changeset/heavy-pugs-divide.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed a bug with remote storage providers and our check for recovering local changes causing the Enter credentials to be shown

--- a/packages/tokens-studio-for-figma/src/figmaStorage/ClientStorageProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/ClientStorageProperty.ts
@@ -26,6 +26,9 @@ export const ClientStorageProperty = {
   async read(key: string) {
     try {
       const compressed = await figma.clientStorage.getAsync(key);
+      if (key.endsWith('/checkForChanges')) {
+        return compressed;
+      }
       if (!compressed) {
         return null;
       }
@@ -37,6 +40,7 @@ export const ClientStorageProperty = {
 
       try {
         const result = JSON.parse(decompressed);
+
         return result;
       } catch (parseError) {
         console.error('Error parsing decompressed data:', parseError);


### PR DESCRIPTION
Fixed an issue that was causing checkForChanges to not be read correctly, causing a 'not a function' 