### PR TITLE
Fix/3227

### DIFF
--- a/.changeset/brave-tables-divide.md
+++ b/.changeset/brave-tables-divide.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix to display border radius and border width tokens as tokens in the Inspect Panel in the plugin, instead of variables.Only native variables applied from Figma will be displayed as variables.

--- a/packages/tokens-studio-for-figma/src/plugin/applyBorderRadiusValuesOnNode.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/applyBorderRadiusValuesOnNode.ts
@@ -23,16 +23,7 @@ export async function applyBorderRadiusValuesOnNode(
       switch (individualBorderRadius.length) {
         case 1:
           if ('cornerRadius' in node) {
-            if (
-              !(
-                (await tryApplyVariableId(node, 'topLeftRadius', data.borderRadius))
-                && (await tryApplyVariableId(node, 'topRightRadius', data.borderRadius))
-                && (await tryApplyVariableId(node, 'bottomRightRadius', data.borderRadius))
-                && (await tryApplyVariableId(node, 'bottomLeftRadius', data.borderRadius))
-              )
-            ) {
-              node.cornerRadius = transformValue(String(values.borderRadius), 'borderRadius', baseFontSize);
-            }
+            node.cornerRadius = transformValue(String(values.borderRadius), 'borderRadius', baseFontSize);
           }
           break;
         case 2:

--- a/packages/tokens-studio-for-figma/src/plugin/applyBorderRadiusValuesOnNode.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/applyBorderRadiusValuesOnNode.ts
@@ -23,7 +23,16 @@ export async function applyBorderRadiusValuesOnNode(
       switch (individualBorderRadius.length) {
         case 1:
           if ('cornerRadius' in node) {
-            node.cornerRadius = transformValue(String(values.borderRadius), 'borderRadius', baseFontSize);
+            if (
+              !(
+                (await tryApplyVariableId(node, 'topLeftRadius', data.borderRadius))
+                && (await tryApplyVariableId(node, 'topRightRadius', data.borderRadius))
+                && (await tryApplyVariableId(node, 'bottomRightRadius', data.borderRadius))
+                && (await tryApplyVariableId(node, 'bottomLeftRadius', data.borderRadius))
+              )
+            ) {
+              node.cornerRadius = transformValue(String(values.borderRadius), 'borderRadius', baseFontSize);
+            }
           }
           break;
         case 2:

--- a/packages/tokens-studio-for-figma/src/utils/convertVariableTypeToProperty.ts
+++ b/packages/tokens-studio-for-figma/src/utils/convertVariableTypeToProperty.ts
@@ -12,6 +12,16 @@ export default function convertVariableTypeToProperty(variableType: string): Pro
       return 'borderRadiusBottomLeft' as Properties;
     case 'bottomRightRadius':
       return 'borderRadiusBottomRight' as Properties;
+    case 'strokeWeight':
+      return 'borderWidth' as Properties;
+    case 'strokeTopWeight':
+      return 'borderWidthTop' as Properties;
+    case 'strokeRightWeight':
+      return 'borderWidthRight' as Properties;
+    case 'strokeBottomWeight':
+      return 'borderWidthBottom' as Properties;
+    case 'strokeLeftWeight':
+      return 'borderWidthLeft' as Properties;
     default:
       return variableType as Properties;
   }


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #3227 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Currently, when users apply border radius/border width on a layer in Figma, it is applied as variable when we apply as token from our plugin, when we inspect in our Inspect Panel. Tokens should be displayed as variables when we apply a variable from Figma directly.
This PR addresses that, when we apply tokens as token, it displays as token, and when we apply as variables, it displays as variable.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Export tokens as variables
- Apply border radius/border width as token
- Check inspect panel on the layer, it should be displayed as tokens
- Now create another layer and apply it as variables exported directly from Figma
- It should now reflect the applied variable in the Inspect panel in our plugin.

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)


https://github.com/user-attachments/assets/c1837aa0-5d62-4eee-bb9f-9baf23886d29



<!--
  Add any other context or screenshots about the pull request
-->
