### PR TITLE
Add living documentation generator

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ToolsDropdown.tsx
@@ -7,6 +7,7 @@ import { FileZipIcon } from '@primer/octicons-react';
 import { editProhibitedSelector } from '@/selectors';
 import PresetModal from './modals/PresetModal';
 import ExportModal from './modals/ExportModal';
+import LivingDocumentationModal from './modals/LivingDocumentationModal';
 
 export default function ToolsDropdown() {
   const editProhibited = useSelector(editProhibitedSelector);
@@ -15,6 +16,7 @@ export default function ToolsDropdown() {
 
   const [presetModalVisible, showPresetModal] = React.useState(false);
   const [exportModalVisible, showExportModal] = React.useState(false);
+  const [docModalVisible, showDocModal] = React.useState(false);
 
   const handleCloseExportModal = useCallback(() => {
     showExportModal(false);
@@ -24,11 +26,18 @@ export default function ToolsDropdown() {
     showPresetModal(false);
   }, []);
 
+  const handleCloseDocModal = useCallback(() => {
+    showDocModal(false);
+  }, []);
+
   const handleShowPresetModal = useCallback(() => {
     showPresetModal(true);
   }, []);
   const handleShowExportModal = useCallback(() => {
     showExportModal(true);
+  }, []);
+  const handleShowDocModal = useCallback(() => {
+    showDocModal(true);
   }, []);
 
   return (
@@ -39,14 +48,16 @@ export default function ToolsDropdown() {
         </DropdownMenu.Trigger>
 
         <DropdownMenu.Portal>
-          <DropdownMenu.Content side="top">
-            <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowPresetModal}>{t('loadFromFileOrPreset')}</DropdownMenu.Item>
-            <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowExportModal}>{t('exportToFile')}</DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu.Portal>
+        <DropdownMenu.Content side="top">
+          <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowPresetModal}>{t('loadFromFileOrPreset')}</DropdownMenu.Item>
+          <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowExportModal}>{t('exportToFile')}</DropdownMenu.Item>
+          <DropdownMenu.Item disabled={editProhibited} onSelect={handleShowDocModal}>Generate documentation</DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
       </DropdownMenu>
       {exportModalVisible && <ExportModal onClose={handleCloseExportModal} />}
       {presetModalVisible && <PresetModal onClose={handleClosePresetModal} />}
+      {docModalVisible && <LivingDocumentationModal isOpen onClose={handleCloseDocModal} />}
     </>
   );
 }

