### PR TITLE
fix persistent push indicator issue

### DIFF
--- a/.changeset/gold-eels-complain.md
+++ b/.changeset/gold-eels-complain.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixes an issue where the blue dot push indicator persists after a change is pushed to a remote provider, especially when a token set is renamed or deleted

--- a/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
@@ -36,7 +36,19 @@ export function setTokenData(state: TokenState, payload: SetTokenDataPayload): T
   const tokenValues = Array.isArray(payload.values) ? payload.values : removeIdPropertyFromTokens(payload.values);
 
   // When the remote data has changed, we will update the last synced state
-  const lastSyncedState = payload.hasChangedRemote ? JSON.stringify(compact([tokenValues, payload.themes, TokenFormat.format]), null, 2) : state.lastSyncedState;
+  const lastSyncedState = payload.hasChangedRemote
+    ? (() => {
+      const cleanedThemes = (payload.themes ?? []).map((theme) => ({
+        ...theme,
+        selectedTokenSets: Object.fromEntries(
+          Object.entries(theme.selectedTokenSets).filter(
+            ([setName, status]) => allAvailableTokenSets.includes(setName) && status !== 'disabled',
+          ),
+        ),
+      }));
+      return JSON.stringify(compact([tokenValues, cleanedThemes, TokenFormat.format]), null, 2);
+    })()
+    : state.lastSyncedState;
 
   // @README (1) for the sake of normalization we will set the DISABLED status for all available token sets
   // this way we can always be certain the status is available. This behavior is also reflected in the createTokenSet logic

