### PR TITLE
feat: save variable and style references for Studio projects

### DIFF
--- a/.changeset/theme-refs-round-trip.md
+++ b/.changeset/theme-refs-round-trip.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Added support for saving variable and style references for Studio projects

--- a/packages/tokens-studio-for-figma/src/app/store/middlewares/tokenState.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/middlewares/tokenState.ts
@@ -1,6 +1,6 @@
 import { StorageProviderType } from '@/constants/StorageProviderType';
 import { updateThemeGroupsInTokensStudio } from '@/storage/tokensStudio/updateThemeGroupsInTokensStudio';
-import { updateThemeRefsViaRestApi } from '@/utils/tokensStudio/updateThemeRefsViaRestApi';
+import { updateThemeRefsViaRestApi, snapshotThemeRefs } from '@/utils/tokensStudio/updateThemeRefsViaRestApi';
 
 const actionsToTriggerUpdateInTokensStudio = [
   'tokenState/assignVariableIdsToCurrentTheme',
@@ -33,6 +33,14 @@ const refOnlyActions = [
 
 export const tokenStateMiddleware = (store) => (next) => (action) => {
   const prevState = store.getState();
+
+  // Capture refs snapshot BEFORE the action runs
+  const isOAuthRefAction = prevState.uiState.api?.provider === StorageProviderType.TOKENS_STUDIO_OAUTH
+    && refOnlyActions.includes(action.type);
+  const prevThemeRefs = isOAuthRefAction
+    ? snapshotThemeRefs(prevState.tokenState.themes)
+    : undefined;
+
   next(action);
   const nextState = store.getState();
 
@@ -48,12 +56,9 @@ export const tokenStateMiddleware = (store) => (next) => (action) => {
     });
   }
 
-  if (
-    nextState.uiState.api?.provider === StorageProviderType.TOKENS_STUDIO_OAUTH
-      && refOnlyActions.includes(action.type)
-  ) {
+  if (prevThemeRefs) {
     updateThemeRefsViaRestApi({
-      prevState,
+      prevThemeRefs,
       rootState: nextState,
     }).catch((err) => console.error('[tokenStateMiddleware] REST ref sync failed:', err));
   }

--- a/packages/tokens-studio-for-figma/src/app/store/middlewares/tokenState.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/middlewares/tokenState.ts
@@ -22,6 +22,13 @@ const refOnlyActions = [
   'tokenState/assignStyleIdsToTheme',
   'tokenState/disconnectVariableFromTheme',
   'tokenState/disconnectStyleFromTheme',
+  'tokenState/renameVariableIdsToTheme',
+  'tokenState/renameStyleIdsToCurrentTheme',
+  'tokenState/renameVariableNamesToThemes',
+  'tokenState/renameStyleNamesToCurrentTheme',
+  'tokenState/removeVariableNamesFromThemes',
+  'tokenState/removeStyleNamesFromThemes',
+  'tokenState/removeStyleIdsFromThemes',
 ];
 
 export const tokenStateMiddleware = (store) => (next) => (action) => {
@@ -48,6 +55,6 @@ export const tokenStateMiddleware = (store) => (next) => (action) => {
     updateThemeRefsViaRestApi({
       prevState,
       rootState: nextState,
-    });
+    }).catch((err) => console.error('[tokenStateMiddleware] REST ref sync failed:', err));
   }
 };

--- a/packages/tokens-studio-for-figma/src/app/store/middlewares/tokenState.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/middlewares/tokenState.ts
@@ -1,5 +1,6 @@
 import { StorageProviderType } from '@/constants/StorageProviderType';
 import { updateThemeGroupsInTokensStudio } from '@/storage/tokensStudio/updateThemeGroupsInTokensStudio';
+import { updateThemeRefsViaRestApi } from '@/utils/tokensStudio/updateThemeRefsViaRestApi';
 
 const actionsToTriggerUpdateInTokensStudio = [
   'tokenState/assignVariableIdsToCurrentTheme',
@@ -10,6 +11,15 @@ const actionsToTriggerUpdateInTokensStudio = [
   'tokenState/setThemes',
   'tokenState/deleteTheme',
   'tokenState/updateThemeGroupName',
+  'tokenState/disconnectVariableFromTheme',
+  'tokenState/disconnectStyleFromTheme',
+];
+
+const refOnlyActions = [
+  'tokenState/assignVariableIdsToCurrentTheme',
+  'tokenState/assignVariableIdsToTheme',
+  'tokenState/assignStyleIdsToCurrentTheme',
+  'tokenState/assignStyleIdsToTheme',
   'tokenState/disconnectVariableFromTheme',
   'tokenState/disconnectStyleFromTheme',
 ];
@@ -28,6 +38,16 @@ export const tokenStateMiddleware = (store) => (next) => (action) => {
       rootState: nextState,
       action,
       dispatch: store.dispatch,
+    });
+  }
+
+  if (
+    nextState.uiState.api?.provider === StorageProviderType.TOKENS_STUDIO_OAUTH
+      && refOnlyActions.includes(action.type)
+  ) {
+    updateThemeRefsViaRestApi({
+      prevState,
+      rootState: nextState,
     });
   }
 };

--- a/packages/tokens-studio-for-figma/src/storage/schemas/themeObjectSchema.ts
+++ b/packages/tokens-studio-for-figma/src/storage/schemas/themeObjectSchema.ts
@@ -14,4 +14,6 @@ export const themeObjectSchema = z.object({
   $figmaVariableReferences: z.record(z.string()).optional(),
   $figmaCollectionId: z.string().optional(),
   $figmaModeId: z.string().optional(),
+  $themeGroupId: z.string().optional(),
+  $themeOptionId: z.string().optional(),
 });

