### PR TITLE
fix: realtime sync writes to stale branch after switching branches

### DIFF
--- a/.changeset/fix-branch-switch-stale-changeset-id.md
+++ b/.changeset/fix-branch-switch-stale-changeset-id.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed a critical bug where switching branches on the Tokens Studio (OAuth) provider kept syncing edits to the previously selected branch's change set instead of the newly selected one, causing destructive writes to land on the wrong branch (e.g. `main`) while the UI showed a different branch selected.

--- a/packages/tokens-studio-for-figma/src/app/components/BranchSelector.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BranchSelector.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import {
+  render, fireEvent, waitFor, createMockStore,
+} from '../../../tests/config/setupTest';
+import BranchSelector from './BranchSelector';
+import { StorageProviderType } from '@/constants/StorageProviderType';
+import useRemoteTokens from '../store/remoteTokens';
+
+jest.mock('../store/remoteTokens', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../hooks/useIsProUser', () => ({
+  __esModule: true,
+  useIsProUser: () => true,
+}));
+
+const mockPullTokens = jest.fn();
+const mockFetchBranches = jest.fn();
+
+describe('BranchSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useRemoteTokens as jest.Mock).mockReturnValue({
+      pullTokens: mockPullTokens,
+      fetchBranches: mockFetchBranches,
+    });
+    mockFetchBranches.mockResolvedValue(['main', 'truncation-test']);
+  });
+
+  // Regression test for: plugin realtime sync writing to `main` while a
+  // different branch was selected. The Tokens Studio backend identifies a
+  // branch by changeSetId, so switching branches must refresh changeSetId in
+  // uiState.api/localApiState, not just the `branch` name.
+  it('updates changeSetId in uiState.api when switching to a Tokens Studio OAuth branch', async () => {
+    mockPullTokens.mockResolvedValue({
+      status: 'success',
+      tokens: {},
+      themes: [],
+      metadata: { changeSetId: 'truncation-test-change-set-id' },
+    });
+
+    const mockStore = createMockStore({
+      uiState: {
+        api: {
+          provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+          id: 'project-1',
+          branch: 'main',
+          changeSetId: 'main-change-set-id',
+        } as any,
+        localApiState: {
+          provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+          id: 'project-1',
+          branch: 'main',
+          changeSetId: 'main-change-set-id',
+        } as any,
+      },
+      branchState: {
+        branches: ['main', 'truncation-test'],
+      },
+    });
+
+    const result = render(
+      <Provider store={mockStore}>
+        <BranchSelector />
+      </Provider>,
+    );
+
+    fireEvent.click(result.getByTestId('branch-selector-menu-trigger'));
+
+    const branchItem = await result.findByTestId('popover-item-truncation-test');
+    fireEvent.click(branchItem);
+
+    await waitFor(() => {
+      expect(mockStore.getState().uiState.api.branch).toBe('truncation-test');
+    });
+
+    expect(mockStore.getState().uiState.api.changeSetId).toBe('truncation-test-change-set-id');
+    expect(mockStore.getState().uiState.localApiState.changeSetId).toBe('truncation-test-change-set-id');
+
+    result.unmount();
+  });
+});

--- a/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
@@ -129,18 +129,30 @@ export default function BranchSelector() {
           // Clear local token state BEFORE pulling to prevent bleed
           dispatch.tokenState.setEmptyTokens();
           // Pull tokens from new branch BEFORE switching UI state
-          await pullTokens({
+          const remoteData = await pullTokens({
             context: { ...apiData, branch }, usedTokenSet, activeTheme, updateLocalTokens: true, skipConfirmation: true,
           });
+          // The Tokens Studio backend identifies a branch by changeSetId, not by name.
+          // Carry over the changeSetId the pull just resolved for `branch`, otherwise
+          // writes keep targeting whichever branch was selected at connect time.
+          const changeSetId = isTokensStudioProvider && remoteData?.status === 'success'
+            ? remoteData.metadata?.changeSetId
+            : undefined;
+          const updatedApiData = {
+            ...apiData, branch, ...(changeSetId ? { changeSetId } : {}),
+          } as StorageTypeCredentials;
+          const updatedLocalApiState = {
+            ...localApiState, branch, ...(changeSetId ? { changeSetId } : {}),
+          } as StorageTypeCredentials;
           // Now update UI state to show the new branch with already-loaded tokens
           setCurrentBranch(branch);
-          dispatch.uiState.setApiData({ ...apiData, branch });
-          dispatch.uiState.setLocalApiState({ ...localApiState, branch });
+          dispatch.uiState.setApiData(updatedApiData);
+          dispatch.uiState.setLocalApiState(updatedLocalApiState);
           AsyncMessageChannel.ReactInstance.message({
             type: AsyncMessageTypes.CREDENTIALS,
-            credential: { ...apiData, branch },
+            credential: updatedApiData,
           });
-          setStorageType({ provider: { ...apiData, branch } as StorageTypeCredentials, shouldSetInDocument: true });
+          setStorageType({ provider: updatedApiData, shouldSetInDocument: true });
         } finally {
           setIsSwitchingBranch(false);
         }


### PR DESCRIPTION
## Summary
- Blocker bug (reported in Notion): after switching branches on the Tokens Studio OAuth provider, subsequent token edits/deletes kept syncing to the *previously selected* branch (e.g. `main`) instead of the newly selected one, even though the plugin UI showed the correct branch — causing destructive writes to the wrong branch.
- Root cause: the Tokens Studio backend identifies a branch by `changeSetId`, not by name. `changeAndPull` in `BranchSelector.tsx` correctly pulled the new branch's tokens (and `pullTokens` internally refreshed `uiState.api.changeSetId`), but then immediately overwrote it by re-spreading the pre-switch `apiData` value captured in the React closure — reverting `changeSetId` back to the stale one from connect time. Every write handler in `tokenState.tsx` reads `rootState.uiState.api` for this id on every REST call (`editToken`, `deleteToken`, etc.), so all writes silently targeted the wrong branch.
- Fix: `changeAndPull` now uses the `changeSetId` returned by `pullTokens` (`remoteData.metadata.changeSetId`) when updating `uiState.api`, `uiState.localApiState`, the `CREDENTIALS` message, and `setStorageType`, instead of reusing the stale closure value.

## Test plan
- [x] Added `BranchSelector.test.tsx`: switches from `main` to `truncation-test`, asserts `uiState.api.changeSetId`/`uiState.localApiState.changeSetId` are updated to the new branch's id (previously they stayed on the old branch's id).
- [x] Verified the new test fails against the pre-fix code with `Expected: "truncation-test-change-set-id" Received: "main-change-set-id"` — matching the reported repro.
- [x] `yarn lint` on changed files — no errors.
- [x] `yarn test` for `BranchSelector`, `Footer`, `CreateBranchModal`, `remoteTokens` — 133 passed.
- [x] Added a changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)