--- a/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
@@ -7,6 +7,7 @@ import removeIdPropertyFromTokens from '@/utils/removeIdPropertyFromTokens';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { TokenStore } from '@/types/tokens';
 import { checkStorageSize } from '@/utils/checkStorageSize';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export function setTokenData(state: TokenState, payload: SetTokenDataPayload): TokenState {
   if (payload.values.length === 0) {
@@ -38,14 +39,7 @@ export function setTokenData(state: TokenState, payload: SetTokenDataPayload): T
   // When the remote data has changed, we will update the last synced state
   const lastSyncedState = payload.hasChangedRemote
     ? (() => {
-      const cleanedThemes = (payload.themes ?? []).map((theme) => ({
-        ...theme,
-        selectedTokenSets: Object.fromEntries(
-          Object.entries(theme.selectedTokenSets).filter(
-            ([setName, status]) => allAvailableTokenSets.includes(setName) && status !== 'disabled',
-          ),
-        ),
-      }));
+      const cleanedThemes = cleanThemesSelectedTokenSets(payload.themes ?? [], allAvailableTokenSets);
       return JSON.stringify(compact([tokenValues, cleanedThemes, TokenFormat.format]), null, 2);
     })()
     : state.lastSyncedState;
@@ -56,14 +50,7 @@ export function setTokenData(state: TokenState, payload: SetTokenDataPayload): T
     ...state,
     lastSyncedState,
     tokens: values,
-    themes: (payload.themes ?? []).map((theme) => ({
-      ...theme,
-      selectedTokenSets: Object.fromEntries(
-        Object.entries(theme.selectedTokenSets).filter(
-          ([setName, status]) => allAvailableTokenSets.includes(setName) && status !== TokenSetStatus.DISABLED,
-        ),
-      ),
-    })),
+    themes: cleanThemesSelectedTokenSets(payload.themes ?? [], allAvailableTokenSets),
     activeTheme: newActiveTheme ?? {},
     ...(Object.keys(payload.values).includes(state.activeTokenSet)
       ? {}

--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -22,6 +22,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 
 type AdoCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.ADO; }>;
@@ -93,14 +94,7 @@ export const useADO = () => {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const cleanedThemes = themes.map((theme) => ({
-          ...theme,
-          selectedTokenSets: Object.fromEntries(
-            Object.entries(theme.selectedTokenSets).filter(
-              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
-            ),
-          ),
-        }));
+        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
 
         const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
@@ -238,14 +232,7 @@ export const useADO = () => {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const cleanedThemes = content.themes.map((theme) => ({
-              ...theme,
-              selectedTokenSets: Object.fromEntries(
-                Object.entries(theme.selectedTokenSets).filter(
-                  ([setName, status]) => Object.keys(sortedValues).includes(setName) && status !== 'disabled',
-                ),
-              ),
-            }));
+            const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(sortedValues));
 
             const stringifiedRemoteTokens = JSON.stringify(compact([sortedValues, cleanedThemes, TokenFormat.format]), null, 2);
             dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import React from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
-import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -20,10 +19,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
-
 
 type AdoCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.ADO; }>;
 type AdoFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.ADO; }>;
@@ -94,10 +90,7 @@ export const useADO = () => {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
-
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
-        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+        dispatch.tokenState.setLastSyncedState({ tokens, themes });
         pushDialog({ state: 'success' });
 
         return {
@@ -232,10 +225,7 @@ export const useADO = () => {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(sortedValues));
-
-            const stringifiedRemoteTokens = JSON.stringify(compact([sortedValues, cleanedThemes, TokenFormat.format]), null, 2);
-            dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+            dispatch.tokenState.setLastSyncedState({ tokens: sortedValues, themes: content.themes });
             dispatch.tokenState.setCollapsedTokenSets([]);
             notifyToUI('Pulled tokens from ADO');
           }

--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -93,7 +93,16 @@ export const useADO = () => {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const cleanedThemes = themes.map((theme) => ({
+          ...theme,
+          selectedTokenSets: Object.fromEntries(
+            Object.entries(theme.selectedTokenSets).filter(
+              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
+            ),
+          ),
+        }));
+
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
 
@@ -229,7 +238,16 @@ export const useADO = () => {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const stringifiedRemoteTokens = JSON.stringify(compact([sortedValues, content.themes, TokenFormat.format]), null, 2);
+            const cleanedThemes = content.themes.map((theme) => ({
+              ...theme,
+              selectedTokenSets: Object.fromEntries(
+                Object.entries(theme.selectedTokenSets).filter(
+                  ([setName, status]) => Object.keys(sortedValues).includes(setName) && status !== 'disabled',
+                ),
+              ),
+            }));
+
+            const stringifiedRemoteTokens = JSON.stringify(compact([sortedValues, cleanedThemes, TokenFormat.format]), null, 2);
             dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
             dispatch.tokenState.setCollapsedTokenSets([]);
             notifyToUI('Pulled tokens from ADO');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -97,7 +97,16 @@ export function useBitbucket() {
           themes,
           metadata,
         });
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const cleanedThemes = themes.map((theme) => ({
+          ...theme,
+          selectedTokenSets: Object.fromEntries(
+            Object.entries(theme.selectedTokenSets).filter(
+              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
+            ),
+          ),
+        }));
+
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -22,6 +22,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type BitbucketCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.BITBUCKET }>;
 type BitbucketFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.BITBUCKET }>;
@@ -97,14 +98,7 @@ export function useBitbucket() {
           themes,
           metadata,
         });
-        const cleanedThemes = themes.map((theme) => ({
-          ...theme,
-          selectedTokenSets: Object.fromEntries(
-            Object.entries(theme.selectedTokenSets).filter(
-              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
-            ),
-          ),
-        }));
+        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
 
         const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
-import compact from 'just-compact';
+
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -20,9 +20,8 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+
 import { categorizeError } from '@/utils/error/categorizeError';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type BitbucketCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.BITBUCKET }>;
 type BitbucketFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.BITBUCKET }>;
@@ -98,10 +97,7 @@ export function useBitbucket() {
           themes,
           metadata,
         });
-        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
-
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
-        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+        dispatch.tokenState.setLastSyncedState({ tokens, themes });
         pushDialog({ state: 'success' });
         return {
           status: 'success',
@@ -243,8 +239,7 @@ export function useBitbucket() {
                 themes: content.themes,
                 metadata: content.metadata,
               });
-              const stringifiedRemoteTokens = JSON.stringify(compact([sortedValues, content.themes, TokenFormat.format]), null, 2);
-              dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+              dispatch.tokenState.setLastSyncedState({ tokens: sortedValues, themes: content.themes });
               dispatch.tokenState.setCollapsedTokenSets([]);
               notifyToUI('Pulled tokens from Bitbucket');
             }

--- a/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
-import compact from 'just-compact';
+
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../../../plugin/notifiers';
 import pjs from '../../../../../package.json';
