### PR TITLE
fix: resolve variable collection by key when cross-file ID lookup fails

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/swapFigmaModes.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/swapFigmaModes.test.ts
@@ -11,6 +11,7 @@ jest.mock('../../notifiers', () => ({
 // Mock figma API
 const mockSetExplicitVariableModeForCollection = jest.fn();
 const mockGetVariableCollectionByIdAsync = jest.fn();
+const mockImportVariableByKeyAsync = jest.fn();
 
 const mockCurrentPage = {
   name: 'Page 1',
@@ -36,6 +37,7 @@ global.figma = {
   root: mockRoot,
   variables: {
     getVariableCollectionByIdAsync: mockGetVariableCollectionByIdAsync,
+    importVariableByKeyAsync: mockImportVariableByKeyAsync,
   },
 } as any;
 
@@ -196,6 +198,128 @@ describe('swapFigmaModes', () => {
     );
 
     consoleSpy.mockRestore();
+  });
+
+  describe('import-based fallback (stale or cross-file collection ID)', () => {
+    const themeWithVariableRefs = {
+      id: 'dark',
+      name: 'Dark',
+      selectedTokenSets: {},
+      $figmaCollectionId: 'stale-collection-id',
+      $figmaModeId: 'stale-mode-id',
+      $figmaVariableReferences: { 'color.background': 'variable-key-abc' },
+    };
+
+    const fallbackCollection = {
+      id: 'new-collection-id',
+      name: 'My Collection',
+      modes: [
+        { modeId: 'new-mode-id', name: 'Dark' },
+        { modeId: 'new-mode-light-id', name: 'Light' },
+      ],
+    };
+
+    const importedVariable = {
+      variableCollectionId: 'new-collection-id',
+    };
+
+    beforeEach(() => {
+      mockImportVariableByKeyAsync.mockReset();
+    });
+
+    it('should resolve via importVariableByKeyAsync when stored collection ID is stale', async () => {
+      // Primary lookup fails (stale ID), fallback import succeeds
+      mockGetVariableCollectionByIdAsync.mockImplementation(async (id: string) => {
+        if (id === 'new-collection-id') return fallbackCollection;
+        return null;
+      });
+      mockImportVariableByKeyAsync.mockResolvedValue(importedVariable);
+
+      await swapFigmaModes({ 'no-group': 'dark' }, [themeWithVariableRefs], UpdateMode.PAGE);
+
+      expect(mockImportVariableByKeyAsync).toHaveBeenCalledWith('variable-key-abc');
+      expect(mockSetExplicitVariableModeForCollection).toHaveBeenCalledWith(fallbackCollection, 'new-mode-id');
+      expect(notifiers.notifyUI).not.toHaveBeenCalled();
+    });
+
+    it('should report collection-not-found when fallback collection exists but mode name does not match', async () => {
+      const collectionWithoutDarkMode = {
+        ...fallbackCollection,
+        modes: [{ modeId: 'new-mode-light-id', name: 'Light' }],
+      };
+      mockGetVariableCollectionByIdAsync.mockImplementation(async (id: string) => {
+        if (id === 'new-collection-id') return collectionWithoutDarkMode;
+        return null;
+      });
+      mockImportVariableByKeyAsync.mockResolvedValue(importedVariable);
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await swapFigmaModes({ 'no-group': 'dark' }, [themeWithVariableRefs], UpdateMode.PAGE);
+
+      // Collection was found via fallback, but mode is missing — should report mode-missing error
+      expect(notifiers.notifyUI).toHaveBeenCalledWith(
+        expect.stringContaining('mode'),
+        { error: true },
+      );
+      expect(mockSetExplicitVariableModeForCollection).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should report collection-not-found when importVariableByKeyAsync throws', async () => {
+      mockGetVariableCollectionByIdAsync.mockResolvedValue(null);
+      mockImportVariableByKeyAsync.mockRejectedValue(new Error('Key not found in any library'));
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await swapFigmaModes({ 'no-group': 'dark' }, [themeWithVariableRefs], UpdateMode.PAGE);
+
+      expect(notifiers.notifyUI).toHaveBeenCalledWith(
+        'One of the variable collections linked to this theme no longer exists',
+        { error: true },
+      );
+      expect(mockSetExplicitVariableModeForCollection).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should report collection-not-found when $figmaVariableReferences is empty', async () => {
+      const themeWithNoRefs = { ...themeWithVariableRefs, $figmaVariableReferences: {} };
+      mockGetVariableCollectionByIdAsync.mockResolvedValue(null);
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await swapFigmaModes({ 'no-group': 'dark' }, [themeWithNoRefs], UpdateMode.PAGE);
+
+      expect(mockImportVariableByKeyAsync).not.toHaveBeenCalled();
+      expect(notifiers.notifyUI).toHaveBeenCalledWith(
+        'One of the variable collections linked to this theme no longer exists',
+        { error: true },
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should match mode name against truncated name for long theme names', async () => {
+      const longName = 'A'.repeat(50); // longer than Figma 40-char limit
+      const truncated = `${'A'.repeat(37)}...`;
+      const themeWithLongName = {
+        ...themeWithVariableRefs,
+        name: longName,
+      };
+      const collectionWithTruncatedMode = {
+        ...fallbackCollection,
+        modes: [{ modeId: 'new-mode-id', name: truncated }],
+      };
+      mockGetVariableCollectionByIdAsync.mockImplementation(async (id: string) => {
+        if (id === 'new-collection-id') return collectionWithTruncatedMode;
+        return null;
+      });
+      mockImportVariableByKeyAsync.mockResolvedValue(importedVariable);
+
+      await swapFigmaModes({ 'no-group': 'dark' }, [themeWithLongName], UpdateMode.PAGE);
+
+      expect(mockSetExplicitVariableModeForCollection).toHaveBeenCalledWith(collectionWithTruncatedMode, 'new-mode-id');
+      expect(notifiers.notifyUI).not.toHaveBeenCalled();
+    });
   });
 
   describe('multi-dimensional themes', () => {

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/swapFigmaModes.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/swapFigmaModes.ts
@@ -1,5 +1,6 @@
 import { UpdateMode } from '@/constants/UpdateMode';
 import { ThemeObjectsList, ThemeObject } from '@/types';
+import { truncateModeName } from '@/utils/truncateName';
 import { notifyUI, notifyException } from '../notifiers';
 
 // Type predicate to check for Figma theme with collection and mode IDs
@@ -68,9 +69,9 @@ export async function swapFigmaModes(activeTheme: Record<string, string>, themes
           if (importedVariable) {
             const fallbackCollection = await figma.variables.getVariableCollectionByIdAsync(importedVariable.variableCollectionId);
             if (fallbackCollection) {
-              const matchingMode = fallbackCollection.modes.find((mode) => mode.name === themeObject.name);
+              resolvedCollection = fallbackCollection;
+              const matchingMode = fallbackCollection.modes.find((mode) => mode.name === truncateModeName(themeObject.name));
               if (matchingMode) {
-                resolvedCollection = fallbackCollection;
                 resolvedModeId = matchingMode.modeId;
               }
             }

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/swapFigmaModes.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/swapFigmaModes.ts
@@ -54,8 +54,34 @@ export async function swapFigmaModes(activeTheme: Record<string, string>, themes
     const { $figmaCollectionId: collectionId, $figmaModeId: modeId } = themeObject;
 
     // Validate that the collection exists and contains the mode
-    const collection = await figma.variables.getVariableCollectionByIdAsync(collectionId);
-    if (!collection) {
+    let resolvedCollection = await figma.variables.getVariableCollectionByIdAsync(collectionId);
+    let resolvedModeId = modeId;
+
+    if (!resolvedCollection) {
+      // Fallback: the stored ID is from a different file (e.g. a published library used in a consumer file,
+      // or a collection that was deleted and recreated). Try to resolve via a variable key from
+      // $figmaVariableReferences — variable keys are stable across files.
+      const variableKey = Object.values(themeObject.$figmaVariableReferences ?? {})[0];
+      if (variableKey) {
+        try {
+          const importedVariable = await figma.variables.importVariableByKeyAsync(variableKey);
+          if (importedVariable) {
+            const fallbackCollection = await figma.variables.getVariableCollectionByIdAsync(importedVariable.variableCollectionId);
+            if (fallbackCollection) {
+              const matchingMode = fallbackCollection.modes.find((mode) => mode.name === themeObject.name);
+              if (matchingMode) {
+                resolvedCollection = fallbackCollection;
+                resolvedModeId = matchingMode.modeId;
+              }
+            }
+          }
+        } catch (e) {
+          // importVariableByKeyAsync throws if the key cannot be found in any subscribed library
+        }
+      }
+    }
+
+    if (!resolvedCollection) {
       // eslint-disable-next-line no-console
       console.warn(`Variable collection with ID ${collectionId} no longer exists. Skipping this theme dimension.`);
       notifyUI('One of the variable collections linked to this theme no longer exists', { error: true });
@@ -63,16 +89,16 @@ export async function swapFigmaModes(activeTheme: Record<string, string>, themes
       continue;
     }
 
-    const modeExists = collection.modes.some((mode) => mode.modeId === modeId);
+    const modeExists = resolvedCollection.modes.some((mode) => mode.modeId === resolvedModeId);
     if (!modeExists) {
       // eslint-disable-next-line no-console
-      console.warn(`Mode ${modeId} no longer exists in collection ${collection.name}. Skipping this theme dimension.`);
-      notifyUI(`One of the modes linked to this theme no longer exists in collection "${collection.name}"`, { error: true });
+      console.warn(`Mode ${resolvedModeId} no longer exists in collection ${resolvedCollection.name}. Skipping this theme dimension.`);
+      notifyUI(`One of the modes linked to this theme no longer exists in collection "${resolvedCollection.name}"`, { error: true });
       // eslint-disable-next-line no-continue
       continue;
     }
 
-    validCollectionModePairs.push({ collection, modeId });
+    validCollectionModePairs.push({ collection: resolvedCollection, modeId: resolvedModeId });
   }
 
   if (validCollectionModePairs.length === 0) {


### PR DESCRIPTION
### Why does this PR exist?

Closes #0000

When a `$themes.json` is used in a different Figma file than where it was created (e.g. a consumer file subscribed to a published library), applying an active theme with "Swap Figma modes" enabled fails with:

> "One of the variable collections linked to this theme no longer exists"

`$figmaCollectionId` is scoped to the file it was created in. In any other file, `getVariableCollectionByIdAsync` returns null and the mode swap is skipped entirely.

### What does this pull request do?

Adds a fallback in `swapFigmaModes` for when the stored collection ID can't be resolved. It takes the first variable key from `$figmaVariableReferences`, calls `importVariableByKeyAsync` to resolve it in the current file, and derives the correct collection and mode from the result. Variable keys are stable across files, so this works for subscribed library collections.

The error toast is preserved for cases where the fallback also fails (e.g. the library is not subscribed, or `$figmaVariableReferences` is empty).

### Testing this change

1. In file A, create variables via **Export to Figma** with at least one theme — this populates `$figmaCollectionId` and `$figmaVariableReferences` in `$themes.json`
2. Publish the variable collection from file A as a library
3. Open file B, subscribe to file A's library
4. Load the same `$themes.json` into the plugin in file B
5. Enable **Swap Figma modes** in plugin settings
6. Set one of the themes as active in the theme switcher
7. Hit **Apply to canvas**

**Before**: error toast fires, mode is not swapped  
**After**: mode swaps silently

### Additional Notes (if any)

The fallback requires `$figmaVariableReferences` to be populated. If a theme has no variable references stored (i.e. "Export to Figma" was never run), the fallback cannot resolve the collection and the error toast still appears. Users in that state need to run "Export to Figma" in the source file first.