### PR TITLE
Fix outdated turbo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://turbo.build/schema.json",
     "globalDependencies": ["**/.env.*local"],
-    "pipeline": {
+    "tasks": {
       "build": {
         "dependsOn": ["^build"],
         "outputs": [".next/**", "dist/**", "!.next/cache/**"]


### PR DESCRIPTION
## Summary
- update turbo.json to use `tasks` instead of deprecated `pipeline`

## Testing
- `yarn lint` *(fails: ESLint couldn't find configuration file)*
- `yarn test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840234652688331be71eb6c1ee439ca