### PR TITLE
fix: dedupe Tokens Studio OAuth sync providers

### DIFF
--- a/.changeset/dedupe-studio-oauth-sync-providers.md
+++ b/.changeset/dedupe-studio-oauth-sync-providers.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix duplicate Tokens Studio sync providers appearing in Sync Settings. Tokens Studio OAuth providers are derived live from the user's organizations and are no longer persisted to client storage. Any legacy persisted OAuth entries are stripped on read, and the Sync Settings list now defensively dedupes against live OAuth providers.

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
@@ -83,6 +83,19 @@ const SyncSettings = () => {
     return [];
   }, [isAuthenticated, organizations]);
 
+  // Defensive: never render an apiProvider that is a Tokens Studio OAuth entry
+  // (those are live-derived above and should not be persisted) or one whose
+  // internalId already matches a live studioProvider — both would create
+  // duplicate rows in Sync Settings.
+  const visibleApiProviders = React.useMemo(() => {
+    const studioInternalIds = new Set(studioProviders.map((p) => p.internalId).filter(Boolean));
+    return apiProviders.filter((item) => {
+      if (item?.provider === StorageProviderType.TOKENS_STUDIO_OAUTH) return false;
+      if (item?.internalId && studioInternalIds.has(item.internalId)) return false;
+      return true;
+    });
+  }, [apiProviders, studioProviders]);
+
   const [open, setOpen] = React.useState(false);
 
   // Track when user opens the create new sync provider dialog
@@ -229,13 +242,13 @@ const SyncSettings = () => {
               />
             ))}
             <LocalStorageItem />
