### PR TITLE
Fix pullStyles to use raw values when text style variables exist but …

### DIFF
--- a/.changeset/shy-suns-decide.md
+++ b/.changeset/shy-suns-decide.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix pullStyles to use raw values when text style variables exist but no matching tokens found

--- a/packages/tokens-studio-for-figma/src/plugin/pullStyles.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullStyles.test.ts
@@ -212,6 +212,116 @@ describe('pullStyles', () => {
     });
   });
 
+  it('pulls text styles with bound variables but no matching tokens', async () => {
+    figma.getLocalTextStyles.mockReturnValue([
+      {
+        name: 'heading/h1/bold',
+        id: '456',
+        description: 'text style with variables but no tokens',
+        fontSize: 32,
+        boundVariables: {
+          fontSize: { id: 'fontSize-var-id-1' },
+          lineHeight: { id: 'lineHeight-var-id-1' },
+          letterSpacing: { id: 'letterSpacing-var-id-1' },
+          paragraphSpacing: { id: 'paragraphSpacing-var-id-1' },
+          fontFamily: { id: 'fontFamily-var-id-1' },
+          fontStyle: { id: 'fontStyle-var-id-1' },
+        },
+        fontName: { family: 'Roboto', style: 'Bold' },
+        lineHeight: { unit: 'PIXELS', value: 40 },
+        paragraphSpacing: 12,
+        paragraphIndent: 0,
+        letterSpacing: { unit: 'PERCENT', value: 2 },
+        textCase: 'ORIGINAL',
+        textDecoration: 'NONE',
+      },
+    ]);
+
+    // Variables exist in Figma but no matching tokens in token store
+    figma.variables.getLocalVariables.mockReturnValue([
+      {
+        id: 'fontSize-var-id-1',
+        name: 'Typography/heading/fontSize/1',
+        value: '32',
+      },
+      {
+        id: 'lineHeight-var-id-1',
+        name: 'Typography/heading/lineHeight/1',
+        value: '40',
+      },
+      {
+        id: 'letterSpacing-var-id-1',
+        name: 'Typography/heading/letterSpacing/1',
+        value: '2%',
+      },
+      {
+        id: 'paragraphSpacing-var-id-1',
+        name: 'Typography/heading/paragraphSpacing/1',
+        value: '12',
+      },
+      {
+        id: 'fontFamily-var-id-1',
+        name: 'Typography/heading/fontFamily/1',
+        value: 'Roboto',
+      },
+      {
+        id: 'fontStyle-var-id-1',
+        name: 'Typography/heading/fontStyle/1',
+        value: 'Bold',
+      },
+    ]);
+
+    await pullStyles({ textStyles: true });
+
+    expect(notifyStyleValuesSpy).toHaveBeenCalledWith({
+      typography: [
+        {
+          name: 'heading.h1.bold',
+          type: 'typography',
+          value: {
+            fontFamily: 'Roboto', // Should use raw value when no token found
+            fontWeight: 'Bold', // Should use raw value when no token found
+            fontSize: '32', // Should use raw value when no token found
+            lineHeight: '40', // Should use raw value when no token found
+            letterSpacing: '2%', // Should use raw value when no token found
+            paragraphSpacing: '12', // Should use raw value when no token found
+            paragraphIndent: '0px', // Raw value
+            textCase: 'none', // Raw value
+            textDecoration: 'none', // Raw value
+          },
+          description: 'text style with variables but no tokens',
+        },
+      ],
+      fontFamilies: [
+        { name: 'fontFamilies.roboto', type: 'fontFamilies', value: 'Roboto' },
+      ],
+      fontWeights: [
+        { name: 'fontWeights.roboto-0', type: 'fontWeights', value: 'Bold' },
+      ],
+      fontSizes: [
+        { name: 'fontSize.0', type: 'fontSizes', value: '32' },
+      ],
+      letterSpacing: [
+        { name: 'letterSpacing.0', type: 'letterSpacing', value: '2%' },
+      ],
+      lineHeights: [
+        { name: 'lineHeights.0', type: 'lineHeights', value: '40' },
+      ],
+      paragraphSpacing: [
+        { name: 'paragraphSpacing.0', type: 'paragraphSpacing', value: '12' },
+      ],
+      paragraphIndent: [
+        { name: 'paragraphIndent.0', type: 'dimension', value: '0px' },
+      ],
+      textCase: [
+        { name: 'textCase.none', type: 'textCase', value: 'none' },
+      ],
+      textDecoration: [
+        { name: 'textDecoration.none', type: 'textDecoration', value: 'none' },
+      ],
+    });
+  });
+
   it('pulls shadow styles', async () => {
     figma.getLocalEffectStyles.mockReturnValue([
       {

--- a/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/pullStyles.ts
@@ -278,15 +278,15 @@ export default async function pullStyles(styleTypes: PullStyleOptions): Promise<
       );
 
       const obj = {
-        fontFamily: `{${foundFamily?.name}}`,
-        fontWeight: `{${foundFontWeight?.name}}`,
-        lineHeight: `{${foundLineHeight?.name}}`,
-        fontSize: `{${foundFontSize?.name}}`,
-        letterSpacing: `{${foundLetterSpacing?.name}}`,
-        paragraphSpacing: `{${foundParagraphSpacing?.name}}`,
-        paragraphIndent: `{${foundParagraphIndent?.name}}`,
-        textCase: `{${foundTextCase?.name}}`,
-        textDecoration: `{${foundTextDecoration?.name}}`,
+        fontFamily: foundFamily?.name ? `{${foundFamily.name}}` : style.fontName.family,
+        fontWeight: foundFontWeight?.name ? `{${foundFontWeight.name}}` : style.fontName.style,
+        lineHeight: foundLineHeight?.name ? `{${foundLineHeight.name}}` : convertFigmaToLineHeight(style.lineHeight).toString(),
+        fontSize: foundFontSize?.name ? `{${foundFontSize.name}}` : style.fontSize.toString(),
+        letterSpacing: foundLetterSpacing?.name ? `{${foundLetterSpacing.name}}` : convertFigmaToLetterSpacing(style.letterSpacing).toString(),
+        paragraphSpacing: foundParagraphSpacing?.name ? `{${foundParagraphSpacing.name}}` : style.paragraphSpacing.toString(),
+        paragraphIndent: foundParagraphIndent?.name ? `{${foundParagraphIndent.name}}` : `${style.paragraphIndent.toString()}px`,
+        textCase: foundTextCase?.name ? `{${foundTextCase.name}}` : convertFigmaToTextCase(style.textCase),
+        textDecoration: foundTextDecoration?.name ? `{${foundTextDecoration.name}}` : convertFigmaToTextDecoration(style.textDecoration),
       };
 
       const normalizedName = style.name

--- a/packages/tokens-studio-for-figma/tests/__mocks__/textEncoderDecoderMock.js
+++ b/packages/tokens-studio-for-figma/tests/__mocks__/textEncoderDecoderMock.js
@@ -1,3 +1,3 @@
-import { TextEncoder, TextDecoder } from 'util'
+const { TextEncoder, TextDecoder } = require('util')
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder


### PR DESCRIPTION
Previously, when importing text styles with bound variables that don't have corresponding tokens in the token store, the system would create typography tokens with {undefined} values instead of using the raw style values.

This fix modifies the typography object construction to:
- Use token references ({tokenName}) when matching tokens are found
- Fall back to raw style values when variables exist but no tokens match
- Continue using raw values when no variables exist

Resolves the issue where text styles would show {undefined} for fontFamily, fontWeight, fontSize, etc. when variable references couldn't be resolved to existing tokens.

<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes https://github.com/tokens-studio/figma-plugin/issues/3458


### Testing this change
**Setup**: Create a Figma file with text styles that have bound variables │
 │  but no corresponding tokens in your token store     
**Import**: Use the "Pull from Figma" feature to import text styles       │
**Verify**: Check that the resulting typography tokens contain actual     │
 │ values (e.g., `"Roboto"`, `"Bold"`, `"32"`) instead of `{undefined}` 