@@ -26,8 +26,6 @@ import {
 } from '@/types/StorageType';
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { ErrorMessages } from '@/constants/ErrorMessages';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export async function updateGenericVersionedTokens({
   tokens,
@@ -160,7 +158,7 @@ export function useGenericVersionedStorage() {
       notifyToUI('Something went wrong. See console for details', { error: true });
       return null;
     },
-    [dispatch, themes, tokens],
+    [dispatch, themes, tokens, storeTokenIdInJsonEditor],
   );
 
   // Read tokens from endpoint
@@ -280,14 +278,7 @@ export function useGenericVersionedStorage() {
             tokenSetOrder: Object.keys(content.tokens),
           },
         });
-        const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
-
-        const stringifiedRemoteTokens = JSON.stringify(
-          compact([content.tokens, cleanedThemes, TokenFormat.format]),
-          null,
-          2,
-        );
-        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+        dispatch.tokenState.setLastSyncedState({ tokens: content.tokens, themes: content.themes });
         return content;
       }
 

--- a/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
@@ -279,8 +279,17 @@ export function useGenericVersionedStorage() {
             tokenSetOrder: Object.keys(content.tokens),
           },
         });
+        const cleanedThemes = content.themes.map((theme) => ({
+          ...theme,
+          selectedTokenSets: Object.fromEntries(
+            Object.entries(theme.selectedTokenSets).filter(
+              ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
+            ),
+          ),
+        }));
+
         const stringifiedRemoteTokens = JSON.stringify(
-          compact([content.tokens, content.themes, TokenFormat.format]),
+          compact([content.tokens, cleanedThemes, TokenFormat.format]),
           null,
           2,
         );

--- a/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/generic/versionedStorage.ts
@@ -27,6 +27,7 @@ import {
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { ErrorMessages } from '@/constants/ErrorMessages';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export async function updateGenericVersionedTokens({
   tokens,
@@ -279,14 +280,7 @@ export function useGenericVersionedStorage() {
             tokenSetOrder: Object.keys(content.tokens),
           },
         });
-        const cleanedThemes = content.themes.map((theme) => ({
-          ...theme,
-          selectedTokenSets: Object.fromEntries(
-            Object.entries(theme.selectedTokenSets).filter(
-              ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
-            ),
-          ),
-        }));
+        const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
 
         const stringifiedRemoteTokens = JSON.stringify(
           compact([content.tokens, cleanedThemes, TokenFormat.format]),

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
-import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -24,8 +23,6 @@ import { applyTokenSetOrder } from '@/utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { categorizeError } from '@/utils/error/categorizeError';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type GithubCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITHUB; }>;
 type GithubFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITHUB }>;
@@ -115,10 +112,7 @@ export function useGitHub() {
           themes,
           metadata,
         });
-        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
-
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
-        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+        dispatch.tokenState.setLastSyncedState({ tokens, themes });
         pushDialog({ state: 'success' });
         return {
           status: 'success',
@@ -268,10 +262,7 @@ export function useGitHub() {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
-
-            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, cleanedThemes, TokenFormat.format]), null, 2);
-            dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+            dispatch.tokenState.setLastSyncedState({ tokens: content.tokens, themes: content.themes });
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(commitSha ? { commitSha } : {}) });
             notifyToUI('Pulled tokens from GitHub');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -25,6 +25,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { categorizeError } from '@/utils/error/categorizeError';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type GithubCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITHUB; }>;
 type GithubFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITHUB }>;
@@ -114,14 +115,7 @@ export function useGitHub() {
           themes,
           metadata,
         });
-        const cleanedThemes = themes.map((theme) => ({
-          ...theme,
-          selectedTokenSets: Object.fromEntries(
-            Object.entries(theme.selectedTokenSets).filter(
-              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
-            ),
-          ),
-        }));
+        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
 
         const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