--- a/packages/tokens-studio-for-figma/src/types/ThemeObject.ts
+++ b/packages/tokens-studio-for-figma/src/types/ThemeObject.ts
@@ -15,4 +15,7 @@ export type ThemeObject = {
   $figmaCollectionId?: string;
   $figmaModeId?: string;
   $figmaVariableReferences?: Record<string, string>;
+  // Server IDs for REST API round-trip (Studio-on-Rails)
+  $themeGroupId?: string;
+  $themeOptionId?: string;
 };

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchBranchesListRest.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchBranchesListRest.ts
@@ -25,6 +25,33 @@ export function parseBranchesFromResponse(branchesData: any): RestBranch[] {
   return branches;
 }
 
+export async function resolveChangeSetId(
+  authToken: string,
+  apiBaseUrl: string,
+  projectId: string,
+  branchName: string,
+): Promise<string | null> {
+  const headers = {
+    Authorization: `Bearer ${authToken}`,
+    'Content-Type': 'application/json',
+  };
+
+  try {
+    const branchesRes = await fetch(`${apiBaseUrl}/api/v1/projects/${projectId}/branches`, { headers });
+    if (!branchesRes.ok) throw new Error(`Failed to fetch branches: ${branchesRes.statusText}`);
+    const branchesData = await branchesRes.json();
+
+    const branches = parseBranchesFromResponse(branchesData);
+    const branch = branches.find((b) => b.name === branchName)
+      || branches.find((b) => b.is_default);
+
+    return branch?.change_set_id || null;
+  } catch (error) {
+    console.error('Error resolving change_set_id:', error);
+    return null;
+  }
+}
+
 export async function fetchBranchesListRest(
   authToken: string,
   apiBaseUrl: string,

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
@@ -20,7 +20,6 @@ interface RestThemeOption {
   theme_group_id: string;
   selected_token_sets: Record<string, string>;
   figmaStyleReferences?: Record<string, string>;
-  figmaVariableReferences?: Record<string, string>;
   figmaCollectionId?: string;
   figmaModeId?: string;
 }
@@ -219,7 +218,6 @@ export async function fetchProjectDataRest(
           theme_group_id: item.relationships?.theme_group?.data?.id || '',
           selected_token_sets: item.attributes?.selected_token_sets || {},
           figmaStyleReferences: item.attributes?.figma_style_references,
-          figmaVariableReferences: item.attributes?.figma_variable_references,
           figmaCollectionId: item.attributes?.figma_collection_id,
           figmaModeId: item.attributes?.figma_mode_id,
         });
@@ -232,12 +230,13 @@ export async function fetchProjectDataRest(
       optionsByGroupId[opt.theme_group_id].push(opt);
     });
 
