### PR TITLE
update metadata with tokenSetsData in useChangedState

### DIFF
--- a/.changeset/thick-jokes-thank.md
+++ b/.changeset/thick-jokes-thank.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes an issue where pulling from Tokens Studio would display a confusing metadata change, even when no actual changes took place.

--- a/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/PullDialog.tsx
@@ -12,7 +12,9 @@ import { transformProviderName } from '@/utils/transformProviderName';
 import ChangedStateList from './ChangedStateList';
 
 function PullDialog() {
-  const { onConfirm, onCancel, pullDialogMode, closePullDialog } = usePullDialog();
+  const {
+    onConfirm, onCancel, pullDialogMode, closePullDialog,
+  } = usePullDialog();
   const storageType = useSelector(storageTypeSelector);
   const { changedPullState } = useChangedState();
   const { t } = useTranslation(['sync']);
@@ -28,8 +30,8 @@ function PullDialog() {
   // Check if there are any changes to display
   const hasTokenChanges = Object.entries(changedPullState.tokens).length > 0;
   const hasThemeChanges = changedPullState.themes.length > 0;
-  const hasMetadataChanges = changedPullState.metadata?.tokenSetOrder && 
-                            Object.entries(changedPullState.metadata.tokenSetOrder).length > 0;
+  const hasMetadataChanges = changedPullState.metadata?.tokenSetOrder
+                            && Object.entries(changedPullState.metadata.tokenSetOrder).length > 0;
   const hasChanges = hasTokenChanges || hasThemeChanges || hasMetadataChanges;
 
   // Close the dialog if there are no changes to display
@@ -44,7 +46,7 @@ function PullDialog() {
       if (!hasChanges) {
         return null;
       }
-      
+
       return (
         <Modal
           title={t('pullFrom', { provider: transformProviderName(storageType.provider) })}

--- a/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
@@ -26,7 +26,10 @@ export function useChangedState() {
     return findDifferentState(remoteData, {
       tokens,
       themes,
-      metadata: storageType.provider !== StorageProviderType.LOCAL ? { tokenSetOrder } : {},
+      metadata: storageType.provider !== StorageProviderType.LOCAL ? {
+        tokenSetsData: remoteData.metadata?.tokenSetsData || {},
+        tokenSetOrder,
+      } : {},
     });
   }, [remoteData, tokens, themes, storageType]);
 
@@ -36,7 +39,10 @@ export function useChangedState() {
       {
         tokens,
         themes,
-        metadata: storageType.provider !== StorageProviderType.LOCAL ? { tokenSetOrder } : {},
+        metadata: storageType.provider !== StorageProviderType.LOCAL ? {
+          tokenSetsData: remoteData.metadata?.tokenSetsData || {},
+          tokenSetOrder,
+        } : {},
       },
       remoteData,
     );


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #3303 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Currently when a user has Tokens Studio synced with the plugin, and he pulls changes, even in the cases when there are no changes, he is prompted a delta in metadata configuration, and doesn't pull any changes, leading to a confusing user experience. 

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Setup a sync with studio
- Load tokens
- Make changes to studio, the plugin will display the changes and pull as expected
- Now pull again without making any change in studio, now nothing should happen after a loading state.

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