@@ -274,14 +268,7 @@ export function useGitHub() {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const cleanedThemes = content.themes.map((theme) => ({
-              ...theme,
-              selectedTokenSets: Object.fromEntries(
-                Object.entries(theme.selectedTokenSets).filter(
-                  ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
-                ),
-              ),
-            }));
+            const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
 
             const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, cleanedThemes, TokenFormat.format]), null, 2);
             dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -114,7 +114,16 @@ export function useGitHub() {
           themes,
           metadata,
         });
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const cleanedThemes = themes.map((theme) => ({
+          ...theme,
+          selectedTokenSets: Object.fromEntries(
+            Object.entries(theme.selectedTokenSets).filter(
+              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
+            ),
+          ),
+        }));
+
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {
@@ -265,7 +274,16 @@ export function useGitHub() {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, content.themes, TokenFormat.format]), null, 2);
+            const cleanedThemes = content.themes.map((theme) => ({
+              ...theme,
+              selectedTokenSets: Object.fromEntries(
+                Object.entries(theme.selectedTokenSets).filter(
+                  ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
+                ),
+              ),
+            }));
+
+            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, cleanedThemes, TokenFormat.format]), null, 2);
             dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(commitSha ? { commitSha } : {}) });

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -25,6 +25,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { categorizeError } from '@/utils/error/categorizeError';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export type GitlabCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITLAB; }>;
 type GitlabFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITLAB }>;
@@ -103,14 +104,7 @@ export function useGitLab() {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const cleanedThemes = themes.map((theme) => ({
-          ...theme,
-          selectedTokenSets: Object.fromEntries(
-            Object.entries(theme.selectedTokenSets).filter(
-              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
-            ),
-          ),
-        }));
+        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
 
         const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
@@ -253,14 +247,7 @@ export function useGitLab() {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const cleanedThemes = content.themes.map((theme) => ({
-              ...theme,
-              selectedTokenSets: Object.fromEntries(
-                Object.entries(theme.selectedTokenSets).filter(
-                  ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
-                ),
-              ),
-            }));
+            const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
 
             const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, cleanedThemes, TokenFormat.format]), null, 2);
             dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -103,7 +103,16 @@ export function useGitLab() {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const cleanedThemes = themes.map((theme) => ({
+          ...theme,
+          selectedTokenSets: Object.fromEntries(
+            Object.entries(theme.selectedTokenSets).filter(
+              ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
+            ),
+          ),
+        }));
+
+        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {
@@ -244,7 +253,16 @@ export function useGitLab() {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, content.themes, TokenFormat.format]), null, 2);
+            const cleanedThemes = content.themes.map((theme) => ({
+              ...theme,
+              selectedTokenSets: Object.fromEntries(
+                Object.entries(theme.selectedTokenSets).filter(
+                  ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
+                ),
+              ),
+            }));
+
+            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, cleanedThemes, TokenFormat.format]), null, 2);
             dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(latestCommitDate ? { commitDate: latestCommitDate } : {}) });

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
-import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import usePushDialog from '@/app/hooks/usePushDialog';
@@ -24,8 +23,6 @@ import { applyTokenSetOrder } from '@/utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { categorizeError } from '@/utils/error/categorizeError';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export type GitlabCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITLAB; }>;
 type GitlabFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITLAB }>;
@@ -104,10 +101,7 @@ export function useGitLab() {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
-
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
-        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+        dispatch.tokenState.setLastSyncedState({ tokens, themes });
         pushDialog({ state: 'success' });
         return {
           status: 'success',
@@ -247,10 +241,7 @@ export function useGitLab() {
               themes: content.themes,
               metadata: content.metadata,
             });
-            const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
-
-            const stringifiedRemoteTokens = JSON.stringify(compact([content.tokens, cleanedThemes, TokenFormat.format]), null, 2);
-            dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+            dispatch.tokenState.setLastSyncedState({ tokens: content.tokens, themes: content.themes });
             dispatch.tokenState.setCollapsedTokenSets([]);
             dispatch.uiState.setApiData({ ...context, ...(latestCommitDate ? { commitDate: latestCommitDate } : {}) });
             notifyToUI('Pulled tokens from GitLab');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
@@ -226,7 +226,16 @@ export function useJSONbin() {
         themes: content.themes,
         metadata: { tokenSetOrder: Object.keys(tokens) },
       });
-      const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), content.themes, TokenFormat.format]), null, 2);
+      const cleanedThemes = content.themes.map((theme) => ({
+        ...theme,
+        selectedTokenSets: Object.fromEntries(
+          Object.entries(theme.selectedTokenSets).filter(
+            ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
+          ),
+        ),
+      }));
+
+      const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), cleanedThemes, TokenFormat.format]), null, 2);
       dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
       return content;
     }