-            {apiProviders.length > 0 && (
+            {visibleApiProviders.length > 0 && (
               <Box css={{
                 width: '100%', height: '1px', backgroundColor: '$borderSubtle', margin: '$2 0',
               }}
               />
             )}
-            {apiProviders.length > 0 && apiProviders.map((item) => (
+            {visibleApiProviders.length > 0 && visibleApiProviders.map((item) => (
               <StorageItem
                 key={item?.internalId || `${item.provider}-${item.id}`}
                 onEdit={handleEditClick(item)}

--- a/packages/tokens-studio-for-figma/src/figmaStorage/ApiProvidersProperty.ts
+++ b/packages/tokens-studio-for-figma/src/figmaStorage/ApiProvidersProperty.ts
@@ -1,3 +1,4 @@
+import { StorageProviderType } from '@/constants/StorageProviderType';
 import { StorageTypeCredentials } from '@/types/StorageType';
 import { tryParseJson } from '@/utils/tryParseJson';
 import { FigmaStorageProperty, FigmaStorageType } from './FigmaStorageProperty';
@@ -9,9 +10,15 @@ export const ApiProvidersProperty = new FigmaStorageProperty<StorageTypeCredenti
   (outgoing) => {
     type PossibleIncomingType = StorageTypeCredentials[] | Record<string, StorageTypeCredentials>;
     const result = tryParseJson<PossibleIncomingType>(outgoing) ?? [];
-    if (Array.isArray(result)) return result;
-    return Object.values(result).filter((value) => (
-      typeof value === 'object'
-    ));
+    const asArray = Array.isArray(result)
+      ? result
+      : Object.values(result).filter((value) => (
+        typeof value === 'object'
+      ));
+    // Tokens Studio OAuth providers are derived live from the user's organizations
+    // and must never be persisted. Strip any legacy entries that were saved by
+    // older builds (e.g. when switching branches in an OAuth sync) so we don't
+    // render duplicate rows in Sync Settings.
+    return asArray.filter((value) => value?.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH);
   },
 );

--- a/packages/tokens-studio-for-figma/src/utils/credentials.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/credentials.test.ts
@@ -100,6 +100,20 @@ describe('updateCredentials', () => {
     await updateCredentials(newObject);
     expect(figma.clientStorage.setAsync).toHaveBeenCalledWith('apiProviders', JSON.stringify(newArray));
   });
+
+  it('does not persist Tokens Studio OAuth providers', async () => {
+    const oauthCredential = {
+      id: 'project-1',
+      orgId: 'org-1',
+      name: "admin's workspace",
+      provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+      internalId: 'tokens-studio-org-1',
+    };
+    await updateCredentials(oauthCredential);
+
+    expect(figma.clientStorage.getAsync).not.toHaveBeenCalled();
+    expect(figma.clientStorage.setAsync).not.toHaveBeenCalled();
+  });
 });
 
 describe('removeSingleCredential', () => {

--- a/packages/tokens-studio-for-figma/src/utils/credentials.ts
+++ b/packages/tokens-studio-for-figma/src/utils/credentials.ts
@@ -3,9 +3,17 @@ import { notifyAPIProviders, notifyUI } from '@/plugin/notifiers';
 import isSameCredentials from './isSameCredentials';
 import { ApiProvidersProperty } from '@/figmaStorage';
 import { StorageTypeCredentials } from '@/types/StorageType';
+import { StorageProviderType } from '@/constants/StorageProviderType';
 import { generateId } from './generateId';
 
 export async function updateCredentials(context: StorageTypeCredentials) {
+  // Tokens Studio OAuth providers are derived live from the user's organizations
+  // on every load and must never be persisted to clientStorage. Persisting them
+  // creates duplicate rows in Sync Settings (a live OAuth-derived row + a stale
+  // persisted row) and can pin sync to a stale token/branch context.
+  if (context.provider === StorageProviderType.TOKENS_STUDIO_OAUTH) {
+    return;
+  }
   try {
     const data = await ApiProvidersProperty.read();
     let existingProviders: NonNullable<typeof data> = [];


### PR DESCRIPTION
## Problem

Some users on the new Studio (OAuth) sync see the same workspace listed **twice** under Settings → Sync providers, and sync silently uses a stale entry.

### Repro
1. Connect to a Tokens Studio (OAuth) sync provider.
2. Close the plugin.
3. Open again, switch to a different branch.
4. Close and reopen the plugin → the workspace now appears twice.

## Root cause

OAuth sync providers (`TOKENS_STUDIO_OAUTH`) are designed to be derived **live** on every plugin load from the user's organizations (`SyncSettings.tsx` → `studioProviders` memo). They should never live in `figma.clientStorage`.

`BranchSelector.tsx` calls `AsyncMessageTypes.CREDENTIALS` on every branch switch — including for OAuth providers — which routes through `updateCredentials` and **persists** the OAuth credential into `apiProviders` clientStorage. On the next load:

- `studioProviders` re-derives the OAuth row from `organizations` (correct, live).
- `apiProviders` is loaded from clientStorage and includes the now-stale OAuth row.
- Both render in Sync Settings → user sees the same workspace twice.

Whichever entry happens to win `storageType` may carry a stale token / branch / context, which is why sync also "stops working" for affected users.

## Fix

1. **`utils/credentials.ts`** – short-circuit `updateCredentials` for `TOKENS_STUDIO_OAUTH`. OAuth providers must never be persisted.
2. **`figmaStorage/ApiProvidersProperty.ts`** – strip any `TOKENS_STUDIO_OAUTH` entries when reading `apiProviders`. This auto-cleans existing affected users on next plugin load — no manual intervention needed.
3. **`app/components/SyncSettings.tsx`** – defensively filter `apiProviders` against live `studioProviders` internalIds (and drop OAuth) so even a stale in-memory state can never render duplicates.

## Tests

- Added `updateCredentials` test asserting OAuth providers are not persisted.
- Existing credentials + figmaStorage suites (30 tests) still pass.

## Notes

Did not modify the offending `BranchSelector` call site directly because `updateCredentials` is the right place to enforce this invariant — `BranchSelector` legitimately needs to persist branch changes for *non*-OAuth providers, and there are other callers (jsonbin, github, gitlab, ado, bitbucket, supernova, generic versioned, tokensStudio PAT) that should keep persisting.