### PR TITLE
Fix number tokens display in json

### DIFF
--- a/.changeset/fast-toes-approve.md
+++ b/.changeset/fast-toes-approve.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Display Number tokens without literals as an integer in json format of tokes in line with DTCG specs.

--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -387,7 +387,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
       if (internalEditToken.initialName !== name && internalEditToken.initialName) {
         oldName = internalEditToken.initialName;
       }
-      const trimmedValue = trimValue(value);
+      const trimmedValue = trimValue(value, type);
       const newName = name
         .split('/')
         .map((n) => n.trim())

--- a/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/EditTokenForm.tsx
@@ -633,7 +633,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
         return (
           <div>
             <DownshiftInput
-              value={internalEditToken.value}
+              value={typeof internalEditToken.value === 'number' ? String(internalEditToken.value) : internalEditToken.value}
               type={internalEditToken.type}
               label={internalEditToken.schema?.property}
               resolvedTokens={resolvedTokens}

--- a/packages/tokens-studio-for-figma/src/types/tokens/SingleNumberToken.ts
+++ b/packages/tokens-studio-for-figma/src/types/tokens/SingleNumberToken.ts
@@ -1,4 +1,4 @@
 import { TokenTypes } from '@/constants/TokenTypes';
 import { SingleGenericToken } from './SingleGenericToken';
 
-export type SingleNumberToken<Named extends boolean = true, P = unknown> = SingleGenericToken<TokenTypes.NUMBER, string, Named, P>;
+export type SingleNumberToken<Named extends boolean = true, P = unknown> = SingleGenericToken<TokenTypes.NUMBER, number | string, Named, P>;

--- a/packages/tokens-studio-for-figma/src/utils/TokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/utils/TokenResolver.ts
@@ -160,7 +160,7 @@ class TokenResolver {
             const resolvedNestedToken = this.resolveReferences({ ...nestedToken, name: nestedTokenName } as SingleToken, new Set(resolvedReferences));
 
             if (typeof resolvedNestedToken.value === 'string' || typeof resolvedNestedToken.value === 'number') {
-              resolvedPath = resolvedPath.replace(match[0], resolvedNestedToken.value);
+              resolvedPath = resolvedPath.replace(match[0], String(resolvedNestedToken.value));
             }
           } else {
             break;
@@ -199,7 +199,7 @@ class TokenResolver {
 
           // We replace the reference with the resolved value if needed
           if (typeof finalValue === 'string' && (typeof resolvedTokenValue.value === 'string' || typeof resolvedTokenValue.value === 'number')) {
-            finalValue = finalValue.replace(reference, resolvedTokenValue.value);
+            finalValue = finalValue.replace(reference, String(resolvedTokenValue.value));
           } else if (resolvedTokenValue.value !== undefined) {
             finalValue = resolvedTokenValue.value;
           }
@@ -213,7 +213,7 @@ class TokenResolver {
             if (parsedValue === undefined) {
               finalValue = token.value;
             } else {
-              finalValue = (typeof finalValue === 'string' && (typeof parsedValue === 'string' || typeof parsedValue === 'number')) ? finalValue.replace(reference, parsedValue) : parsedValue;
+              finalValue = (typeof finalValue === 'string' && (typeof parsedValue === 'string' || typeof parsedValue === 'number')) ? finalValue.replace(reference, String(parsedValue)) : parsedValue;
             }
           } else {
             // Otherwise, we return the token as is, but mark it as failed to resolve
@@ -226,7 +226,7 @@ class TokenResolver {
 
       let resolvedToken: ResolveTokenValuesResult;
       // When we have a string or number, we need to check if it's a valid token value.
-      if ((typeof finalValue === 'string' || typeof finalValue === 'number') && !AliasRegex.test(finalValue)) {
+      if ((typeof finalValue === 'string' || typeof finalValue === 'number') && !AliasRegex.test(String(finalValue))) {
         // We need to calculate the value of the token, as it might be a color or math transformation
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         const calculated = this.calculateTokenValue({ ...token, value: finalValue } as SingleToken, resolvedReferences);

--- a/packages/tokens-studio-for-figma/src/utils/getResolvedTextValue.ts
+++ b/packages/tokens-studio-for-figma/src/utils/getResolvedTextValue.ts
@@ -24,7 +24,7 @@ export default function getResolvedTextValue(token: SingleToken) {
     ), []);
     returnValue = array.join(',');
   } else if (typeof token.value === 'string' || typeof token.value === 'number') {
-    returnValue = token.value;
+    returnValue = String(token.value);
   }
   return returnValue;
 }

--- a/packages/tokens-studio-for-figma/src/utils/mapTokensToVariableInfo.ts
+++ b/packages/tokens-studio-for-figma/src/utils/mapTokensToVariableInfo.ts
@@ -7,7 +7,7 @@ import { ThemeObject } from '@/types';
 export function mapTokensToVariableInfo(token: ResolveTokenValuesResult, theme: ThemeObject, settings: SettingsState) {
   return {
     ...token,
-    value: (typeof token.value === 'string' || typeof token.value === 'number') ? transformValue(token.value, token.type, settings?.baseFontSize, true) : token.value,
+    value: (typeof token.value === 'string' || typeof token.value === 'number') ? transformValue(String(token.value), token.type, settings?.baseFontSize, true) : token.value,
     path: token.name.split('.').join('/'),
     variableId: theme.$figmaVariableReferences?.[token.name] ?? '',
   } as VariableToken;

--- a/packages/tokens-studio-for-figma/src/utils/processNumberValue.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/processNumberValue.test.ts
@@ -1,0 +1,71 @@
+import { processNumberValue } from './processNumberValue';
+
+describe('processNumberValue', () => {
+  it('should return number as-is when value is already a number', () => {
+    expect(processNumberValue(42)).toBe(42);
+    expect(processNumberValue(0)).toBe(0);
+    expect(processNumberValue(-3.14)).toBe(-3.14);
+    expect(processNumberValue(1.5)).toBe(1.5);
+    expect(processNumberValue(-0)).toBe(-0);
+  });
+
+  it('should parse valid numeric strings to numbers', () => {
+    expect(processNumberValue('42')).toBe(42);
+    expect(processNumberValue(' 42 ')).toBe(42);
+    expect(processNumberValue('0')).toBe(0);
+    expect(processNumberValue('-3.14')).toBe(-3.14);
+    expect(processNumberValue('1.5')).toBe(1.5);
+    expect(processNumberValue('  -0  ')).toBe(-0);
+    expect(processNumberValue('123.456')).toBe(123.456);
+  });
+
+  it('should return trimmed string for non-numeric strings', () => {
+    expect(processNumberValue('16px')).toBe('16px');
+    expect(processNumberValue(' hello ')).toBe('hello');
+    expect(processNumberValue('abc')).toBe('abc');
+    expect(processNumberValue('  text  ')).toBe('text');
+    expect(processNumberValue('auto')).toBe('auto');
+  });
+
+  it('should return trimmed string for invalid numbers', () => {
+    expect(processNumberValue('NaN')).toBe('NaN');
+    expect(processNumberValue('Infinity')).toBe('Infinity');
+    expect(processNumberValue('-Infinity')).toBe('-Infinity');
+  });
+
+  it('should handle empty strings', () => {
+    expect(processNumberValue('')).toBe('');
+    expect(processNumberValue('   ')).toBe('');
+  });
+
+  it('should handle edge cases with numeric patterns', () => {
+    // These should not be converted to numbers due to the regex check
+    expect(processNumberValue('1.2.3')).toBe('1.2.3');
+    expect(processNumberValue('1e5')).toBe('1e5'); // Scientific notation not supported by regex
+    expect(processNumberValue('0x10')).toBe('0x10'); // Hex not supported by regex
+    expect(processNumberValue('1.')).toBe('1.'); // Trailing dot without digit after
+
+    // This one actually gets converted because .5 is a valid decimal number
+    expect(processNumberValue('.5')).toBe(0.5); // Leading dot with digit - valid decimal
+  });
+
+  it('should handle non-string, non-number values', () => {
+    expect(processNumberValue(null as any)).toBe(null);
+    expect(processNumberValue(undefined as any)).toBe(undefined);
+    expect(processNumberValue({} as any)).toEqual({});
+    expect(processNumberValue([] as any)).toEqual([]);
+  });
+
+  it('should handle decimal numbers correctly', () => {
+    expect(processNumberValue('0.5')).toBe(0.5);
+    expect(processNumberValue('-0.5')).toBe(-0.5);
+    expect(processNumberValue('10.0')).toBe(10.0);
+    expect(processNumberValue('  3.14159  ')).toBe(3.14159);
+  });
+
+  it('should handle integer strings correctly', () => {
+    expect(processNumberValue('100')).toBe(100);
+    expect(processNumberValue('-100')).toBe(-100);
+    expect(processNumberValue('  999  ')).toBe(999);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/processNumberValue.ts
+++ b/packages/tokens-studio-for-figma/src/utils/processNumberValue.ts
@@ -15,7 +15,10 @@ export function processNumberValue(value: SingleToken['value']): number | string
   if (typeof value === 'string') {
     const trimmedValue = value.trim();
     const numericValue = Number(trimmedValue);
+    // Check if the value is a valid number and not empty
     if (!isNaN(numericValue) && isFinite(numericValue) && trimmedValue !== '') {
+      // Use regex to ensure it's a proper numeric format (optional minus, digits, optional decimal point, digits)
+      // This prevents conversion of values like "1e5", "0x10", "Infinity", etc.
       if (/^-?\d*\.?\d+$/.test(trimmedValue)) {
         return numericValue;
       }

--- a/packages/tokens-studio-for-figma/src/utils/processNumberValue.ts
+++ b/packages/tokens-studio-for-figma/src/utils/processNumberValue.ts
@@ -1,0 +1,27 @@
+import { SingleToken } from '@/types/tokens';
+
+/**
+ * Processes a token value and converts it to a number if it's a valid numeric string,
+ * otherwise returns the trimmed string value.
+ *
+ * @param value - The token value to process
+ * @returns A number if the value is numeric, otherwise a trimmed string
+ */
+export function processNumberValue(value: SingleToken['value']): number | string {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+    const numericValue = Number(trimmedValue);
+    if (!isNaN(numericValue) && isFinite(numericValue) && trimmedValue !== '') {
+      if (/^-?\d*\.?\d+$/.test(trimmedValue)) {
+        return numericValue;
+      }
+    }
+    return trimmedValue;
+  }
+
+  return value as string;
+}

--- a/packages/tokens-studio-for-figma/src/utils/stringifyTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/stringifyTokens.ts
@@ -4,7 +4,7 @@ import { AnyTokenList } from '@/types/tokens';
 import removeTokenId from './removeTokenId';
 import { TokenFormat, TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
 import { TokenInJSON } from './convertTokens';
-import { processNumberValue } from './trimValue';
+import { processNumberValue } from './processNumberValue';
 import { TokenTypes } from '@/constants/TokenTypes';
 
 export function getGroupTypeName(tokenName: string, groupLevel: number): string {

--- a/packages/tokens-studio-for-figma/src/utils/stringifyTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/stringifyTokens.ts
@@ -4,6 +4,8 @@ import { AnyTokenList } from '@/types/tokens';
 import removeTokenId from './removeTokenId';
 import { TokenFormat, TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
 import { TokenInJSON } from './convertTokens';
+import { processNumberValue } from './trimValue';
+import { TokenTypes } from '@/constants/TokenTypes';
 
 export function getGroupTypeName(tokenName: string, groupLevel: number): string {
   if (tokenName.includes('.')) {
@@ -11,6 +13,13 @@ export function getGroupTypeName(tokenName: string, groupLevel: number): string 
     return `${tokenName.slice(0, lastDotPosition)}.${TokenFormat.tokenTypeKey}`;
   }
   return TokenFormat.tokenTypeKey;
+}
+
+function processTokenValue(value: any, tokenType: string): any {
+  if (tokenType === TokenTypes.NUMBER) {
+    return processNumberValue(value);
+  }
+  return value;
 }
 
 export default function stringifyTokens(
@@ -27,7 +36,7 @@ export default function stringifyTokens(
       const tokenInJSON: TokenInJSON = tokenWithoutInheritTypeLevel;
       // set type of group level
       set(tokenObj, getGroupTypeName(token.name, inheritTypeLevel), tokenInJSON.type);
-      tokenInJSON[TokenFormat.tokenValueKey] = tokenWithoutName.value;
+      tokenInJSON[TokenFormat.tokenValueKey] = processTokenValue(tokenWithoutName.value, tokenWithoutName.type);
       tokenInJSON[TokenFormat.tokenDescriptionKey] = tokenWithoutName.description;
       if (TokenFormat.format === TokenFormatOptions.DTCG) {
         delete tokenInJSON.type;
@@ -39,7 +48,7 @@ export default function stringifyTokens(
     } else {
       const tokenInJSON: TokenInJSON = tokenWithoutName;
       tokenInJSON[TokenFormat.tokenTypeKey] = tokenInJSON.type;
-      tokenInJSON[TokenFormat.tokenValueKey] = tokenInJSON.value;
+      tokenInJSON[TokenFormat.tokenValueKey] = processTokenValue(tokenInJSON.value, tokenInJSON.type);
       tokenInJSON[TokenFormat.tokenDescriptionKey] = tokenInJSON.description;
       if (TokenFormat.format === TokenFormatOptions.DTCG) {
         delete tokenInJSON.type;

--- a/packages/tokens-studio-for-figma/src/utils/trimValue.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/trimValue.test.ts
@@ -1,5 +1,6 @@
 import { BoxShadowTypes } from '@/constants/BoxShadowTypes';
-import trimValue from './trimValue';
+import { TokenTypes } from '@/constants/TokenTypes';
+import trimValue, { processNumberValue } from './trimValue';
 
 const regularValue = ['#ff00ff', ' #ff00ff', '#ff00ff ', ' #ff00ff '];
 const typographyValue = {
@@ -70,5 +71,58 @@ describe('trimValue', () => {
         type: BoxShadowTypes.DROP_SHADOW,
       },
     ]);
+  });
+
+  describe('processNumberValue', () => {
+    it('should return number as-is when value is already a number', () => {
+      expect(processNumberValue(42)).toBe(42);
+      expect(processNumberValue(0)).toBe(0);
+      expect(processNumberValue(-3.14)).toBe(-3.14);
+    });
+
+    it('should parse valid numeric strings to numbers', () => {
+      expect(processNumberValue('42')).toBe(42);
+      expect(processNumberValue(' 42 ')).toBe(42);
+      expect(processNumberValue('0')).toBe(0);
+      expect(processNumberValue('-3.14')).toBe(-3.14);
+      expect(processNumberValue('1.5')).toBe(1.5);
+    });
+
+    it('should return trimmed string for non-numeric strings', () => {
+      expect(processNumberValue('16px')).toBe('16px');
+      expect(processNumberValue(' hello ')).toBe('hello');
+      expect(processNumberValue('abc')).toBe('abc');
+      expect(processNumberValue('')).toBe('');
+    });
+
+    it('should return trimmed string for invalid numbers', () => {
+      expect(processNumberValue('NaN')).toBe('NaN');
+      expect(processNumberValue('Infinity')).toBe('Infinity');
+    });
+  });
+
+  describe('number token handling', () => {
+    it('should return number for number tokens with numeric string values', () => {
+      expect(trimValue('42', TokenTypes.NUMBER)).toBe(42);
+      expect(trimValue(' 16 ', TokenTypes.NUMBER)).toBe(16);
+      expect(trimValue('0', TokenTypes.NUMBER)).toBe(0);
+      expect(trimValue('-3.14', TokenTypes.NUMBER)).toBe(-3.14);
+    });
+
+    it('should return number for number tokens with numeric values', () => {
+      expect(trimValue(42, TokenTypes.NUMBER)).toBe(42);
+      expect(trimValue(0, TokenTypes.NUMBER)).toBe(0);
+      expect(trimValue(-3.14, TokenTypes.NUMBER)).toBe(-3.14);
+    });
+
+    it('should return trimmed string for number tokens with non-numeric values', () => {
+      expect(trimValue('16px', TokenTypes.NUMBER)).toBe('16px');
+      expect(trimValue(' hello ', TokenTypes.NUMBER)).toBe('hello');
+    });
+
+    it('should handle non-number tokens normally', () => {
+      expect(trimValue('42', TokenTypes.COLOR)).toBe('42');
+      expect(trimValue(' hello ', TokenTypes.TEXT)).toBe('hello');
+    });
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/trimValue.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/trimValue.test.ts
@@ -1,6 +1,6 @@
 import { BoxShadowTypes } from '@/constants/BoxShadowTypes';
 import { TokenTypes } from '@/constants/TokenTypes';
-import trimValue, { processNumberValue } from './trimValue';
+import trimValue from './trimValue';
 
 const regularValue = ['#ff00ff', ' #ff00ff', '#ff00ff ', ' #ff00ff '];
 const typographyValue = {
@@ -71,34 +71,6 @@ describe('trimValue', () => {
         type: BoxShadowTypes.DROP_SHADOW,
       },
     ]);
-  });
-
-  describe('processNumberValue', () => {
-    it('should return number as-is when value is already a number', () => {
-      expect(processNumberValue(42)).toBe(42);
-      expect(processNumberValue(0)).toBe(0);
-      expect(processNumberValue(-3.14)).toBe(-3.14);
-    });
-
-    it('should parse valid numeric strings to numbers', () => {
-      expect(processNumberValue('42')).toBe(42);
-      expect(processNumberValue(' 42 ')).toBe(42);
-      expect(processNumberValue('0')).toBe(0);
-      expect(processNumberValue('-3.14')).toBe(-3.14);
-      expect(processNumberValue('1.5')).toBe(1.5);
-    });
-
-    it('should return trimmed string for non-numeric strings', () => {
-      expect(processNumberValue('16px')).toBe('16px');
-      expect(processNumberValue(' hello ')).toBe('hello');
-      expect(processNumberValue('abc')).toBe('abc');
-      expect(processNumberValue('')).toBe('');
-    });
-
-    it('should return trimmed string for invalid numbers', () => {
-      expect(processNumberValue('NaN')).toBe('NaN');
-      expect(processNumberValue('Infinity')).toBe('Infinity');
-    });
   });
 
   describe('number token handling', () => {

--- a/packages/tokens-studio-for-figma/src/utils/trimValue.ts
+++ b/packages/tokens-studio-for-figma/src/utils/trimValue.ts
@@ -1,16 +1,40 @@
 import { SingleToken } from '@/types/tokens';
+import { TokenTypes } from '@/constants/TokenTypes';
 
-export default function trimValue(value: SingleToken['value']): SingleToken['value'] {
+export function processNumberValue(value: SingleToken['value']): number | string {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+    const numericValue = Number(trimmedValue);
+    if (!isNaN(numericValue) && isFinite(numericValue) && trimmedValue !== '') {
+      if (/^-?\d*\.?\d+$/.test(trimmedValue)) {
+        return numericValue;
+      }
+    }
+    return trimmedValue;
+  }
+
+  return value as string;
+}
+
+export default function trimValue(value: SingleToken['value'], tokenType?: TokenTypes): SingleToken['value'] {
+  if (tokenType === TokenTypes.NUMBER) {
+    return processNumberValue(value) as SingleToken['value'];
+  }
+
   if (Array.isArray(value)) {
     return value.map((item) => (
-      Object.entries(item).reduce<Record<string, string>>((acc, [key, value]) => {
-        acc[key] = value.toString().trim();
+      Object.entries(item).reduce<Record<string, string>>((acc, [key, val]) => {
+        acc[key] = val.toString().trim();
         return acc;
       }, {})
     )) as SingleToken['value'];
   } if (typeof value === 'object') {
-    return Object.entries(value).reduce<Record<string, string>>((acc, [key, value]) => {
-      acc[key] = value.toString().trim();
+    return Object.entries(value).reduce<Record<string, string>>((acc, [key, val]) => {
+      acc[key] = val.toString().trim();
       return acc;
     }, {});
   }

--- a/packages/tokens-studio-for-figma/src/utils/trimValue.ts
+++ b/packages/tokens-studio-for-figma/src/utils/trimValue.ts
@@ -1,24 +1,6 @@
 import { SingleToken } from '@/types/tokens';
 import { TokenTypes } from '@/constants/TokenTypes';
-
-export function processNumberValue(value: SingleToken['value']): number | string {
-  if (typeof value === 'number') {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const trimmedValue = value.trim();
-    const numericValue = Number(trimmedValue);
-    if (!isNaN(numericValue) && isFinite(numericValue) && trimmedValue !== '') {
-      if (/^-?\d*\.?\d+$/.test(trimmedValue)) {
-        return numericValue;
-      }
-    }
-    return trimmedValue;
-  }
-
-  return value as string;
-}
+import { processNumberValue } from './processNumberValue';
 
 export default function trimValue(value: SingleToken['value'], tokenType?: TokenTypes): SingleToken['value'] {
   if (tokenType === TokenTypes.NUMBER) {


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #3465 

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

Currently number tokens are displayed as strings in the json file export/editor
According to DTCG format, it should be displayed in numeric format without quotes, this PR addresses that concern and will now be displayed with appropriate format.

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

- Create a numeric token
- Go to JSON editor and check how is it being displayed

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
<img width="404" height="539" alt="Screenshot 2025-07-31 at 11 55 52 AM" src="https://github.com/user-attachments/assets/81cdccca-a959-407d-b4cb-6fc83ada64de" />