--- a/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
@@ -20,6 +20,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export async function updateJSONBinTokens({
   tokens, themes, context, updatedAt, oldUpdatedAt = null, storeTokenIdInJsonEditor,
@@ -226,14 +227,7 @@ export function useJSONbin() {
         themes: content.themes,
         metadata: { tokenSetOrder: Object.keys(tokens) },
       });
-      const cleanedThemes = content.themes.map((theme) => ({
-        ...theme,
-        selectedTokenSets: Object.fromEntries(
-          Object.entries(theme.selectedTokenSets).filter(
-            ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
-          ),
-        ),
-      }));
+      const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
 
       const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), cleanedThemes, TokenFormat.format]), null, 2);
       dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/jsonbin.tsx
@@ -1,6 +1,5 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
-import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../../plugin/notifiers';
 import pjs from '../../../../package.json';
@@ -18,9 +17,7 @@ import { StorageTypeCredentials, StorageTypeFormValues } from '@/types/StorageTy
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export async function updateJSONBinTokens({
   tokens, themes, context, updatedAt, oldUpdatedAt = null, storeTokenIdInJsonEditor,
@@ -227,10 +224,10 @@ export function useJSONbin() {
         themes: content.themes,
         metadata: { tokenSetOrder: Object.keys(tokens) },
       });
-      const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
-
-      const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), cleanedThemes, TokenFormat.format]), null, 2);
-      dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+      dispatch.tokenState.setLastSyncedState({
+        tokens: applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder),
+        themes: content.themes,
+      });
       return content;
     }
     return content;

--- a/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
@@ -76,7 +76,16 @@ export function useSupernova() {
             themes,
             metadata,
           });
-          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+          const cleanedThemes = themes.map((theme) => ({
+            ...theme,
+            selectedTokenSets: Object.fromEntries(
+              Object.entries(theme.selectedTokenSets).filter(
+                ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
+              ),
+            ),
+          }));
+
+          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
           dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
           pushDialog({ state: 'success' });
           return {

--- a/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
-import compact from 'just-compact';
+
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '@/plugin/notifiers';
 import {
@@ -21,8 +21,6 @@ import { RemoteResponseData } from '../../../../types/RemoteResponseData';
 import { ErrorMessages } from '../../../../constants/ErrorMessages';
 import { applyTokenSetOrder } from '../../../../utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type SupernovaCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.SUPERNOVA }>;
 type SupernovaFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.SUPERNOVA }>;
@@ -77,10 +75,7 @@ export function useSupernova() {
             themes,
             metadata,
           });
-          const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
-
-          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
-          dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+          dispatch.tokenState.setLastSyncedState({ tokens, themes });
           pushDialog({ state: 'success' });
           return {
             status: 'success',

--- a/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/supernova/supernova.tsx
@@ -22,6 +22,7 @@ import { ErrorMessages } from '../../../../constants/ErrorMessages';
 import { applyTokenSetOrder } from '../../../../utils/tokenset';
 import { PushOverrides } from '../../remoteTokens';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type SupernovaCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.SUPERNOVA }>;
 type SupernovaFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.SUPERNOVA }>;
@@ -76,14 +77,7 @@ export function useSupernova() {
             themes,
             metadata,
           });
-          const cleanedThemes = themes.map((theme) => ({
-            ...theme,
-            selectedTokenSets: Object.fromEntries(
-              Object.entries(theme.selectedTokenSets).filter(
-                ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
-              ),
-            ),
-          }));
+          const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
 
           const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
           dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
@@ -1,7 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import compact from 'just-compact';
 import { Dispatch } from '@/app/store';
 import useConfirm from '@/app/hooks/useConfirm';
 import { notifyToUI } from '@/plugin/notifiers';
@@ -26,8 +25,6 @@ import { PushOverrides } from '../../remoteTokens';
 import { categorizeError } from '@/utils/error/categorizeError';
 import { RemoteTokenStorageMetadata } from '@/storage/RemoteTokenStorage';
 import { applyTokenSetOrder } from '@/utils/tokenset';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type TokensStudioCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.TOKENS_STUDIO }>;
 type TokensStudioFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.TOKENS_STUDIO }>;
