### PR TITLE
Fix nested button validation warning in TokenSetItem

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/TokenSetItem/TokenSetItem.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenSetItem/TokenSetItem.tsx
@@ -131,41 +131,41 @@ export function TokenSetItem({
           </ContextMenu.Trigger>
         ) : (
           <ContextMenu.Trigger asChild id={`${item.path}-trigger`}>
-            <StyledDragButton
-              type="button"
-              css={{
-                padding: '$3 $6 $3 $1',
-                paddingLeft: `${5 * item.level}px`,
-              }}
-              data-testid={`tokensetitem-${item.path}`}
-              isActive={isActive}
-              canReorder={canReorder}
-              onClick={handleClick}
-            >
-              <DragGrabber item={item} canReorder={canReorder} onDragStart={handleGrabberPointerDown} />
-              <Box
+            <Tooltip label={item.label} side="right" asChild>
+              <StyledDragButton
+                type="button"
                 css={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '$2',
-                  overflow: 'hidden',
-                  height: '1.5em',
-                  maxWidth: 'calc(100% - $sizes$6)',
-                  whiteSpace: 'nowrap',
-                  textOverflow: 'ellipsis',
-                  userSelect: 'none',
+                  padding: '$3 $6 $3 $1',
+                  paddingLeft: `${5 * item.level}px`,
                 }}
+                data-testid={`tokensetitem-${item.path}`}
+                isActive={isActive}
+                canReorder={canReorder}
+                onClick={handleClick}
               >
-                <Tooltip label={item.label} side="right">
+                <DragGrabber item={item} canReorder={canReorder} onDragStart={handleGrabberPointerDown} />
+                <Box
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '$2',
+                    overflow: 'hidden',
+                    height: '1.5em',
+                    maxWidth: 'calc(100% - $sizes$6)',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                    userSelect: 'none',
+                  }}
+                >
                   <span style={{ overflow: 'hidden' }}>{item.label}</span>
-                </Tooltip>
-                {item.tokenCount !== undefined && item.tokenCount > 0 && (
-                  <Text size="xsmall" muted css={{ flexShrink: 0 }}>
-                    {formatCount(item.tokenCount)}
-                  </Text>
-                )}
-              </Box>
-            </StyledDragButton>
+                  {item.tokenCount !== undefined && item.tokenCount > 0 && (
+                    <Text size="xsmall" muted css={{ flexShrink: 0 }}>
+                      {formatCount(item.tokenCount)}
+                    </Text>
+                  )}
+                </Box>
+              </StyledDragButton>
+            </Tooltip>
           </ContextMenu.Trigger>
         )}
         <ContextMenu.Portal>


### PR DESCRIPTION
## Summary
- Fixes React DOM validation warning: "button cannot appear as a descendant of button"
- Restructures TokenSetItem component to prevent nested button elements

## Problem
The TokenSetItem component was generating a console warning due to a Tooltip component creating a button element inside an existing StyledDragButton, violating HTML semantics.

## Solution
- Moved Tooltip to wrap the entire StyledDragButton instead of just the label span
- Added `asChild` prop to Tooltip to prevent it from creating its own button element
- Maintains all existing functionality while fixing the DOM validation issue

## Test plan
- [ ] Launch the plugin and verify no nested button warnings appear in console
- [ ] Verify tooltip functionality still works when hovering over token set items
- [ ] Confirm context menu and drag functionality remain intact

🤖 Generated with [Claude Code](https://claude.ai/code)