--- a/packages/tokens-studio-for-figma/src/app/components/modals/LivingDocumentationModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/modals/LivingDocumentationModal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Button, Stack } from '@tokens-studio/ui';
+import Modal from '../Modal';
+import Input from '../Input';
+import { AsyncMessageChannel } from '@/AsyncMessageChannel';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+
+type Props = { isOpen: boolean; onClose: () => void };
+
+export default function LivingDocumentationModal({ isOpen, onClose }: Props) {
+  const [tokenSet, setTokenSet] = React.useState('');
+  const [startsWith, setStartsWith] = React.useState('');
+
+  const handleGenerate = React.useCallback(() => {
+    AsyncMessageChannel.ReactInstance.message({
+      type: AsyncMessageTypes.CREATE_LIVING_DOCUMENTATION,
+      tokenSet,
+      startsWith,
+    });
+    onClose();
+  }, [tokenSet, startsWith, onClose]);
+
+  return (
+    <Modal title="Generate documentation" isOpen={isOpen} close={onClose} size="large">
+      <Stack direction="column" gap={4}>
+        <Input full label="Token set" value={tokenSet} onChange={(e) => setTokenSet(e.target.value)} />
+        <Input full label="Name starts with" value={startsWith} onChange={(e) => setStartsWith(e.target.value)} />
+        <Stack direction="row" justify="end" gap={4}>
+          <Button variant="secondary" onClick={onClose}>Cancel</Button>
+          <Button variant="primary" onClick={handleGenerate}>Generate</Button>
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+}

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createLivingDocumentation.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createLivingDocumentation.ts
@@ -1,0 +1,42 @@
+import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import { ValuesProperty, IsCompressedProperty } from '@/figmaStorage';
+import { SharedPluginDataNamespaces } from '@/constants/SharedPluginDataNamespaces';
+
+export const createLivingDocumentation: AsyncMessageChannelHandlers[AsyncMessageTypes.CREATE_LIVING_DOCUMENTATION] = async (msg) => {
+  const isCompressed = await IsCompressedProperty.read(figma.root) ?? false;
+  const values = await ValuesProperty.read(figma.root, isCompressed);
+  if (!values) return;
+  const { tokenSet, startsWith } = msg;
+  const tokens = values[tokenSet]?.filter((t) => t.name.startsWith(startsWith));
+  if (!tokens) return;
+  const [template] = figma.currentPage.selection;
+  if (!template) {
+    figma.notify('Select a template node first');
+    return;
+  }
+
+  const container = figma.createFrame();
+  container.layoutMode = 'VERTICAL';
+  container.itemSpacing = 16;
+  container.primaryAxisSizingMode = 'AUTO';
+  container.counterAxisSizingMode = 'AUTO';
+  container.paddingLeft = 32;
+  container.paddingRight = 32;
+  container.paddingTop = 32;
+  container.paddingBottom = 32;
+
+  for (const token of tokens) {
+    const clone = template.clone();
+    clone.name = token.name;
+    const placeholders = clone.findAll((n) => n.type === 'TEXT' && n.name.startsWith('__')) as TextNode[];
+    placeholders.forEach((node) => {
+      const prop = node.name.replace(/^__/, '');
+      node.characters = node.name;
+      node.setSharedPluginData(SharedPluginDataNamespaces.TOKENS, prop, JSON.stringify(token.name));
+    });
+    container.appendChild(clone);
+  }
+
+  figma.currentPage.appendChild(container);
+};

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/index.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/index.ts
@@ -43,3 +43,4 @@ export * from './preview';
 export * from './removeStylesWithoutConnection';
 export * from './setVariableExportSettings';
 export * from './setSelectedExportThemes';
+export * from './createLivingDocumentation';

--- a/packages/tokens-studio-for-figma/src/plugin/controller.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/controller.ts
@@ -47,6 +47,7 @@ AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CANCEL_OPERATION, as
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SET_SHOW_EMPTY_GROUPS, asyncHandlers.setShowEmptyGroups);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SET_UI, asyncHandlers.setUi);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CREATE_ANNOTATION, asyncHandlers.createAnnotation);
+AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CREATE_LIVING_DOCUMENTATION, asyncHandlers.createLivingDocumentation);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CREATE_STYLES, asyncHandlers.createStyles);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.RENAME_STYLES, asyncHandlers.renameStyles);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.REMOVE_STYLES, asyncHandlers.removeStyles);

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -62,6 +62,7 @@ export enum AsyncMessageTypes {
   REMOVE_RELAUNCH_DATA = 'async/remove-relaunch-data',
   SET_VARIABLE_EXPORT_SETTINGS = 'async/set-variable-export-settings',
   SET_SELECTED_EXPORT_THEMES = 'async/set-selected-export-themes',
+  CREATE_LIVING_DOCUMENTATION = 'async/create-living-documentation',
   // the below messages are going from plugin to UI
   STARTUP = 'async/startup',
   GET_THEME_INFO = 'async/get-theme-info',
@@ -182,6 +183,12 @@ export type CreateAnnotationAsyncMessage = AsyncMessage<AsyncMessageTypes.CREATE
   direction: Direction;
 }>;
 export type CreateAnnotationAsyncMessageResult = AsyncMessage<AsyncMessageTypes.CREATE_ANNOTATION>;
+
+export type CreateLivingDocumentationAsyncMessage = AsyncMessage<AsyncMessageTypes.CREATE_LIVING_DOCUMENTATION, {
+  tokenSet: string;
+  startsWith: string;
+}>;
+export type CreateLivingDocumentationAsyncMessageResult = AsyncMessage<AsyncMessageTypes.CREATE_LIVING_DOCUMENTATION>;
 
 export type CreateStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.CREATE_STYLES, {
   tokens: AnyTokenList;
@@ -394,6 +401,7 @@ export type AsyncMessages =
   | SetShowEmptyGroupsAsyncMessage
   | SetUiAsyncMessage
   | CreateAnnotationAsyncMessage
+  | CreateLivingDocumentationAsyncMessage
   | UpdateAsyncMessage
   | UpdateCheckForChangesAsyncMessage
   | GetThemeInfoMessage
@@ -444,6 +452,7 @@ export type AsyncMessageResults =
   | SetShowEmptyGroupsAsyncMessageResult
   | SetUiAsyncMessageResult
   | CreateAnnotationAsyncMessageResult
+  | CreateLivingDocumentationAsyncMessageResult
   | UpdateAsyncMessageResult
   | UpdateCheckForChangesAsyncMessageResult
   | GetThemeInfoMessageResult


### PR DESCRIPTION
## Summary
- add living documentation creation modal and menu item
- implement plugin handler to generate documentation frames from tokens
- wire up new async message types and handlers

## Testing
- `yarn lint` *(fails: need turbo dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6874dcd32198833182ddbcc7feccd099