-    // Parse theme groups
+    // Parse theme groups — variable refs live at the group level
     const themes: ThemeObjectsList = [];
     if (themeGroupsData.data && Array.isArray(themeGroupsData.data)) {
       themeGroupsData.data.forEach((group: any) => {
         const { id } = group;
         const name = group.attributes?.name || id;
+        const groupVariableRefs: Record<string, string> | undefined = group.attributes?.figma_variable_references;
         const options = optionsByGroupId[id] || [];
 
         options.forEach((opt) => {
@@ -255,10 +254,12 @@ export async function fetchProjectDataRest(
             name: opt.name,
             group: name,
             selectedTokenSets: selectedTokenSetsByName as any,
+            $themeGroupId: id,
+            $themeOptionId: opt.id,
           };
 
           if (opt.figmaStyleReferences !== undefined) themeObj.$figmaStyleReferences = opt.figmaStyleReferences;
-          if (opt.figmaVariableReferences !== undefined) themeObj.$figmaVariableReferences = opt.figmaVariableReferences;
+          if (groupVariableRefs !== undefined) themeObj.$figmaVariableReferences = groupVariableRefs;
           if (opt.figmaCollectionId !== undefined) themeObj.$figmaCollectionId = opt.figmaCollectionId;
           if (opt.figmaModeId !== undefined) themeObj.$figmaModeId = opt.figmaModeId;
 

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
@@ -259,7 +259,7 @@ export async function fetchProjectDataRest(
           };
 
           if (opt.figmaStyleReferences !== undefined) themeObj.$figmaStyleReferences = opt.figmaStyleReferences;
-          if (groupVariableRefs !== undefined) themeObj.$figmaVariableReferences = groupVariableRefs;
+          if (groupVariableRefs !== undefined) themeObj.$figmaVariableReferences = { ...groupVariableRefs };
           if (opt.figmaCollectionId !== undefined) themeObj.$figmaCollectionId = opt.figmaCollectionId;
           if (opt.figmaModeId !== undefined) themeObj.$figmaModeId = opt.figmaModeId;
 

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/pushThemeRefsRest.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/pushThemeRefsRest.test.ts
@@ -1,0 +1,102 @@
+import { patchThemeGroupVariableRefs, patchThemeOptionStyleRefs } from './pushThemeRefsRest';
+
+describe('pushThemeRefsRest', () => {
+  const mockFetch = jest.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  const authToken = 'test-token';
+  const apiBaseUrl = 'https://studio.example.com';
+  const projectId = 'proj-123';
+  const changeSetId = 'cs-456';
+
+  describe('patchThemeGroupVariableRefs', () => {
+    it('should skip PATCH when refs is undefined (preserve semantics)', async () => {
+      await patchThemeGroupVariableRefs(authToken, apiBaseUrl, projectId, changeSetId, 'group-1', undefined);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should PATCH with empty object to clear refs', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+
+      await patchThemeGroupVariableRefs(authToken, apiBaseUrl, projectId, changeSetId, 'group-1', {});
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${apiBaseUrl}/api/v1/projects/${projectId}/theme_groups/group-1?change_set_id=${encodeURIComponent(changeSetId)}`,
+        expect.objectContaining({
+          method: 'PATCH',
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${authToken}`,
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ theme_group: { figma_variable_references: {} } }),
+        }),
+      );
+    });
+
+    it('should PATCH with refs map', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const refs = { 'color.brand.500': 'VariableID:123:456' };
+
+      await patchThemeGroupVariableRefs(authToken, apiBaseUrl, projectId, changeSetId, 'group-1', refs);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.theme_group.figma_variable_references).toEqual(refs);
+    });
+
+    it('should throw on non-OK response', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 422, text: () => Promise.resolve('Unprocessable') });
+
+      await expect(
+        patchThemeGroupVariableRefs(authToken, apiBaseUrl, projectId, changeSetId, 'group-1', {}),
+      ).rejects.toThrow('Failed to PATCH theme_group variable refs (422)');
+    });
+  });
+
+  describe('patchThemeOptionStyleRefs', () => {
+    it('should skip PATCH when refs is undefined (preserve semantics)', async () => {
+      await patchThemeOptionStyleRefs(authToken, apiBaseUrl, projectId, changeSetId, 'opt-1', undefined);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should PATCH with empty object to clear refs', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+
+      await patchThemeOptionStyleRefs(authToken, apiBaseUrl, projectId, changeSetId, 'opt-1', {});
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${apiBaseUrl}/api/v1/projects/${projectId}/theme_options/opt-1?change_set_id=${encodeURIComponent(changeSetId)}`,
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ theme_option: { figma_style_references: {} } }),
+        }),
+      );
+    });
+
+    it('should PATCH with style refs verbatim (S: prefix included)', async () => {
+      mockFetch.mockResolvedValue({ ok: true });
+      const refs = { 'hint.text': 'S:81e4c301abc,' };
+
+      await patchThemeOptionStyleRefs(authToken, apiBaseUrl, projectId, changeSetId, 'opt-1', refs);
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.theme_option.figma_style_references).toEqual(refs);
+    });
+
+    it('should throw on non-OK response', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('Internal') });
+
+      await expect(
+        patchThemeOptionStyleRefs(authToken, apiBaseUrl, projectId, changeSetId, 'opt-1', {}),
+      ).rejects.toThrow('Failed to PATCH theme_option style refs (500)');
+    });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/pushThemeRefsRest.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/pushThemeRefsRest.ts
@@ -1,0 +1,73 @@
+/**
+ * REST PATCH helpers for syncing $figmaVariableReferences and $figmaStyleReferences
+ * with Studio-on-Rails theme_groups and theme_options endpoints.
+ *
+ * Semantics:
+ * - undefined → omit key from payload (preserve existing refs on server)
+ * - {}       → explicitly clear all refs
+ * - never send null
+ */
+
+export async function patchThemeGroupVariableRefs(
+  authToken: string,
+  apiBaseUrl: string,
+  projectId: string,
+  changeSetId: string,
+  themeGroupId: string,
+  refs: Record<string, string> | undefined,
+): Promise<void> {
+  if (refs === undefined) return;
+
+  const url = `${apiBaseUrl}/api/v1/projects/${projectId}/theme_groups/${themeGroupId}?change_set_id=${encodeURIComponent(changeSetId)}`;
+  const body = {
+    theme_group: {
+      figma_variable_references: refs,
+    },
+  };
+
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => '');
+    throw new Error(`Failed to PATCH theme_group variable refs (${res.status}): ${errorText}`);
+  }
+}
+
+export async function patchThemeOptionStyleRefs(
+  authToken: string,
+  apiBaseUrl: string,
+  projectId: string,
+  changeSetId: string,
+  themeOptionId: string,
+  refs: Record<string, string> | undefined,
+): Promise<void> {
+  if (refs === undefined) return;
+
+  const url = `${apiBaseUrl}/api/v1/projects/${projectId}/theme_options/${themeOptionId}?change_set_id=${encodeURIComponent(changeSetId)}`;
+  const body = {
+    theme_option: {
+      figma_style_references: refs,
+    },
+  };
+
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => '');
+    throw new Error(`Failed to PATCH theme_option style refs (${res.status}): ${errorText}`);
+  }
+}

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.test.ts
@@ -1,4 +1,4 @@
-import { updateThemeRefsViaRestApi } from './updateThemeRefsViaRestApi';
+import { updateThemeRefsViaRestApi, snapshotThemeRefs } from './updateThemeRefsViaRestApi';
 
 // Mock dependencies
 jest.mock('@/app/store/useAuthStore', () => ({
@@ -46,7 +46,7 @@ describe('updateThemeRefsViaRestApi', () => {
     mockPatchOption.mockResolvedValue(undefined);
   });
 
-  const makeState = (themes: any[], api?: any) => ({
+  const makeRootState = (themes: any[], api?: any) => ({
     tokenState: { themes },
     uiState: { api: api || { provider: 'tokensstudio-oauth', id: 'proj-1', branch: 'main' } },
   });
@@ -62,8 +62,8 @@ describe('updateThemeRefsViaRestApi', () => {
     }];
 
     await updateThemeRefsViaRestApi({
-      prevState: makeState(themes) as any,
-      rootState: makeState(themes) as any,
+      prevThemeRefs: snapshotThemeRefs(themes as any),
+      rootState: makeRootState(themes) as any,
     });
 
     expect(mockPatchGroup).not.toHaveBeenCalled();
@@ -87,8 +87,8 @@ describe('updateThemeRefsViaRestApi', () => {
     }];
 
     await updateThemeRefsViaRestApi({
-      prevState: makeState(prevThemes) as any,
-      rootState: makeState(nextThemes) as any,
+      prevThemeRefs: snapshotThemeRefs(prevThemes as any),
+      rootState: makeRootState(nextThemes) as any,
     });
 
     expect(mockPatchGroup).toHaveBeenCalledWith(
@@ -118,8 +118,8 @@ describe('updateThemeRefsViaRestApi', () => {
     }];
 
     await updateThemeRefsViaRestApi({
-      prevState: makeState(prevThemes) as any,
-      rootState: makeState(nextThemes) as any,
+      prevThemeRefs: snapshotThemeRefs(prevThemes as any),
+      rootState: makeRootState(nextThemes) as any,
     });
 
     expect(mockPatchOption).toHaveBeenCalledWith(
@@ -143,8 +143,8 @@ describe('updateThemeRefsViaRestApi', () => {
     ];
 
     await updateThemeRefsViaRestApi({
-      prevState: makeState(prevThemes) as any,
-      rootState: makeState(nextThemes) as any,
+      prevThemeRefs: snapshotThemeRefs(prevThemes as any),
+      rootState: makeRootState(nextThemes) as any,
     });
 
     expect(mockPatchGroup).toHaveBeenCalledTimes(1);
@@ -154,8 +154,8 @@ describe('updateThemeRefsViaRestApi', () => {
     mockGetState.mockReturnValue({ oauthTokens: null });
 
     await updateThemeRefsViaRestApi({
-      prevState: makeState([]) as any,
-      rootState: makeState([]) as any,
+      prevThemeRefs: new Map(),
+      rootState: makeRootState([]) as any,
     });
 
     expect(mockResolveChangeSetId).not.toHaveBeenCalled();
@@ -171,12 +171,54 @@ describe('updateThemeRefsViaRestApi', () => {
     }];
 
     await updateThemeRefsViaRestApi({
-      prevState: makeState([{ id: 'opt-1', $themeGroupId: 'grp-1', $themeOptionId: 'opt-1' }]) as any,
-      rootState: makeState(themes) as any,
+      prevThemeRefs: snapshotThemeRefs([{ id: 'opt-1', $themeGroupId: 'grp-1', $themeOptionId: 'opt-1' }] as any),
+      rootState: makeRootState(themes) as any,
     });
 
     expect(mockPatchGroup).not.toHaveBeenCalled();
     expect(mockPatchOption).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  it('should correctly detect changes even when refs are mutated in-place by utilizing snapshots', async () => {
+    // Simulate what the current reducers do: mutate refs in-place
+    const sharedVarRefs = { 'color.old': 'VarID:1' };
+    
+    const themesBeforeMutation = [{
+      id: 'light',
+      $themeGroupId: 'grp-1',
+      $themeOptionId: 'opt-1',
+      $figmaVariableReferences: sharedVarRefs,
+    }];
+
+    // Capture snapshot BEFORE the mutation
+    const prevThemeRefs = snapshotThemeRefs(themesBeforeMutation as any);
+
+    // Now mutate in-place (simulating the reducer)
+    sharedVarRefs['color.new'] = 'VarID:1';
+    delete sharedVarRefs['color.old'];
+
+    // nextState themes point to the mutated sharedVarRefs object
+    const nextThemes = [{
+      id: 'light',
+      $themeGroupId: 'grp-1',
+      $themeOptionId: 'opt-1',
+      $figmaVariableReferences: sharedVarRefs,
+    }];
+
+    await updateThemeRefsViaRestApi({
+      prevThemeRefs,
+      rootState: makeRootState(nextThemes) as any,
+    });
+
+    // The diff should succeed because it compares against the snapshot
+    expect(mockPatchGroup).toHaveBeenCalledWith(
+      'test-token',
+      'https://api.studio.example.com',
+      'proj-1',
+      'cs-789',
+      'grp-1',
+      { 'color.new': 'VarID:1' },
+    );
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.test.ts
@@ -1,0 +1,180 @@
+import { updateThemeRefsViaRestApi } from './updateThemeRefsViaRestApi';
+
+// Mock dependencies
+jest.mock('@/app/store/useAuthStore', () => ({
+  useAuthStore: {
+    getState: jest.fn(),
+  },
+}));
+
+jest.mock('@/app/services/OAuthService', () => ({
+  OAuthService: {
+    getApiBaseUrl: jest.fn(() => 'https://api.studio.example.com'),
+  },
+}));
+
+jest.mock('@/constants/TokensStudio', () => ({
+  TOKENS_STUDIO_APP_URL: 'https://studio.example.com',
+}));
+
+jest.mock('./fetchBranchesListRest', () => ({
+  resolveChangeSetId: jest.fn(),
+}));
+
+jest.mock('./pushThemeRefsRest', () => ({
+  patchThemeGroupVariableRefs: jest.fn(),
+  patchThemeOptionStyleRefs: jest.fn(),
+}));
+
+import { useAuthStore } from '@/app/store/useAuthStore';
+import { resolveChangeSetId } from './fetchBranchesListRest';
+import { patchThemeGroupVariableRefs, patchThemeOptionStyleRefs } from './pushThemeRefsRest';
+
+describe('updateThemeRefsViaRestApi', () => {
+  const mockGetState = useAuthStore.getState as jest.Mock;
+  const mockResolveChangeSetId = resolveChangeSetId as jest.Mock;
+  const mockPatchGroup = patchThemeGroupVariableRefs as jest.Mock;
+  const mockPatchOption = patchThemeOptionStyleRefs as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetState.mockReturnValue({
+      oauthTokens: { accessToken: 'test-token' },
+    });
+    mockResolveChangeSetId.mockResolvedValue('cs-789');
+    mockPatchGroup.mockResolvedValue(undefined);
+    mockPatchOption.mockResolvedValue(undefined);
+  });
+
+  const makeState = (themes: any[], api?: any) => ({
+    tokenState: { themes },
+    uiState: { api: api || { provider: 'tokensstudio-oauth', id: 'proj-1', branch: 'main' } },
+  });
+
+  it('should not call PATCH when no refs changed', async () => {
+    const themes = [{
+      id: 'opt-1',
+      name: 'Light',
+      $themeGroupId: 'grp-1',
+      $themeOptionId: 'opt-1',
+      $figmaVariableReferences: { 'color.bg': 'VarID:1:1' },
+      $figmaStyleReferences: { 'text.body': 'S:abc,' },
+    }];
+
+    await updateThemeRefsViaRestApi({
+      prevState: makeState(themes) as any,
+      rootState: makeState(themes) as any,
+    });
+
+    expect(mockPatchGroup).not.toHaveBeenCalled();
+    expect(mockPatchOption).not.toHaveBeenCalled();
+  });
+
+  it('should PATCH variable refs when they change (group-level)', async () => {
+    const prevThemes = [{
+      id: 'opt-1',
+      name: 'Light',
+      $themeGroupId: 'grp-1',
+      $themeOptionId: 'opt-1',
+      $figmaVariableReferences: { 'color.bg': 'VarID:1:1' },
+    }];
+    const nextThemes = [{
+      id: 'opt-1',
+      name: 'Light',
+      $themeGroupId: 'grp-1',
+      $themeOptionId: 'opt-1',
+      $figmaVariableReferences: { 'color.bg': 'VarID:1:1', 'color.fg': 'VarID:2:2' },
+    }];
+
+    await updateThemeRefsViaRestApi({
+      prevState: makeState(prevThemes) as any,
+      rootState: makeState(nextThemes) as any,
+    });
+
+    expect(mockPatchGroup).toHaveBeenCalledWith(
+      'test-token',
+      'https://api.studio.example.com',
+      'proj-1',
+      'cs-789',
+      'grp-1',
+      { 'color.bg': 'VarID:1:1', 'color.fg': 'VarID:2:2' },
+    );
+  });
+
+  it('should PATCH style refs when they change (option-level)', async () => {
+    const prevThemes = [{
+      id: 'opt-1',
+      name: 'Light',
+      $themeGroupId: 'grp-1',
+      $themeOptionId: 'opt-1',
+      $figmaStyleReferences: { 'text.body': 'S:abc,' },
+    }];
+    const nextThemes = [{
+      id: 'opt-1',
+      name: 'Light',
+      $themeGroupId: 'grp-1',
+      $themeOptionId: 'opt-1',
+      $figmaStyleReferences: { 'text.body': 'S:abc,', 'text.heading': 'S:def,' },
+    }];
+
+    await updateThemeRefsViaRestApi({
+      prevState: makeState(prevThemes) as any,
+      rootState: makeState(nextThemes) as any,
+    });
+
+    expect(mockPatchOption).toHaveBeenCalledWith(
+      'test-token',
+      'https://api.studio.example.com',
+      'proj-1',
+      'cs-789',
+      'opt-1',
+      { 'text.body': 'S:abc,', 'text.heading': 'S:def,' },
+    );
+  });
+
+  it('should only PATCH group once even if multiple options share it', async () => {
+    const prevThemes = [
+      { id: 'opt-1', name: 'Light', $themeGroupId: 'grp-1', $themeOptionId: 'opt-1', $figmaVariableReferences: {} },
+      { id: 'opt-2', name: 'Dark', $themeGroupId: 'grp-1', $themeOptionId: 'opt-2', $figmaVariableReferences: {} },
+    ];
+    const nextThemes = [
+      { id: 'opt-1', name: 'Light', $themeGroupId: 'grp-1', $themeOptionId: 'opt-1', $figmaVariableReferences: { 'x': 'y' } },
+      { id: 'opt-2', name: 'Dark', $themeGroupId: 'grp-1', $themeOptionId: 'opt-2', $figmaVariableReferences: { 'x': 'y' } },
+    ];
+
+    await updateThemeRefsViaRestApi({
+      prevState: makeState(prevThemes) as any,
+      rootState: makeState(nextThemes) as any,
+    });
+
+    expect(mockPatchGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it('should abort if no OAuth token', async () => {
+    mockGetState.mockReturnValue({ oauthTokens: null });
+
+    await updateThemeRefsViaRestApi({
+      prevState: makeState([]) as any,
+      rootState: makeState([]) as any,
+    });
+
+    expect(mockResolveChangeSetId).not.toHaveBeenCalled();
+  });
+
+  it('should abort if changeSetId cannot be resolved', async () => {
+    mockResolveChangeSetId.mockResolvedValue(null);
+
+    const themes = [{
+      id: 'opt-1', $themeGroupId: 'grp-1', $themeOptionId: 'opt-1',
+      $figmaVariableReferences: { a: 'b' },
+    }];
+
+    await updateThemeRefsViaRestApi({
+      prevState: makeState([{ id: 'opt-1', $themeGroupId: 'grp-1', $themeOptionId: 'opt-1' }]) as any,
+      rootState: makeState(themes) as any,
+    });
+
+    expect(mockPatchGroup).not.toHaveBeenCalled();
+    expect(mockPatchOption).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.test.ts
@@ -162,6 +162,7 @@ describe('updateThemeRefsViaRestApi', () => {
   });
 
   it('should abort if changeSetId cannot be resolved', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
     mockResolveChangeSetId.mockResolvedValue(null);
 
     const themes = [{
@@ -176,5 +177,6 @@ describe('updateThemeRefsViaRestApi', () => {
 
     expect(mockPatchGroup).not.toHaveBeenCalled();
     expect(mockPatchOption).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
@@ -12,6 +12,18 @@ interface UpdateThemeRefsPayload {
   rootState: RematchRootState<RootModel, Record<string, never>>;
 }
 
+function shallowEqual(
+  a: Record<string, string> | undefined,
+  b: Record<string, string> | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((k) => a[k] === b[k]);
+}
+
 /**
  * Diffs prev vs next themes and PATCHes changed refs to Studio-on-Rails.
  * Only called for ref-mutation actions on the OAuth provider path.
@@ -50,64 +62,52 @@ export async function updateThemeRefsViaRestApi({
 
   for (const nextTheme of nextThemes) {
     const prevTheme = prevThemes.find((t) => t.id === nextTheme.id);
-    if (!prevTheme) continue;
+    if (prevTheme) {
+      const themeGroupId = nextTheme.$themeGroupId;
+      const themeOptionId = nextTheme.$themeOptionId;
 
-    const themeGroupId = nextTheme.$themeGroupId;
-    const themeOptionId = nextTheme.$themeOptionId;
+      // Variable refs — group-level, only PATCH once per group
+      if (themeGroupId && !patchedGroups.has(themeGroupId)) {
+        const prevVarRefs = prevTheme.$figmaVariableReferences;
+        const nextVarRefs = nextTheme.$figmaVariableReferences;
 
-    // Variable refs — group-level, only PATCH once per group
-    if (themeGroupId && !patchedGroups.has(themeGroupId)) {
-      const prevVarRefs = prevTheme.$figmaVariableReferences;
-      const nextVarRefs = nextTheme.$figmaVariableReferences;
-
-      if (!shallowEqual(prevVarRefs, nextVarRefs)) {
-        patchedGroups.add(themeGroupId);
-        try {
-          await patchThemeGroupVariableRefs(
-            oauthTokens.accessToken,
-            apiBaseUrl,
-            projectId,
-            changeSetId,
-            themeGroupId,
-            nextVarRefs ?? {},
-          );
-        } catch (err) {
-          console.error('[updateThemeRefsViaRestApi] Failed to patch variable refs:', err);
+        if (!shallowEqual(prevVarRefs, nextVarRefs)) {
+          patchedGroups.add(themeGroupId);
+          try {
+            await patchThemeGroupVariableRefs(
+              oauthTokens.accessToken,
+              apiBaseUrl,
+              projectId,
+              changeSetId,
+              themeGroupId,
+              nextVarRefs ?? {},
+            );
+          } catch (err) {
+            console.error('[updateThemeRefsViaRestApi] Failed to patch variable refs:', err);
+          }
         }
       }
-    }
 
-    // Style refs — option-level
-    if (themeOptionId) {
-      const prevStyleRefs = prevTheme.$figmaStyleReferences;
-      const nextStyleRefs = nextTheme.$figmaStyleReferences;
+      // Style refs — option-level
+      if (themeOptionId) {
+        const prevStyleRefs = prevTheme.$figmaStyleReferences;
+        const nextStyleRefs = nextTheme.$figmaStyleReferences;
 
-      if (!shallowEqual(prevStyleRefs, nextStyleRefs)) {
-        try {
-          await patchThemeOptionStyleRefs(
-            oauthTokens.accessToken,
-            apiBaseUrl,
-            projectId,
-            changeSetId,
-            themeOptionId,
-            nextStyleRefs ?? {},
-          );
-        } catch (err) {
-          console.error('[updateThemeRefsViaRestApi] Failed to patch style refs:', err);
+        if (!shallowEqual(prevStyleRefs, nextStyleRefs)) {
+          try {
+            await patchThemeOptionStyleRefs(
+              oauthTokens.accessToken,
+              apiBaseUrl,
+              projectId,
+              changeSetId,
+              themeOptionId,
+              nextStyleRefs ?? {},
+            );
+          } catch (err) {
+            console.error('[updateThemeRefsViaRestApi] Failed to patch style refs:', err);
+          }
         }
       }
     }
   }
-}
-
-function shallowEqual(
-  a: Record<string, string> | undefined,
-  b: Record<string, string> | undefined,
-): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
-  if (keysA.length !== keysB.length) return false;
-  return keysA.every((k) => a[k] === b[k]);
 }

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
@@ -1,6 +1,7 @@
 import { RematchRootState } from '@rematch/core';
 import { RootModel } from '@/types/RootModel';
 import { ThemeObjectsList } from '@/types';
+import { TokensStudioOAuthStorageType } from '@/types/StorageType';
 import { useAuthStore } from '@/app/store/useAuthStore';
 import { OAuthService } from '@/app/services/OAuthService';
 import { TOKENS_STUDIO_APP_URL } from '@/constants/TokensStudio';
@@ -13,8 +14,8 @@ interface UpdateThemeRefsPayload {
 }
 
 function shallowEqual(
-  a: Record<string, string> | undefined,
-  b: Record<string, string> | undefined,
+  a: Record<string, string> | null | undefined,
+  b: Record<string, string> | null | undefined,
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
@@ -38,8 +39,9 @@ export async function updateThemeRefsViaRestApi({
   const context = rootState.uiState.api;
   if (!context || !('id' in context)) return;
 
-  const projectId = (context as any).id;
-  const branchName = (context as any).branch || 'main';
+  const oauthContext = context as TokensStudioOAuthStorageType;
+  const projectId = oauthContext.id;
+  const branchName = oauthContext.branch || 'main';
 
   const apiBaseUrl = OAuthService.getApiBaseUrl(TOKENS_STUDIO_APP_URL);
 

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
@@ -8,9 +8,31 @@ import { TOKENS_STUDIO_APP_URL } from '@/constants/TokensStudio';
 import { resolveChangeSetId } from './fetchBranchesListRest';
 import { patchThemeGroupVariableRefs, patchThemeOptionStyleRefs } from './pushThemeRefsRest';
 
+/** Pre-action snapshot of each theme's refs, keyed by theme id. */
+export type ThemeRefsSnapshot = Map<string, {
+  varRefs?: Record<string, string>;
+  styleRefs?: Record<string, string>;
+}>;
+
 interface UpdateThemeRefsPayload {
-  prevState: RematchRootState<RootModel, Record<string, never>>;
+  /** Cloned refs captured *before* the reducer ran (immune to in-place mutation). */
+  prevThemeRefs: ThemeRefsSnapshot;
   rootState: RematchRootState<RootModel, Record<string, never>>;
+}
+
+/**
+ * Shallow-clone every theme's ref maps to create a snapshot that is immune
+ * to in-place mutations performed by some reducers.
+ */
+export function snapshotThemeRefs(themes: ThemeObjectsList): ThemeRefsSnapshot {
+  const snapshot: ThemeRefsSnapshot = new Map();
+  themes.forEach((theme) => {
+    snapshot.set(theme.id, {
+      varRefs: theme.$figmaVariableReferences ? { ...theme.$figmaVariableReferences } : undefined,
+      styleRefs: theme.$figmaStyleReferences ? { ...theme.$figmaStyleReferences } : undefined,
+    });
+  });
+  return snapshot;
 }
 
 function shallowEqual(
@@ -30,7 +52,7 @@ function shallowEqual(
  * Only called for ref-mutation actions on the OAuth provider path.
  */
 export async function updateThemeRefsViaRestApi({
-  prevState,
+  prevThemeRefs,
   rootState,
 }: UpdateThemeRefsPayload): Promise<void> {
   const { oauthTokens } = useAuthStore.getState();
@@ -56,21 +78,20 @@ export async function updateThemeRefsViaRestApi({
     return;
   }
 
-  const prevThemes: ThemeObjectsList = prevState.tokenState.themes;
   const nextThemes: ThemeObjectsList = rootState.tokenState.themes;
 
   // Track which groups have already been patched (variable refs are group-level)
   const patchedGroups = new Set<string>();
 
   for (const nextTheme of nextThemes) {
-    const prevTheme = prevThemes.find((t) => t.id === nextTheme.id);
-    if (prevTheme) {
+    const prev = prevThemeRefs.get(nextTheme.id);
+    if (prev) {
       const themeGroupId = nextTheme.$themeGroupId;
       const themeOptionId = nextTheme.$themeOptionId;
 
       // Variable refs — group-level, only PATCH once per group
       if (themeGroupId && !patchedGroups.has(themeGroupId)) {
-        const prevVarRefs = prevTheme.$figmaVariableReferences;
+        const prevVarRefs = prev.varRefs;
         const nextVarRefs = nextTheme.$figmaVariableReferences;
 
         if (!shallowEqual(prevVarRefs, nextVarRefs)) {
@@ -92,7 +113,7 @@ export async function updateThemeRefsViaRestApi({
 
       // Style refs — option-level
       if (themeOptionId) {
-        const prevStyleRefs = prevTheme.$figmaStyleReferences;
+        const prevStyleRefs = prev.styleRefs;
         const nextStyleRefs = nextTheme.$figmaStyleReferences;
 
         if (!shallowEqual(prevStyleRefs, nextStyleRefs)) {

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/updateThemeRefsViaRestApi.ts
@@ -1,0 +1,113 @@
+import { RematchRootState } from '@rematch/core';
+import { RootModel } from '@/types/RootModel';
+import { ThemeObjectsList } from '@/types';
+import { useAuthStore } from '@/app/store/useAuthStore';
+import { OAuthService } from '@/app/services/OAuthService';
+import { TOKENS_STUDIO_APP_URL } from '@/constants/TokensStudio';
+import { resolveChangeSetId } from './fetchBranchesListRest';
+import { patchThemeGroupVariableRefs, patchThemeOptionStyleRefs } from './pushThemeRefsRest';
+
+interface UpdateThemeRefsPayload {
+  prevState: RematchRootState<RootModel, Record<string, never>>;
+  rootState: RematchRootState<RootModel, Record<string, never>>;
+}
+
+/**
+ * Diffs prev vs next themes and PATCHes changed refs to Studio-on-Rails.
+ * Only called for ref-mutation actions on the OAuth provider path.
+ */
+export async function updateThemeRefsViaRestApi({
+  prevState,
+  rootState,
+}: UpdateThemeRefsPayload): Promise<void> {
+  const { oauthTokens } = useAuthStore.getState();
+  if (!oauthTokens?.accessToken) return;
+
+  const context = rootState.uiState.api;
+  if (!context || !('id' in context)) return;
+
+  const projectId = (context as any).id;
+  const branchName = (context as any).branch || 'main';
+
+  const apiBaseUrl = OAuthService.getApiBaseUrl(TOKENS_STUDIO_APP_URL);
+
+  const changeSetId = await resolveChangeSetId(
+    oauthTokens.accessToken,
+    apiBaseUrl,
+    projectId,
+    branchName,
+  );
+  if (!changeSetId) {
+    console.error('[updateThemeRefsViaRestApi] Could not resolve change_set_id, aborting write');
+    return;
+  }
+
+  const prevThemes: ThemeObjectsList = prevState.tokenState.themes;
+  const nextThemes: ThemeObjectsList = rootState.tokenState.themes;
+
+  // Track which groups have already been patched (variable refs are group-level)
+  const patchedGroups = new Set<string>();
+
+  for (const nextTheme of nextThemes) {
+    const prevTheme = prevThemes.find((t) => t.id === nextTheme.id);
+    if (!prevTheme) continue;
+
+    const themeGroupId = nextTheme.$themeGroupId;
+    const themeOptionId = nextTheme.$themeOptionId;
+
+    // Variable refs — group-level, only PATCH once per group
+    if (themeGroupId && !patchedGroups.has(themeGroupId)) {
+      const prevVarRefs = prevTheme.$figmaVariableReferences;
+      const nextVarRefs = nextTheme.$figmaVariableReferences;
+
+      if (!shallowEqual(prevVarRefs, nextVarRefs)) {
+        patchedGroups.add(themeGroupId);
+        try {
+          await patchThemeGroupVariableRefs(
+            oauthTokens.accessToken,
+            apiBaseUrl,
+            projectId,
+            changeSetId,
+            themeGroupId,
+            nextVarRefs ?? {},
+          );
+        } catch (err) {
+          console.error('[updateThemeRefsViaRestApi] Failed to patch variable refs:', err);
+        }
+      }
+    }
+
+    // Style refs — option-level
+    if (themeOptionId) {
+      const prevStyleRefs = prevTheme.$figmaStyleReferences;
+      const nextStyleRefs = nextTheme.$figmaStyleReferences;
+
+      if (!shallowEqual(prevStyleRefs, nextStyleRefs)) {
+        try {
+          await patchThemeOptionStyleRefs(
+            oauthTokens.accessToken,
+            apiBaseUrl,
+            projectId,
+            changeSetId,
+            themeOptionId,
+            nextStyleRefs ?? {},
+          );
+        } catch (err) {
+          console.error('[updateThemeRefsViaRestApi] Failed to patch style refs:', err);
+        }
+      }
+    }
+  }
+}
+
+function shallowEqual(
+  a: Record<string, string> | undefined,
+  b: Record<string, string> | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((k) => a[k] === b[k]);
+}


### PR DESCRIPTION
### Why does this PR exist?

When using the REST/OAuth path to sync with Studio projects (Studio-on-Rails), variable references (`$figmaVariableReferences`) and style references (`$figmaStyleReferences`) were read-only -- changes made in the plugin were never written back to the server. This PR adds round-trip support so these maps are persisted when users update them.

Related backend PR: https://github.com/The-Phoenix-Will-Fly/studio-on-rails/pull/2396

### What does this pull request do?

Adds write support for Figma variable/style references on the REST/OAuth path:

- **Fixes the read path**: Variable refs are sourced from the theme *group* (where the API stores them) rather than incorrectly reading from the theme option.
- **Adds PATCH helpers**: Two functions that write variable refs to theme groups and style refs to theme options via the Rails API.
- **Wires the middleware**: When using `TOKENS_STUDIO_OAUTH`, ref-mutation actions (assign/unassign variable refs, update style refs) now trigger a REST PATCH to persist changes.
- **Caches server IDs**: `$themeGroupId` and `$themeOptionId` are stored on each `ThemeObject` after the initial fetch so we can target the correct API endpoints on write.
- **Re-resolves branch**: The `change_set_id` is re-resolved before each write to handle branch switches between fetch and mutation.

Key design decisions:
- Only the GQL path is untouched (it talks to the original TS backend which uses a different data model).
- Omitting a key preserves existing refs; sending `{}` explicitly clears them; `null` is never sent.
- Style refs are sent verbatim (`"S:key,"` form) -- no stripping/re-adding prefixes.

### Testing this change

Unit tests added (14 new tests):
```
yarn jest --no-coverage --testPathPattern="pushThemeRefsRest.test|updateThemeRefsViaRestApi.test"
```

All existing tokensStudio tests (55) and middleware tests (36) continue to pass.

Manual testing against the preview API (`studio-on-rails-web-5s4z-pr-2396.onrender.com`) has not been done yet -- this needs a live Studio project with OAuth configured.

### Additional Notes (if any)

This is scoped to refs-only sync (Option B). Full OAuth write parity (theme CRUD) is out of scope and can be a follow-up.