@@ -137,10 +134,7 @@ export function useTokensStudio() {
             themes,
             metadata,
           });
-          const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
-
-          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
-          dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+          dispatch.tokenState.setLastSyncedState({ tokens, themes });
           pushDialog({ state: 'success' });
           return {
             status: 'success',
@@ -242,10 +236,7 @@ export function useTokensStudio() {
                 themes: data.themes,
                 metadata: data.metadata,
               });
-              const cleanedThemes = cleanThemesSelectedTokenSets(data.themes, Object.keys(data.tokens));
-
-              const stringifiedRemoteTokens = JSON.stringify(compact([data.tokens, cleanedThemes, TokenFormat.format]), null, 2);
-              dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+              dispatch.tokenState.setLastSyncedState({ tokens: data.tokens, themes: data.themes });
               dispatch.tokenState.setCollapsedTokenSets([]);
               notifyToUI('Pulled tokens from Tokens Studio');
             }

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
@@ -136,7 +136,16 @@ export function useTokensStudio() {
             themes,
             metadata,
           });
-          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+          const cleanedThemes = themes.map((theme) => ({
+            ...theme,
+            selectedTokenSets: Object.fromEntries(
+              Object.entries(theme.selectedTokenSets).filter(
+                ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
+              ),
+            ),
+          }));
+
+          const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
           dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
           pushDialog({ state: 'success' });
           return {
@@ -239,7 +248,16 @@ export function useTokensStudio() {
                 themes: data.themes,
                 metadata: data.metadata,
               });
-              const stringifiedRemoteTokens = JSON.stringify(compact([data.tokens, data.themes, TokenFormat.format]), null, 2);
+              const cleanedThemes = data.themes.map((theme) => ({
+                ...theme,
+                selectedTokenSets: Object.fromEntries(
+                  Object.entries(theme.selectedTokenSets).filter(
+                    ([setName, status]) => Object.keys(data.tokens).includes(setName) && status !== 'disabled',
+                  ),
+                ),
+              }));
+
+              const stringifiedRemoteTokens = JSON.stringify(compact([data.tokens, cleanedThemes, TokenFormat.format]), null, 2);
               dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
               dispatch.tokenState.setCollapsedTokenSets([]);
               notifyToUI('Pulled tokens from Tokens Studio');

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudio.tsx
@@ -27,6 +27,7 @@ import { categorizeError } from '@/utils/error/categorizeError';
 import { RemoteTokenStorageMetadata } from '@/storage/RemoteTokenStorage';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type TokensStudioCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.TOKENS_STUDIO }>;
 type TokensStudioFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.TOKENS_STUDIO }>;
@@ -136,14 +137,7 @@ export function useTokensStudio() {
             themes,
             metadata,
           });
-          const cleanedThemes = themes.map((theme) => ({
-            ...theme,
-            selectedTokenSets: Object.fromEntries(
-              Object.entries(theme.selectedTokenSets).filter(
-                ([setName, status]) => Object.keys(tokens).includes(setName) && status !== 'disabled',
-              ),
-            ),
-          }));
+          const cleanedThemes = cleanThemesSelectedTokenSets(themes, Object.keys(tokens));
 
           const stringifiedRemoteTokens = JSON.stringify(compact([tokens, cleanedThemes, TokenFormat.format]), null, 2);
           dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
@@ -248,14 +242,7 @@ export function useTokensStudio() {
                 themes: data.themes,
                 metadata: data.metadata,
               });
-              const cleanedThemes = data.themes.map((theme) => ({
-                ...theme,
-                selectedTokenSets: Object.fromEntries(
-                  Object.entries(theme.selectedTokenSets).filter(
-                    ([setName, status]) => Object.keys(data.tokens).includes(setName) && status !== 'disabled',
-                  ),
-                ),
-              }));
+              const cleanedThemes = cleanThemesSelectedTokenSets(data.themes, Object.keys(data.tokens));
 
               const stringifiedRemoteTokens = JSON.stringify(compact([data.tokens, cleanedThemes, TokenFormat.format]), null, 2);
               dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
@@ -14,6 +14,7 @@ import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type UrlCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.URL; }>;
 
