### PR TITLE
fix: display resolved value of 0 in token tooltip

### DIFF
--- a/.changeset/fix-tooltip-zero-value.md
+++ b/.changeset/fix-tooltip-zero-value.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix token tooltip not displaying resolved value when value is 0

--- a/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/AliasBadge.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/AliasBadge.tsx
@@ -21,7 +21,7 @@ export default function AliasBadge({ value }: Props) {
 
   return (
     <StyledAliasBadge>
-      {formatTokenValueForDisplay(value || '', currentBaseFontSize)}
+      {formatTokenValueForDisplay(value ?? '', currentBaseFontSize)}
     </StyledAliasBadge>
   );
 }

--- a/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/TokenTooltipContent.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/TokenTooltipContent.test.tsx
@@ -217,6 +217,20 @@ const tokens: SingleToken[] = [
     failedToResolve: true,
   },
   {
+    name: 'spacing.none',
+    type: TokenTypes.SPACING,
+    value: 0,
+    rawValue: 0,
+    description: 'zero value token',
+  },
+  {
+    name: 'spacing.alias',
+    type: TokenTypes.SPACING,
+    value: 0,
+    rawValue: '{spacing.none}',
+    description: 'alias to zero value token',
+  },
+  {
     name: 'border.regular',
     type: TokenTypes.BORDER,
     value: {
@@ -419,5 +433,53 @@ describe('TokenTooltip alias', () => {
 
     expect(getByText(String('brokentoken'))).toBeInTheDocument();
     expect(getByTestId('not-found-badge')).toBeInTheDocument();
+  });
+
+  it('displays resolved value of 0 correctly', () => {
+    const { getByText } = render(
+      <TokensContext.Provider value={customStore}>
+        <TokenTooltipContent
+          token={{
+            name: 'spacing.alias',
+            type: TokenTypes.SPACING,
+            value: '{spacing.none}',
+            rawValue: '{spacing.none}',
+            description: 'alias to zero value token',
+          }}
+        />
+      </TokensContext.Provider>,
+    );
+
+    expect(getByText('0')).toBeInTheDocument();
+  });
+
+  it('displays zero values in composition token tooltip', () => {
+    const compositionZeroToken = {
+      name: 'card.zero',
+      type: TokenTypes.COMPOSITION,
+      value: {
+        spacing: 0,
+        borderRadius: 0,
+      },
+      rawValue: {
+        spacing: 0,
+        borderRadius: 0,
+      },
+      description: 'composition token with zero values',
+    } as SingleToken;
+
+    const store = {
+      resolvedTokens: [compositionZeroToken],
+    };
+
+    const { getAllByText, getByText } = render(
+      <TokensContext.Provider value={store}>
+        <TokenTooltipContent token={compositionZeroToken} />
+      </TokensContext.Provider>,
+    );
+
+    expect(getByText('spacing')).toBeInTheDocument();
+    expect(getByText('borderRadius')).toBeInTheDocument();
+    expect(getAllByText('0').length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3776

When a token's resolved value is exactly `0`, the tooltip's alias badge was showing a blank value instead of displaying "0".

## Root Cause

In `AliasBadge.tsx`, the expression `value || ''` was used to provide a fallback. Since `0` is falsy in JavaScript, this treated a valid value of `0` the same as `null`/`undefined`, replacing it with an empty string.

## Fix

Changed `value || ''` to `value ?? ''` (nullish coalescing), which only falls back to `''` for `null` and `undefined` — not for `0`.

## Testing

- Added test tokens with value `0` and an alias referencing them
- Added explicit test case verifying the resolved value `0` is displayed in the tooltip
- All 33 tooltip tests pass