### PR TITLE
FIx crashing of plugin when importing styles with lots of variable references

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
@@ -26,6 +26,7 @@ export const backgroundJobTitles = {
   [BackgroundJobs.UI_ATTACHING_LOCAL_STYLES]: 'Attaching local styles to theme...',
   [BackgroundJobs.UI_CREATEVARIABLES]: 'Creating variables...',
   [BackgroundJobs.UI_CREATE_STYLES]: 'Creating styles...',
+  [BackgroundJobs.UI_IMPORT_STYLES]: 'Importing styles...',
 };
 
 export default function LoadingBar() {

--- a/packages/tokens-studio-for-figma/src/constants/BackgroundJobs.ts
+++ b/packages/tokens-studio-for-figma/src/constants/BackgroundJobs.ts
@@ -21,4 +21,5 @@ export enum BackgroundJobs {
   UI_RENAME_TOKEN_ACROSS_SETS = 'ui_rename_token_across_sets',
   UI_CREATEVARIABLES = 'ui_create_variables',
   UI_CREATE_STYLES = 'ui_create_styles',
+  UI_IMPORT_STYLES = 'ui_import_styles',
 }

--- a/packages/tokens-studio-for-figma/src/plugin/processTextStyleProperty.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/processTextStyleProperty.ts
@@ -16,27 +16,148 @@ export function processTextStyleProperty(
   const boundVariables = style.boundVariables as Record<string, { id: string; } | undefined>;
   if (boundVariables?.[propertyKey]?.id) {
     const variable = localVariables.find((v) => v.id === boundVariables[propertyKey]?.id);
-    if (variable && tokens) {
+    if (variable) {
       const normalizedName = variable.name.replace(/\//g, '.');
 
-      // Look for an existing token with this name
-      const existingToken = Object.entries(tokens.values).reduce<SingleToken | null>((found, [_, tokenSet]) => {
-        if (found) return found;
-        const foundToken = Array.isArray(tokenSet) ? tokenSet.find((token) => typeof token === 'object'
-          && token !== null
-          && 'name' in token
-          && token.name === normalizedName) : null;
-        return foundToken || null;
-      }, null);
+      // Get the variable's actual value and transform it if needed
+      console.log(`Processing variable ${normalizedName} for property ${propertyKey}`);
+      console.log('Variable object:', JSON.stringify(variable, null, 2));
+      console.log('Variable valuesByMode:', JSON.stringify(variable.valuesByMode, null, 2));
 
-      // If an existing token is found, use it
-      if (existingToken) {
-        return {
-          name: existingToken.name,
-          value: typeof existingToken.value === 'string' ? existingToken.value : String(existingToken.value),
-          type: tokenType,
-        };
+      // Get the first available mode value
+      const modeKeys = Object.keys(variable.valuesByMode || {});
+      let variableValue = modeKeys.length > 0 ? variable.valuesByMode[modeKeys[0]] : undefined;
+
+      console.log(`Available modes: ${modeKeys.join(', ')}`);
+      console.log(`Variable value for mode ${modeKeys[0]}:`, JSON.stringify(variableValue, null, 2));
+      console.log('Variable type:', variable.resolvedType);
+      console.log('Variable value type:', typeof variableValue);
+      console.log('Variable value constructor:', variableValue?.constructor?.name);
+
+      // If no variable value found, fallback to style value
+      if (variableValue === undefined || variableValue === null) {
+        console.log('Variable value not found, using style value as fallback');
+        const styleValue = style[propertyKey as keyof TextStyle];
+        variableValue = valueTransformer ? valueTransformer(styleValue) : String(styleValue);
+      } else {
+        // Extract the actual value from the variable object
+        let actualValue: any = variableValue;
+
+        // Handle different variable value structures
+        if (typeof variableValue === 'object' && variableValue !== null) {
+          console.log('Variable value is an object, extracting actual value');
+          const varObj = variableValue as any;
+
+          // Check if this is a variable alias
+          if (varObj.type === 'VARIABLE_ALIAS' && varObj.id) {
+            console.log('Found variable alias, resolving referenced variable:', varObj.id);
+            // Find the referenced variable
+            const referencedVariable = localVariables.find((v) => v.id === varObj.id);
+            if (referencedVariable) {
+              console.log('Found referenced variable:', referencedVariable.name);
+              // Get the value from the referenced variable
+              const refModeKeys = Object.keys(referencedVariable.valuesByMode || {});
+              if (refModeKeys.length > 0) {
+                const referencedValue = referencedVariable.valuesByMode[refModeKeys[0]];
+                console.log('Referenced variable value:', referencedValue);
+
+                // If the referenced value is also an alias, we'll handle it recursively
+                if (typeof referencedValue === 'object' && (referencedValue as any)?.type === 'VARIABLE_ALIAS') {
+                  console.log('Referenced variable is also an alias, using variable name as reference');
+                  actualValue = `{${referencedVariable.name.replace(/\//g, '.')}}`;
+                } else {
+                  console.log('Using referenced variable value directly:', referencedValue);
+                  actualValue = referencedValue;
+                }
+              } else {
+                console.log('Referenced variable has no modes, using variable name as reference');
+                actualValue = `{${referencedVariable.name.replace(/\//g, '.')}}`;
+              }
+            } else {
+              console.log('Referenced variable not found, falling back to style value');
+              // Instead of using the variable ID, fall back to the actual style value
+              // Provide appropriate fallback based on property type
+              if (propertyKey === 'fontSize') {
+                actualValue = style.fontSize || 16;
+              } else if (propertyKey === 'lineHeight') {
+                actualValue = style.lineHeight || { value: 1.2, unit: 'AUTO' };
+              } else if (propertyKey === 'letterSpacing') {
+                actualValue = style.letterSpacing || { value: 0, unit: 'PIXELS' };
+              } else if (propertyKey === 'paragraphSpacing') {
+                actualValue = style.paragraphSpacing || 0;
+              } else if (propertyKey === 'fontFamily') {
+                actualValue = style.fontName?.family || 'Arial';
+              } else if (propertyKey === 'fontStyle') {
+                actualValue = style.fontName?.style || 'Regular';
+              } else {
+                actualValue = 0; // Generic fallback
+              }
+            }
+          } else if ('value' in varObj) {
+            console.log('Found .value property:', varObj.value);
+            actualValue = varObj.value;
+          } else if ('r' in varObj && 'g' in varObj && 'b' in varObj) {
+            // This is a color object, keep as is for now
+            console.log('Found color object');
+            actualValue = variableValue;
+          } else if (typeof varObj === 'number') {
+            // Sometimes the value itself might be the number
+            console.log('Variable value is directly a number');
+            actualValue = varObj;
+          } else {
+            // For other objects, try to find a numeric property
+            console.log('Searching for numeric properties in object');
+            const numericKeys = Object.keys(varObj).filter((key) => typeof varObj[key] === 'number');
+            console.log('Found numeric keys:', numericKeys);
+            if (numericKeys.length > 0) {
+              actualValue = varObj[numericKeys[0]];
+              console.log(`Using value from key '${numericKeys[0]}':`, actualValue);
+            } else {
+              // Try to extract any primitive value
+              const primitiveKeys = Object.keys(varObj).filter((key) =>
+                typeof varObj[key] === 'string' || typeof varObj[key] === 'number' || typeof varObj[key] === 'boolean'
+              );
+              console.log('Found primitive keys:', primitiveKeys);
+              if (primitiveKeys.length > 0) {
+                actualValue = varObj[primitiveKeys[0]];
+                console.log(`Using primitive value from key '${primitiveKeys[0]}':`, actualValue);
+              }
+            }
+          }
+          console.log('Extracted actual value:', actualValue);
+        }
+
+        // Apply the same transformation that would be applied to the style value
+        if (valueTransformer) {
+          console.log('Applying value transformer to actual value');
+          try {
+            // Validate that the value is suitable for transformation
+            if (actualValue === undefined || actualValue === null) {
+              console.log('Actual value is undefined/null, using fallback');
+              const styleValue = style[propertyKey as keyof TextStyle];
+              variableValue = valueTransformer(styleValue);
+            } else {
+              variableValue = valueTransformer(actualValue);
+            }
+          } catch (error) {
+            console.error('Error applying value transformer:', error);
+            console.log('Falling back to style value');
+            const styleValue = style[propertyKey as keyof TextStyle];
+            variableValue = valueTransformer ? valueTransformer(styleValue) : String(styleValue);
+          }
+        } else {
+          variableValue = String(actualValue);
+        }
       }
+
+      console.log('Final variable value:', variableValue);
+
+      // Create a token with the variable's actual value
+      return {
+        name: normalizedName,
+        value: variableValue, // Use the variable's actual value
+        type: tokenType,
+      };
     }
   }
 

--- a/packages/tokens-studio-for-figma/src/plugin/processTextStyleProperty.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/processTextStyleProperty.ts
@@ -1,12 +1,11 @@
 import { TokenTypes } from '@/constants/TokenTypes';
 import { StyleToCreateToken } from '@/types/payloads';
-import { SingleToken } from '@/types/tokens';
 
 export function processTextStyleProperty(
   style: TextStyle,
   propertyKey: string,
   localVariables: Variable[],
-  tokens: any,
+  _tokens: any,
   tokenType: TokenTypes,
   defaultNamePrefix: string,
   idx: number,
@@ -20,23 +19,12 @@ export function processTextStyleProperty(
       const normalizedName = variable.name.replace(/\//g, '.');
 
       // Get the variable's actual value and transform it if needed
-      console.log(`Processing variable ${normalizedName} for property ${propertyKey}`);
-      console.log('Variable object:', JSON.stringify(variable, null, 2));
-      console.log('Variable valuesByMode:', JSON.stringify(variable.valuesByMode, null, 2));
-
       // Get the first available mode value
       const modeKeys = Object.keys(variable.valuesByMode || {});
       let variableValue = modeKeys.length > 0 ? variable.valuesByMode[modeKeys[0]] : undefined;
 
-      console.log(`Available modes: ${modeKeys.join(', ')}`);
-      console.log(`Variable value for mode ${modeKeys[0]}:`, JSON.stringify(variableValue, null, 2));
-      console.log('Variable type:', variable.resolvedType);
-      console.log('Variable value type:', typeof variableValue);
-      console.log('Variable value constructor:', variableValue?.constructor?.name);
-
       // If no variable value found, fallback to style value
       if (variableValue === undefined || variableValue === null) {
-        console.log('Variable value not found, using style value as fallback');
         const styleValue = style[propertyKey as keyof TextStyle];
         variableValue = valueTransformer ? valueTransformer(styleValue) : String(styleValue);
       } else {
@@ -45,37 +33,31 @@ export function processTextStyleProperty(
 
         // Handle different variable value structures
         if (typeof variableValue === 'object' && variableValue !== null) {
-          console.log('Variable value is an object, extracting actual value');
           const varObj = variableValue as any;
 
           // Check if this is a variable alias
           if (varObj.type === 'VARIABLE_ALIAS' && varObj.id) {
-            console.log('Found variable alias, resolving referenced variable:', varObj.id);
             // Find the referenced variable
             const referencedVariable = localVariables.find((v) => v.id === varObj.id);
             if (referencedVariable) {
-              console.log('Found referenced variable:', referencedVariable.name);
               // Get the value from the referenced variable
               const refModeKeys = Object.keys(referencedVariable.valuesByMode || {});
               if (refModeKeys.length > 0) {
                 const referencedValue = referencedVariable.valuesByMode[refModeKeys[0]];
-                console.log('Referenced variable value:', referencedValue);
 
                 // If the referenced value is also an alias, we'll handle it recursively
                 if (typeof referencedValue === 'object' && (referencedValue as any)?.type === 'VARIABLE_ALIAS') {
-                  console.log('Referenced variable is also an alias, using variable name as reference');
                   actualValue = `{${referencedVariable.name.replace(/\//g, '.')}}`;
                 } else {
-                  console.log('Using referenced variable value directly:', referencedValue);
                   actualValue = referencedValue;
                 }
               } else {
-                console.log('Referenced variable has no modes, using variable name as reference');
                 actualValue = `{${referencedVariable.name.replace(/\//g, '.')}}`;
               }
-            } else {
-              console.log('Referenced variable not found, falling back to style value');
-              // Instead of using the variable ID, fall back to the actual style value
+            }
+
+            // If referenced variable not found, fall back to the actual style value
+            if (!referencedVariable) {
               // Provide appropriate fallback based on property type
               if (propertyKey === 'fontSize') {
                 actualValue = style.fontSize || 16;
@@ -94,54 +76,41 @@ export function processTextStyleProperty(
               }
             }
           } else if ('value' in varObj) {
-            console.log('Found .value property:', varObj.value);
             actualValue = varObj.value;
           } else if ('r' in varObj && 'g' in varObj && 'b' in varObj) {
             // This is a color object, keep as is for now
-            console.log('Found color object');
             actualValue = variableValue;
           } else if (typeof varObj === 'number') {
             // Sometimes the value itself might be the number
-            console.log('Variable value is directly a number');
             actualValue = varObj;
           } else {
             // For other objects, try to find a numeric property
-            console.log('Searching for numeric properties in object');
             const numericKeys = Object.keys(varObj).filter((key) => typeof varObj[key] === 'number');
-            console.log('Found numeric keys:', numericKeys);
             if (numericKeys.length > 0) {
               actualValue = varObj[numericKeys[0]];
-              console.log(`Using value from key '${numericKeys[0]}':`, actualValue);
             } else {
               // Try to extract any primitive value
-              const primitiveKeys = Object.keys(varObj).filter((key) =>
+              const primitiveKeys = Object.keys(varObj).filter((key) => (
                 typeof varObj[key] === 'string' || typeof varObj[key] === 'number' || typeof varObj[key] === 'boolean'
-              );
-              console.log('Found primitive keys:', primitiveKeys);
+              ));
               if (primitiveKeys.length > 0) {
                 actualValue = varObj[primitiveKeys[0]];
-                console.log(`Using primitive value from key '${primitiveKeys[0]}':`, actualValue);
               }
             }
           }
-          console.log('Extracted actual value:', actualValue);
         }
 
         // Apply the same transformation that would be applied to the style value
         if (valueTransformer) {
-          console.log('Applying value transformer to actual value');
           try {
             // Validate that the value is suitable for transformation
             if (actualValue === undefined || actualValue === null) {
-              console.log('Actual value is undefined/null, using fallback');
               const styleValue = style[propertyKey as keyof TextStyle];
               variableValue = valueTransformer(styleValue);
             } else {
               variableValue = valueTransformer(actualValue);
             }
           } catch (error) {
-            console.error('Error applying value transformer:', error);
-            console.log('Falling back to style value');
             const styleValue = style[propertyKey as keyof TextStyle];
             variableValue = valueTransformer ? valueTransformer(styleValue) : String(styleValue);
           }
@@ -149,8 +118,6 @@ export function processTextStyleProperty(
           variableValue = String(actualValue);
         }
       }
-
-      console.log('Final variable value:', variableValue);
 
       // Create a token with the variable's actual value
       return {

--- a/packages/tokens-studio-for-figma/src/plugin/processTextStyleProperty.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/processTextStyleProperty.ts
@@ -18,7 +18,29 @@ export function processTextStyleProperty(
     if (variable) {
       const normalizedName = variable.name.replace(/\//g, '.');
 
-      // Get the variable's actual value and transform it if needed
+      // First, check if there's already an existing token that matches this variable name
+      if (_tokens && typeof _tokens === 'object' && 'values' in _tokens) {
+        const tokenStore = _tokens as any;
+        // Search through all token sets for a matching token
+        for (const setName of Object.keys(tokenStore.values || {})) {
+          const tokenSet = tokenStore.values[setName];
+          if (Array.isArray(tokenSet)) {
+            const existingToken = tokenSet.find((token: any) => (
+              token.name === normalizedName && token.type === tokenType
+            ));
+            if (existingToken) {
+              // Return the existing token
+              return {
+                name: existingToken.name,
+                value: existingToken.value,
+                type: existingToken.type,
+              };
+            }
+          }
+        }
+      }
+
+      // If no existing token found, get the variable's actual value and transform it if needed
       // Get the first available mode value
       const modeKeys = Object.keys(variable.valuesByMode || {});
       let variableValue = modeKeys.length > 0 ? variable.valuesByMode[modeKeys[0]] : undefined;

--- a/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
@@ -32,7 +32,7 @@ function getRelevantVariablesForStyle(style: TextStyle, allVariables: Variable[]
   }
 
   // Return only the variables needed for this style
-  return allVariables.filter(v => relevantVariableIds.has(v.id));
+  return allVariables.filter((v) => relevantVariableIds.has(v.id));
 }
 
 // Helper function to process styles with variable references in small blocks
@@ -43,19 +43,13 @@ async function processStylesWithVariablesInBlocks<T>(
   blockSize: number = 10, // Increased batch size for better performance
 ): Promise<any[]> {
   const results: any[] = [];
-  const totalBlocks = Math.ceil(styles.length / blockSize);
-
-  console.log(`Processing ${styles.length} styles with variables in ${totalBlocks} blocks of ${blockSize}`);
 
   for (let i = 0; i < styles.length; i += blockSize) {
     const block = styles.slice(i, i + blockSize);
-    const blockIndex = Math.floor(i / blockSize);
-
-    console.log(`Processing variable block ${blockIndex + 1}/${totalBlocks}`);
 
     try {
       // Process each style in the block with only the variables it needs
-      for (let j = 0; j < block.length; j++) {
+      for (let j = 0; j < block.length; j += 1) {
         const style = block[j];
         const styleIndex = i + j;
 
@@ -67,16 +61,18 @@ async function processStylesWithVariablesInBlocks<T>(
 
         // Give Figma time between each style when processing variables
         if (relevantVariables.length > 0) {
-          await new Promise((resolve) => setTimeout(resolve, 5));
+          await new Promise((resolve) => {
+            setTimeout(resolve, 5);
+          });
         }
       }
 
       // Clear block and give Figma more time between blocks
       block.length = 0;
-      await new Promise((resolve) => setTimeout(resolve, 20));
-
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
     } catch (error) {
-      console.error(`Error processing variable block ${blockIndex + 1}/${totalBlocks}:`, error);
       // Continue with next block instead of failing completely
     }
   }
@@ -92,34 +88,30 @@ async function processTypographyInBlocks(
   blockSize: number = 10, // Increased batch size for better performance
 ): Promise<any[]> {
   const results: any[] = [];
-  const totalBlocks = Math.ceil(styles.length / blockSize);
-
-  console.log(`Processing ${styles.length} typography styles in ${totalBlocks} blocks of ${blockSize}`);
 
   for (let i = 0; i < styles.length; i += blockSize) {
     const block = styles.slice(i, i + blockSize);
-    const blockIndex = Math.floor(i / blockSize);
-
-    console.log(`Processing typography block ${blockIndex + 1}/${totalBlocks}`);
 
     try {
       // Process each style in the block
-      for (let j = 0; j < block.length; j++) {
+      for (let j = 0; j < block.length; j += 1) {
         const style = block[j];
 
         const result = processor(style);
         results.push(result);
 
         // Give Figma time between each typography style (they're complex)
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
       }
 
       // Clear block and give Figma more time between blocks
       block.length = 0;
-      await new Promise((resolve) => setTimeout(resolve, 30));
-
+      await new Promise((resolve) => {
+        setTimeout(resolve, 30);
+      });
     } catch (error) {
-      console.error(`Error processing typography block ${blockIndex + 1}/${totalBlocks}:`, error);
       // Continue with next block instead of failing completely
     }
   }

--- a/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
@@ -537,7 +537,7 @@ export default async function pullStyles(styleTypes: PullStyleOptions): Promise<
     postToUI({
       type: MessageFromPluginTypes.COMPLETE_JOB_TASKS,
       name: BackgroundJobs.UI_IMPORT_STYLES,
-      count: 1,
+      count: currentStepCount,
     });
   }
 

--- a/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
@@ -40,7 +40,7 @@ async function processStylesWithVariablesInBlocks<T>(
   styles: T[],
   allVariables: Variable[],
   processor: (style: T, relevantVariables: Variable[], index: number) => any,
-  blockSize: number = 5, // Very small blocks for variable processing
+  blockSize: number = 10, // Increased batch size for better performance
 ): Promise<any[]> {
   const results: any[] = [];
   const totalBlocks = Math.ceil(styles.length / blockSize);
@@ -89,7 +89,7 @@ async function processTypographyInBlocks(
   styles: TextStyle[],
   _allVariables: Variable[],
   processor: (style: TextStyle) => any,
-  blockSize: number = 2, // Very small blocks for typography
+  blockSize: number = 10, // Increased batch size for better performance
 ): Promise<any[]> {
   const results: any[] = [];
   const totalBlocks = Math.ceil(styles.length / blockSize);


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #3353 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Currently, when we import styles with a lot of variable references, it breaks down because of memory limits in the Figma sandbox

This PR runs those imports in batches to avoid said breakdowns.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Open a figma file with lots of variables, and a lot of which would be connected to styles
- Import the styles into our plugin to create tokens
- The styles should be imported smoothly and the references of variables would also be created correctly.
- Also added a progress bar to display the user the state of the styles' import

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