@@ -72,14 +73,7 @@ export default function useURL() {
             themes: content.themes,
             metadata: content.metadata,
           });
-          const cleanedThemes = content.themes.map((theme) => ({
-            ...theme,
-            selectedTokenSets: Object.fromEntries(
-              Object.entries(theme.selectedTokenSets).filter(
-                ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
-              ),
-            ),
-          }));
+          const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
 
           const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), cleanedThemes, TokenFormat.format]), null, 2);
           dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);

--- a/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
@@ -72,7 +72,16 @@ export default function useURL() {
             themes: content.themes,
             metadata: content.metadata,
           });
-          const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), content.themes, TokenFormat.format]), null, 2);
+          const cleanedThemes = content.themes.map((theme) => ({
+            ...theme,
+            selectedTokenSets: Object.fromEntries(
+              Object.entries(theme.selectedTokenSets).filter(
+                ([setName, status]) => Object.keys(content.tokens).includes(setName) && status !== 'disabled',
+              ),
+            ),
+          }));
+
+          const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), cleanedThemes, TokenFormat.format]), null, 2);
           dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
           dispatch.tokenState.setEditProhibited(true);
           return content;

--- a/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/url.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
-import compact from 'just-compact';
+
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../../plugin/notifiers';
 import { UrlTokenStorage } from '@/storage/UrlTokenStorage';
@@ -12,9 +12,7 @@ import { ErrorMessages } from '@/constants/ErrorMessages';
 import { activeThemeSelector, usedTokenSetSelector } from '@/selectors';
 import { RemoteResponseData } from '@/types/RemoteResponseData';
 import { applyTokenSetOrder } from '@/utils/tokenset';
-import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 type UrlCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.URL; }>;
 
@@ -73,10 +71,10 @@ export default function useURL() {
             themes: content.themes,
             metadata: content.metadata,
           });
-          const cleanedThemes = cleanThemesSelectedTokenSets(content.themes, Object.keys(content.tokens));
-
-          const stringifiedRemoteTokens = JSON.stringify(compact([applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder), cleanedThemes, TokenFormat.format]), null, 2);
-          dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+          dispatch.tokenState.setLastSyncedState({
+            tokens: applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder),
+            themes: content.themes,
+          });
           dispatch.tokenState.setEditProhibited(true);
           return content;
         }

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallback, useMemo } from 'react';
 import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
-import compact from 'just-compact';
+
 import { track } from '@/utils/analytics';
 import { useJSONbin } from './providers/jsonbin';
 import useURL from './providers/url';
@@ -24,7 +24,7 @@ import { StorageProviderType } from '@/constants/StorageProviderType';
 import { StorageTypeCredentials, StorageTypeFormValues } from '@/types/StorageType';
 import { useGenericVersionedStorage } from './providers/generic/versionedStorage';
 import { RemoteResponseData, RemoteResponseStatus } from '@/types/RemoteResponseData';
-import { getFormat, TokenFormat, TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
+import { getFormat, TokenFormatOptions } from '@/plugin/TokenFormatStoreClass';
 import { ErrorMessages } from '@/constants/ErrorMessages';
 import { applyTokenSetOrder } from '@/utils/tokenset';
 import { isEqual } from '@/utils/isEqual';
@@ -33,7 +33,6 @@ import usePullDialog from '../hooks/usePullDialog';
 import { Tabs } from '@/constants/Tabs';
 import { useTokensStudio } from './providers/tokens-studio';
 import { notifyToUI } from '@/plugin/notifiers';
-import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export type PushOverrides = { branch: string; commitMessage: string };
 
@@ -198,15 +197,7 @@ export default function useRemoteTokens() {
           metadata: successData.metadata,
         });
         dispatch.uiState.setHasRemoteChange(false);
