### PR TITLE
fix border width not applying on ellipses as variable references in Figma

### DIFF
--- a/.changeset/curvy-needles-nail.md
+++ b/.changeset/curvy-needles-nail.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-Fix issue of border width not applying as variable in Figma for non-rectangular shapes like ellipses or ovals
+Fix issue of border width not applying as variable in Figma for non-rectangular shapes like ellipses, ovals or text nodes.

--- a/.changeset/curvy-needles-nail.md
+++ b/.changeset/curvy-needles-nail.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix issue of border width not applying as variable in Figma for non-rectangular shapes like ellipses or ovals

--- a/packages/tokens-studio-for-figma/src/plugin/__tests__/applyBorderWidthValuesOnNode.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/__tests__/applyBorderWidthValuesOnNode.test.ts
@@ -1,0 +1,205 @@
+import { applyBorderWidthValuesOnNode } from '../applyBorderWidthValuesOnNode';
+import { tryApplyVariableId } from '../../utils/tryApplyVariableId';
+
+// Mock the tryApplyVariableId function
+jest.mock('../../utils/tryApplyVariableId');
+const mockTryApplyVariableId = tryApplyVariableId as jest.MockedFunction<typeof tryApplyVariableId>;
+
+describe('applyBorderWidthValuesOnNode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should apply variable to strokeWeight for ELLIPSE nodes', async () => {
+    // Mock an ELLIPSE node that only has strokeWeight
+    const ellipseNode = {
+      type: 'ELLIPSE',
+      strokeWeight: 0,
+      // ELLIPSE nodes don't have individual stroke weight properties
+    } as unknown as EllipseNode;
+
+    const data = {
+      borderWidth: 'border-width-token',
+    };
+
+    const values = {
+      borderWidth: '4',
+    };
+
+    const baseFontSize = '16';
+
+    // Mock tryApplyVariableId to return true for strokeWeight
+    mockTryApplyVariableId.mockImplementation(async (node, type, token) => {
+      if (type === 'strokeWeight' && token === 'border-width-token') {
+        return true;
+      }
+      return false;
+    });
+
+    await applyBorderWidthValuesOnNode(ellipseNode, data, values, baseFontSize);
+
+    // Should try to apply variable to strokeWeight directly
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(ellipseNode, 'strokeWeight', 'border-width-token');
+    
+    // Should not try to apply to individual stroke weight properties
+    expect(mockTryApplyVariableId).not.toHaveBeenCalledWith(ellipseNode, 'strokeTopWeight', expect.any(String));
+    expect(mockTryApplyVariableId).not.toHaveBeenCalledWith(ellipseNode, 'strokeRightWeight', expect.any(String));
+    expect(mockTryApplyVariableId).not.toHaveBeenCalledWith(ellipseNode, 'strokeBottomWeight', expect.any(String));
+    expect(mockTryApplyVariableId).not.toHaveBeenCalledWith(ellipseNode, 'strokeLeftWeight', expect.any(String));
+
+    // Should not set raw value since variable was applied successfully
+    expect(ellipseNode.strokeWeight).toBe(0);
+  });
+
+  it('should apply variable to individual stroke weights for RECTANGLE nodes', async () => {
+    // Mock a RECTANGLE node that has individual stroke weight properties
+    const rectangleNode = {
+      type: 'RECTANGLE',
+      strokeWeight: 0,
+      strokeTopWeight: 0,
+      strokeRightWeight: 0,
+      strokeBottomWeight: 0,
+      strokeLeftWeight: 0,
+    } as unknown as RectangleNode;
+
+    const data = {
+      borderWidth: 'border-width-token',
+    };
+
+    const values = {
+      borderWidth: '4',
+    };
+
+    const baseFontSize = '16';
+
+    // Mock tryApplyVariableId to return true for all individual stroke weights
+    mockTryApplyVariableId.mockImplementation(async (node, type, token) => {
+      if (token === 'border-width-token' && 
+          ['strokeTopWeight', 'strokeRightWeight', 'strokeBottomWeight', 'strokeLeftWeight'].includes(type)) {
+        return true;
+      }
+      return false;
+    });
+
+    await applyBorderWidthValuesOnNode(rectangleNode, data, values, baseFontSize);
+
+    // Should try to apply variable to all individual stroke weight properties
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeTopWeight', 'border-width-token');
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeRightWeight', 'border-width-token');
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeBottomWeight', 'border-width-token');
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeLeftWeight', 'border-width-token');
+
+    // Should not try to apply to strokeWeight directly
+    expect(mockTryApplyVariableId).not.toHaveBeenCalledWith(rectangleNode, 'strokeWeight', expect.any(String));
+
+    // Should not set raw value since variable was applied successfully
+    expect(rectangleNode.strokeWeight).toBe(0);
+  });
+
+  it('should fall back to raw value for ELLIPSE when variable application fails', async () => {
+    // Mock an ELLIPSE node that only has strokeWeight
+    const ellipseNode = {
+      type: 'ELLIPSE',
+      strokeWeight: 0,
+    } as unknown as EllipseNode;
+
+    const data = {
+      borderWidth: 'border-width-token',
+    };
+
+    const values = {
+      borderWidth: '4',
+    };
+
+    const baseFontSize = '16';
+
+    // Mock tryApplyVariableId to return false (variable application failed)
+    mockTryApplyVariableId.mockResolvedValue(false);
+
+    await applyBorderWidthValuesOnNode(ellipseNode, data, values, baseFontSize);
+
+    // Should try to apply variable to strokeWeight
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(ellipseNode, 'strokeWeight', 'border-width-token');
+
+    // Should fall back to setting raw value
+    expect(ellipseNode.strokeWeight).toBe(4);
+  });
+
+  it('should fall back to raw value for RECTANGLE when variable application fails', async () => {
+    // Mock a RECTANGLE node that has individual stroke weight properties
+    const rectangleNode = {
+      type: 'RECTANGLE',
+      strokeWeight: 0,
+      strokeTopWeight: 0,
+      strokeRightWeight: 0,
+      strokeBottomWeight: 0,
+      strokeLeftWeight: 0,
+    } as unknown as RectangleNode;
+
+    const data = {
+      borderWidth: 'border-width-token',
+    };
+
+    const values = {
+      borderWidth: '4',
+    };
+
+    const baseFontSize = '16';
+
+    // Mock tryApplyVariableId to return false (variable application failed)
+    mockTryApplyVariableId.mockResolvedValue(false);
+
+    await applyBorderWidthValuesOnNode(rectangleNode, data, values, baseFontSize);
+
+    // Should try to apply variable to strokeTopWeight first (due to short-circuit evaluation)
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeTopWeight', 'border-width-token');
+
+    // Due to short-circuit evaluation with &&, if the first call fails, the rest won't be called
+    // This is the expected behavior since we need ALL to succeed for variable application to work
+
+    // Should fall back to setting raw value
+    expect(rectangleNode.strokeWeight).toBe(4);
+  });
+
+  it('should handle partial variable application for RECTANGLE nodes', async () => {
+    // Mock a RECTANGLE node that has individual stroke weight properties
+    const rectangleNode = {
+      type: 'RECTANGLE',
+      strokeWeight: 0,
+      strokeTopWeight: 0,
+      strokeRightWeight: 0,
+      strokeBottomWeight: 0,
+      strokeLeftWeight: 0,
+    } as unknown as RectangleNode;
+
+    const data = {
+      borderWidth: 'border-width-token',
+    };
+
+    const values = {
+      borderWidth: '4',
+    };
+
+    const baseFontSize = '16';
+
+    // Mock tryApplyVariableId to return true for top and right, but fail for bottom
+    mockTryApplyVariableId.mockImplementation(async (node, type, token) => {
+      if (token === 'border-width-token') {
+        // Succeed for top and right, fail for bottom (left won't be called due to short-circuit)
+        return type === 'strokeTopWeight' || type === 'strokeRightWeight';
+      }
+      return false;
+    });
+
+    await applyBorderWidthValuesOnNode(rectangleNode, data, values, baseFontSize);
+
+    // Should try to apply variable to stroke weight properties until one fails
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeTopWeight', 'border-width-token');
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeRightWeight', 'border-width-token');
+    expect(mockTryApplyVariableId).toHaveBeenCalledWith(rectangleNode, 'strokeBottomWeight', 'border-width-token');
+    // strokeLeftWeight won't be called due to short-circuit evaluation when strokeBottomWeight fails
+
+    // Should fall back to setting raw value since not all variables were applied
+    expect(rectangleNode.strokeWeight).toBe(4);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/__tests__/setValuesOnNode.test.ts
@@ -845,6 +845,78 @@ describe('Can set values on node', () => {
     expect(solidNodeMock).toEqual({ ...solidNodeMock, strokes: [], cornerRadius: 0 });
   });
 
+  it('should apply border width to ELLIPSE node correctly', async () => {
+    // Mock an ELLIPSE node that only has strokeWeight, not individual stroke weight properties
+    const ellipseNodeMock = ({
+      id: '123:459',
+      type: 'ELLIPSE',
+      strokeWeight: 0,
+      opacity: 1,
+      effects: [],
+      fills: [],
+      strokes: [],
+      effectStyleId: '',
+      fillStyleId: '',
+      strokeStyleId: '',
+      dashPattern: [],
+      visible: true,
+      getSharedPluginData: () => '',
+      setSharedPluginData: () => undefined,
+      // Note: ELLIPSE nodes don't have strokeTopWeight, strokeRightWeight, etc.
+    } as unknown) as EllipseNode;
+
+    const values = {
+      borderWidth: '3',
+    };
+
+    const data = {
+      borderWidth: 'border-width-3',
+    };
+
+    await setValuesOnNode({ node: ellipseNodeMock, values, data });
+
+    // The border width should be applied to strokeWeight
+    expect(ellipseNodeMock.strokeWeight).toEqual(3);
+  });
+
+  it('should apply border width to RECTANGLE node with individual stroke weights', async () => {
+    // Mock a RECTANGLE node that has individual stroke weight properties
+    const rectangleNodeMock = ({
+      id: '123:460',
+      type: 'RECTANGLE',
+      strokeWeight: 0,
+      strokeTopWeight: 0,
+      strokeRightWeight: 0,
+      strokeBottomWeight: 0,
+      strokeLeftWeight: 0,
+      opacity: 1,
+      effects: [],
+      fills: [],
+      strokes: [],
+      effectStyleId: '',
+      fillStyleId: '',
+      strokeStyleId: '',
+      dashPattern: [],
+      visible: true,
+      getSharedPluginData: () => '',
+      setSharedPluginData: () => undefined,
+    } as unknown) as RectangleNode;
+
+    const values = {
+      borderWidth: '3',
+    };
+
+    const data = {
+      borderWidth: 'border-width-3',
+    };
+
+    await setValuesOnNode({ node: rectangleNodeMock, values, data });
+
+    // For RECTANGLE nodes, the border width should be applied to strokeWeight
+    // (since we're not applying variables in this test, it falls back to raw value)
+    expect(rectangleNodeMock.strokeWeight).toEqual(3);
+  });
+
   it('can set boolean token for visibility', async () => {
     const values = {
       visibility: 'false',


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #3439 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

This Pull Request adds a check while applying stroke weight to a node, whether the node has properties like strokeweighttop, left, etc(for rectangule/frame nodes), then checks variable application for each corner.
If it doesn't have corners, then does a check only for strokeweight property of the node(if that exists) and applied variable to that shape(like oval, ellipses, text, etc.)

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Create an oval, ellipse/text node
- Create a border width token and export as variable
- now apply the border width as stroke on these shapes
- it should be applied as a variable

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