-        // Clean up themes to match the format used in comparison (remove disabled token sets)
-        const cleanedThemes = cleanThemesSelectedTokenSets(successData.themes, Object.keys(successData.tokens));
-
-        const stringifiedRemoteTokens = JSON.stringify(
-          compact([successData.tokens, cleanedThemes, TokenFormat.format]),
-          null,
-          2,
-        );
-        dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
+        dispatch.tokenState.setLastSyncedState({ tokens: successData.tokens, themes: successData.themes });
         if (activeTab !== Tabs.LOADING) {
           if (updateLocalTokens) {
             const format = getFormat();

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -188,14 +188,27 @@ export default function useRemoteTokens() {
       }
 
       if (remoteData?.status === 'success') {
+        // Type assertion since we know remoteData is success type here
+        const successData = remoteData as Extract<typeof remoteData, { status: 'success' }>;
+
         dispatch.tokenState.setRemoteData({
-          tokens: remoteData.tokens,
-          themes: remoteData.themes,
-          metadata: remoteData.metadata,
+          tokens: successData.tokens,
+          themes: successData.themes,
+          metadata: successData.metadata,
         });
         dispatch.uiState.setHasRemoteChange(false);
+        // Clean up themes to match the format used in comparison (remove disabled token sets)
+        const cleanedThemes = successData.themes.map((theme) => ({
+          ...theme,
+          selectedTokenSets: Object.fromEntries(
+            Object.entries(theme.selectedTokenSets).filter(
+              ([setName, status]) => Object.keys(successData.tokens).includes(setName) && status !== 'disabled',
+            ),
+          ),
+        }));
+
         const stringifiedRemoteTokens = JSON.stringify(
-          compact([remoteData.tokens, remoteData.themes, TokenFormat.format]),
+          compact([successData.tokens, cleanedThemes, TokenFormat.format]),
           null,
           2,
         );

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -33,6 +33,7 @@ import usePullDialog from '../hooks/usePullDialog';
 import { Tabs } from '@/constants/Tabs';
 import { useTokensStudio } from './providers/tokens-studio';
 import { notifyToUI } from '@/plugin/notifiers';
+import { cleanThemesSelectedTokenSets } from '@/utils/cleanThemesSelectedTokenSets';
 
 export type PushOverrides = { branch: string; commitMessage: string };
 
@@ -198,14 +199,7 @@ export default function useRemoteTokens() {
         });
         dispatch.uiState.setHasRemoteChange(false);
         // Clean up themes to match the format used in comparison (remove disabled token sets)
-        const cleanedThemes = successData.themes.map((theme) => ({
-          ...theme,
-          selectedTokenSets: Object.fromEntries(
-            Object.entries(theme.selectedTokenSets).filter(
-              ([setName, status]) => Object.keys(successData.tokens).includes(setName) && status !== 'disabled',
-            ),
-          ),
-        }));
+        const cleanedThemes = cleanThemesSelectedTokenSets(successData.themes, Object.keys(successData.tokens));
 
         const stringifiedRemoteTokens = JSON.stringify(
           compact([successData.tokens, cleanedThemes, TokenFormat.format]),

--- a/packages/tokens-studio-for-figma/src/utils/cleanThemesSelectedTokenSets.ts
+++ b/packages/tokens-studio-for-figma/src/utils/cleanThemesSelectedTokenSets.ts
@@ -1,0 +1,21 @@
+import { ThemeObjectsList } from '@/types/ThemeObjectsList';
+
+/**
+ * Cleans themes by filtering out disabled token sets from selectedTokenSets
+ * @param themes - Array of theme objects to clean
+ * @param availableTokenSets - Array of available token set names
+ * @returns Cleaned themes with filtered selectedTokenSets
+ */
+export function cleanThemesSelectedTokenSets(
+  themes: ThemeObjectsList,
+  availableTokenSets: string[]
+): ThemeObjectsList {
+  return themes.map((theme) => ({
+    ...theme,
+    selectedTokenSets: Object.fromEntries(
+      Object.entries(theme.selectedTokenSets).filter(
+        ([setName, status]) => availableTokenSets.includes(setName) && status !== 'disabled',
+      ),
+    ),
+  }));
+}


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #3522  <!-- link the related issue -->

The blue dot indicator was incorrectly showing that there were always changes to push to the remote repository, even when the local and remote states were actually identical. This happened because of a format mismatch in how themes were being compared

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

This PR fixes the persistent blue dot by ensuring the lastSyncedState uses the same cleaned theme format (excluding disabled token sets) that's used in current state comparisons, eliminating the format mismatch that caused false change detection


<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

- Rename a token set, included in a theme
- Push the change
- the blue dot should be gone now

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
