### PR TITLE
feat: fail license API requests over to the legacy host during migration

### DIFF
--- a/.changeset/license-api-failover.md
+++ b/.changeset/license-api-failover.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Send license requests to the new production API first and fall back to the previous one when it cannot answer, so both can stay live while license data is migrated.

--- a/packages/tokens-studio-for-figma/.env.example
+++ b/packages/tokens-studio-for-figma/.env.example
@@ -1,4 +1,6 @@
 MIXPANEL_ACCESS_TOKEN=
 ENVIRONMENT=development
+# Legacy license API. Requests go to https://api-production.tokens.studio first
+# and only fall back here while the license data migration is in progress.
 LICENSE_API_URL=https://licence.tokens.studio
 TOKENS_STUDIO_APP_URL=production.tokens.studio

--- a/packages/tokens-studio-for-figma/.env.production.example
+++ b/packages/tokens-studio-for-figma/.env.production.example
@@ -1,4 +1,6 @@
 MIXPANEL_ACCESS_TOKEN=
 ENVIRONMENT=production
+# Legacy license API. Requests go to https://api-production.tokens.studio first
+# and only fall back here while the license data migration is in progress.
 LICENSE_API_URL=https://licence.tokens.studio
 TOKENS_STUDIO_APP_URL=production.tokens.studio

--- a/packages/tokens-studio-for-figma/src/mocks/handlers.ts
+++ b/packages/tokens-studio-for-figma/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from 'msw';
+import { LICENSE_API_HOSTS } from '@/utils/licenseApiUrl';
 
 export const LICENSE_FOR_VALID_RESPONSE = 'validate-c421c421-c421c421c-4c21c421-c421c42';
 export const LICENSE_FOR_ERROR_RESPONSE = 'validate-error-c421c421-c421c421c421421-41';
@@ -53,12 +54,17 @@ export const mockDetachLicenseHandler = jest.fn((req, res, ctx) => {
   return res();
 });
 
+// Both hosts are served by the same mocks so the failover resolves on the
+// primary by default. Tests that exercise the fallback override the primary
+// with server.use().
 export const handlers = [
-  rest.get(`${process.env.LICENSE_API_URL}/get-license`, mockGetLicenseHandler),
+  ...LICENSE_API_HOSTS.flatMap((host) => [
+    rest.get(`${host}/get-license`, mockGetLicenseHandler),
 
-  rest.get(`${process.env.LICENSE_API_URL}/validate-license`, mockValidateLicenseHandler),
+    rest.get(`${host}/validate-license`, mockValidateLicenseHandler),
 
-  rest.put(`${process.env.LICENSE_API_URL}/detach-license`, mockDetachLicenseHandler),
+    rest.put(`${host}/detach-license`, mockDetachLicenseHandler),
+  ]),
 
   rest.post(`${process.env.TOKEN_FLOW_APP_URL}/api/tokens`, (req, res, ctx) => res(ctx.status(200), ctx.json({ result: 'test-id' }))),
 ];

--- a/packages/tokens-studio-for-figma/src/utils/getLicenseKey.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/getLicenseKey.test.ts
@@ -1,12 +1,50 @@
 import * as Sentry from '@sentry/react';
 import { mockFetch } from '../../tests/__mocks__/fetchMock';
+import { LICENSE_API_HOSTS } from './licenseApiUrl';
 import getLicenseKey from './getLicenseKey';
+
+const [PRIMARY, LEGACY] = LICENSE_API_HOSTS;
+
+const json = (status: number, body: unknown) => Promise.resolve({ status, text: () => Promise.resolve(JSON.stringify(body)) });
 
 describe('getLicenseKey', () => {
   const sentrySpy = jest.spyOn(Sentry, 'captureException');
-  it('should call Sentry exception', async () => {
-    mockFetch.mockImplementationOnce(() => Promise.reject());
-    await getLicenseKey('jan');
-    expect(sentrySpy).toBeCalledTimes(1);
+  const sentryMessageSpy = jest.spyOn(Sentry, 'captureMessage');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it('should call Sentry when no host can be reached', async () => {
+    mockFetch.mockImplementation(() => Promise.reject());
+
+    const result = await getLicenseKey('jan');
+
+    expect(result).toEqual({ error: 'Error fetching license' });
+    expect(sentryMessageSpy).toBeCalledTimes(1);
+  });
+
+  it('should not call Sentry when the legacy host answers', async () => {
+    mockFetch
+      .mockImplementationOnce(() => Promise.reject())
+      .mockImplementationOnce(() => json(200, { key: 'a-license-key' }));
+
+    const result = await getLicenseKey('jan');
+
+    expect(result).toEqual({ key: 'a-license-key' });
+    expect(mockFetch).toHaveBeenNthCalledWith(1, `${PRIMARY}/get-license?userId=jan`, expect.anything());
+    expect(mockFetch).toHaveBeenNthCalledWith(2, `${LEGACY}/get-license?userId=jan`, expect.anything());
+    expect(sentrySpy).not.toBeCalled();
+    expect(sentryMessageSpy).not.toBeCalled();
+  });
+
+  it('should surface the last error message when neither host has the license', async () => {
+    mockFetch
+      .mockImplementationOnce(() => json(404, { message: 'Not found' }))
+      .mockImplementationOnce(() => json(404, { message: 'No license key found' }));
+
+    expect(await getLicenseKey('jan')).toEqual({ error: 'No license key found' });
+    expect(sentryMessageSpy).not.toBeCalled();
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/getLicenseKey.ts
+++ b/packages/tokens-studio-for-figma/src/utils/getLicenseKey.ts
@@ -1,24 +1,16 @@
-import { handleReactError } from './error/handleReactError';
+import { fetchLicenseApi } from './licenseApi';
 
 type GetLicenseKeyResponse =
   { key: string; }
   | { error: string; };
 
 export default async function getLicenseKey(userId: string | null): Promise<GetLicenseKeyResponse> {
-  try {
-    const res = await fetch(`${process.env.LICENSE_API_URL}/get-license?userId=${userId}`);
-    if (res.status === 200) {
-      return await res.json();
-    }
+  const result = await fetchLicenseApi<{ key: string }>(`/get-license?userId=${userId}`, {
+    endpoint: 'get-license',
+    figmaId: userId,
+  });
 
-    const { message } = await res.json();
-    return {
-      error: message,
-    };
-  } catch (e) {
-    handleReactError(e);
-    return {
-      error: 'Error fetching license',
-    };
-  }
+  if (result.ok) return result.data;
+
+  return { error: result.message ?? 'Error fetching license' };
 }

--- a/packages/tokens-studio-for-figma/src/utils/licenseApi.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/licenseApi.test.ts
@@ -1,0 +1,177 @@
+import * as Sentry from '@sentry/react';
+import { LICENSE_API_TIMEOUT_MS, fetchLicenseApi } from './licenseApi';
+import { LICENSE_API_HOSTS } from './licenseApiUrl';
+import { track } from './analytics';
+
+jest.mock('./analytics', () => ({ track: jest.fn() }));
+jest.mock('@sentry/react', () => ({ addBreadcrumb: jest.fn(), captureMessage: jest.fn() }));
+
+const [PRIMARY, LEGACY] = LICENSE_API_HOSTS;
+
+const json = (status: number, body: unknown) => ({ status, text: async () => JSON.stringify(body) });
+const raw = (status: number, text: string) => ({ status, text: async () => text });
+
+// Never settles on its own — only when the timeout aborts it.
+const hangs = () => (_url: string, init: RequestInit) => new Promise((_resolve, reject) => {
+  init.signal?.addEventListener('abort', () => {
+    const error = new Error('Aborted');
+    error.name = 'AbortError';
+    reject(error);
+  });
+});
+
+const mockFetch = (...responses: any[]) => {
+  const fetchMock = jest.fn();
+  responses.forEach((response) => {
+    fetchMock.mockImplementationOnce(
+      typeof response === 'function' ? response : () => Promise.resolve(response),
+    );
+  });
+  global.fetch = fetchMock as any;
+  return fetchMock;
+};
+
+const lastTrackCall = () => (track as jest.Mock).mock.calls[(track as jest.Mock).mock.calls.length - 1];
+
+describe('fetchLicenseApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves on the primary host without touching the legacy one', async () => {
+    const fetchMock = mockFetch(json(200, { key: 'abc' }));
+
+    const result = await fetchLicenseApi<{ key: string }>('/get-license?userId=1', { endpoint: 'get-license' });
+
+    expect(result).toMatchObject({ ok: true, data: { key: 'abc' } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual(`${PRIMARY}/get-license?userId=1`);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a 500', json(500, { message: 'boom' })],
+    ['a 404', json(404, { message: 'No license key found' })],
+    ['a 403', json(403, { message: 'Forbidden' })],
+    ['an unparseable 200', raw(200, '<html>gateway</html>')],
+    ['an empty 200', raw(200, '')],
+  ])('falls back to the legacy host on %s from the primary', async (_label, primaryResponse) => {
+    const fetchMock = mockFetch(primaryResponse, json(200, { key: 'abc' }));
+
+    const result = await fetchLicenseApi<{ key: string }>('/get-license?userId=1', { endpoint: 'get-license' });
+
+    expect(result).toMatchObject({ ok: true, data: { key: 'abc' } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toEqual(`${LEGACY}/get-license?userId=1`);
+  });
+
+  it('falls back when the primary cannot be reached at all', async () => {
+    const fetchMock = mockFetch(() => Promise.reject(new Error('Network request failed')), json(200, { key: 'abc' }));
+
+    const result = await fetchLicenseApi<{ key: string }>('/get-license?userId=1', { endpoint: 'get-license' });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(lastTrackCall()[1]).toMatchObject({ primaryReason: 'transport', primaryStatus: null });
+  });
+
+  it('gives up on a hanging primary and falls back', async () => {
+    jest.useFakeTimers();
+    const fetchMock = mockFetch(hangs(), json(200, { key: 'abc' }));
+
+    const pending = fetchLicenseApi<{ key: string }>('/get-license?userId=1', { endpoint: 'get-license' });
+    await Promise.resolve();
+    jest.advanceTimersByTime(LICENSE_API_TIMEOUT_MS);
+
+    const result = await pending;
+
+    expect(result).toMatchObject({ ok: true, data: { key: 'abc' } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(lastTrackCall()[1]).toMatchObject({ primaryReason: 'timeout' });
+    jest.useRealTimers();
+  });
+
+  it('falls back when the primary answers 200 with an incomplete payload', async () => {
+    const fetchMock = mockFetch(
+      json(200, { plan: null, entitlements: [] }),
+      json(200, { plan: 'pro', entitlements: ['pro'] }),
+    );
+
+    const result = await fetchLicenseApi<{ plan?: string; entitlements?: string[] }>('/validate-license', {
+      endpoint: 'validate-license',
+      isComplete: (data) => Boolean(data?.plan) || (data?.entitlements?.length ?? 0) > 0,
+    });
+
+    expect(result).toMatchObject({ ok: true, data: { plan: 'pro' } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(lastTrackCall()[1]).toMatchObject({ primaryReason: 'incomplete', primaryStatus: 200 });
+  });
+
+  it('surfaces the legacy host error message when both hosts fail', async () => {
+    mockFetch(json(404, { message: 'not found on new' }), json(404, { message: 'No license key found' }));
+
+    const result = await fetchLicenseApi('/get-license?userId=1', { endpoint: 'get-license' });
+
+    expect(result).toMatchObject({ ok: false, message: 'No license key found' });
+  });
+
+  it('returns a null message when neither host produced one', async () => {
+    mockFetch(() => Promise.reject(new Error('nope')), () => Promise.reject(new Error('nope')));
+
+    const result = await fetchLicenseApi('/get-license?userId=1', { endpoint: 'get-license' });
+
+    expect(result).toMatchObject({ ok: false, message: null });
+  });
+
+  it('passes request options through to every host', async () => {
+    const fetchMock = mockFetch(json(500, { message: 'boom' }), json(200, 'detached'));
+
+    await fetchLicenseApi<string>('/detach-license', {
+      endpoint: 'detach-license',
+      init: { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: '{"licenseKey":"a"}' },
+    });
+
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'PUT', body: '{"licenseKey":"a"}' });
+  });
+
+  describe('telemetry', () => {
+    it('flags a migration gap when only the legacy host can answer', async () => {
+      mockFetch(json(404, { message: 'not found' }), json(200, { key: 'abc' }));
+
+      await fetchLicenseApi('/get-license?userId=1', { endpoint: 'get-license', figmaId: 'figma-user-1' });
+
+      expect(track).toHaveBeenCalledWith('License API fallback', expect.objectContaining({
+        endpoint: 'get-license',
+        primaryStatus: 404,
+        primaryReason: 'status',
+        fallbackStatus: 200,
+        resolvedBy: LEGACY,
+        migrationGap: true,
+        figmaId: 'figma-user-1',
+      }));
+    });
+
+    // Users with no license 404 on both hosts forever. Counting them as gaps
+    // would leave the cutover metric with a floor it can never clear.
+    it('does not flag a migration gap when neither host has the record', async () => {
+      mockFetch(json(404, { message: 'not found' }), json(404, { message: 'No license key found' }));
+
+      await fetchLicenseApi('/get-license?userId=1', { endpoint: 'get-license' });
+
+      expect(lastTrackCall()[1]).toMatchObject({ migrationGap: false, resolvedBy: null });
+    });
+
+    it('reports to Sentry only when every host is unreachable', async () => {
+      mockFetch(json(404, { message: 'a' }), json(404, { message: 'b' }));
+      await fetchLicenseApi('/get-license?userId=1', { endpoint: 'get-license' });
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+
+      mockFetch(() => Promise.reject(new Error('down')), () => Promise.reject(new Error('down')));
+      await fetchLicenseApi('/get-license?userId=1', { endpoint: 'get-license' });
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        'License API unreachable: get-license',
+        expect.objectContaining({ level: 'error' }),
+      );
+    });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/licenseApi.ts
+++ b/packages/tokens-studio-for-figma/src/utils/licenseApi.ts
@@ -1,0 +1,164 @@
+import * as Sentry from '@sentry/react';
+import { track } from './analytics';
+import { LICENSE_API_HOSTS } from './licenseApiUrl';
+
+// There is no timeout on fetch by default. Without one an unreachable host
+// hangs the startup process forever instead of falling back.
+export const LICENSE_API_TIMEOUT_MS = 8000;
+
+type FailureReason =
+  | 'transport' // network error, DNS, CORS
+  | 'timeout' // exceeded LICENSE_API_TIMEOUT_MS
+  | 'status' // responded, but not with a 200
+  | 'parse' // 200 with a body we could not read as JSON
+  | 'incomplete'; // 200, valid JSON, but the payload failed the caller's check
+
+export type LicenseApiAttempt = {
+  host: string;
+  status: number | null;
+  reason: FailureReason | null;
+  message?: string;
+};
+
+export type LicenseApiResult<T> =
+  | { ok: true; data: T; attempts: LicenseApiAttempt[] }
+  | { ok: false; message: string | null; attempts: LicenseApiAttempt[] };
+
+type LicenseApiOptions<T> = {
+  /**
+   * Marks the endpoint in telemetry. Not the raw path — that carries the
+   * license key and user id.
+   */
+  endpoint: string;
+  init?: RequestInit;
+  /**
+   * Hashed before it is sent. Lets a migration gap be traced back to the
+   * account whose record did not make it across.
+   */
+  figmaId?: string | null;
+  /**
+   * Guard against a half-migrated record answering 200 with a valid-looking
+   * but empty payload, which would otherwise silently downgrade the user.
+   * Returning false falls through to the next host.
+   */
+  isComplete?: (data: T) => boolean;
+};
+
+async function attemptHost<T>(
+  host: string,
+  path: string,
+  { init, isComplete }: Pick<LicenseApiOptions<T>, 'init' | 'isComplete'>,
+): Promise<LicenseApiAttempt & { data?: T }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), LICENSE_API_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${host}${path}`, { ...init, signal: controller.signal });
+    // Read the body once — res.json() cannot be called twice, and both the
+    // success and the error path need it.
+    const text = await res.text();
+
+    let body: any;
+    try {
+      if (!text) throw new Error('Empty response body');
+      body = JSON.parse(text);
+    } catch {
+      return { host, status: res.status, reason: 'parse' };
+    }
+
+    const message = typeof body?.message === 'string' ? body.message : undefined;
+
+    if (res.status !== 200) {
+      return {
+        host, status: res.status, reason: 'status', message,
+      };
+    }
+
+    if (isComplete && !isComplete(body as T)) {
+      return {
+        host, status: res.status, reason: 'incomplete', message,
+      };
+    }
+
+    return {
+      host, status: res.status, reason: null, data: body as T,
+    };
+  } catch (e: any) {
+    return {
+      host,
+      status: null,
+      reason: e?.name === 'AbortError' ? 'timeout' : 'transport',
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function reportFallback(endpoint: string, attempts: LicenseApiAttempt[], figmaId?: string | null) {
+  const [primary, fallback] = attempts;
+  // The cutover signal: the primary could not answer and the legacy host
+  // could. Free users fail on both hosts and are deliberately excluded —
+  // otherwise this number has a permanent floor and never reaches zero.
+  const migrationGap = !!primary && primary.reason !== null && !!fallback && fallback.reason === null;
+
+  track('License API fallback', {
+    endpoint,
+    primaryStatus: primary?.status ?? null,
+    primaryReason: primary?.reason ?? null,
+    fallbackStatus: fallback?.status ?? null,
+    resolvedBy: attempts.find((a) => a.reason === null)?.host ?? null,
+    migrationGap,
+    ...(figmaId ? { figmaId } : {}),
+  });
+
+  Sentry.addBreadcrumb({
+    category: 'license-api',
+    level: 'info',
+    message: `${endpoint} fell back from ${primary?.host}`,
+    data: { primaryStatus: primary?.status, primaryReason: primary?.reason, migrationGap },
+  });
+}
+
+/**
+ * Tries each host in LICENSE_API_HOSTS in order, returning the first clean
+ * answer. Anything short of one — transport error, timeout, non-200,
+ * unreadable body, or a payload the caller rejects — moves on to the next
+ * host. The last host's error is what the caller surfaces.
+ */
+export async function fetchLicenseApi<T>(
+  path: string,
+  options: LicenseApiOptions<T>,
+): Promise<LicenseApiResult<T>> {
+  const { endpoint, figmaId, ...rest } = options;
+  const attempts: LicenseApiAttempt[] = [];
+
+  for (let i = 0; i < LICENSE_API_HOSTS.length; i += 1) {
+    // Sequential on purpose — the fallback only runs when the primary failed.
+    // eslint-disable-next-line no-await-in-loop
+    const { data, ...attempt } = await attemptHost<T>(LICENSE_API_HOSTS[i], path, rest);
+    attempts.push(attempt);
+
+    if (attempt.reason === null && data !== undefined) {
+      if (attempts.length > 1) reportFallback(endpoint, attempts, figmaId);
+      return { ok: true, data, attempts };
+    }
+  }
+
+  if (attempts.length > 1) reportFallback(endpoint, attempts, figmaId);
+
+  // A 404 from every host is an ordinary "no license" answer. Every host
+  // failing to respond at all is not, and is what the previous per-helper
+  // Sentry.captureException reported.
+  if (attempts.every((a) => a.reason === 'transport' || a.reason === 'timeout')) {
+    Sentry.captureMessage(`License API unreachable: ${endpoint}`, {
+      level: 'error',
+      extra: { attempts },
+    });
+  }
+
+  return {
+    ok: false,
+    message: attempts[attempts.length - 1]?.message ?? null,
+    attempts,
+  };
+}

--- a/packages/tokens-studio-for-figma/src/utils/licenseApiUrl.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/licenseApiUrl.test.ts
@@ -16,6 +16,10 @@ describe('licenseApiUrl', () => {
     expect(() => normalizeLicenseApiUrl('   ')).toThrow('License API URL cannot be empty');
   });
 
+  it('rejects a protocol it cannot fetch over', () => {
+    expect(() => normalizeLicenseApiUrl('ftp://api-production.tokens.studio')).toThrow('License API URL must use http or https');
+  });
+
   it('tries the new production API before the legacy one', () => {
     expect(LICENSE_API_HOSTS[0]).toEqual(PRIMARY_LICENSE_API_URL);
     expect(PRIMARY_LICENSE_API_URL).toEqual('https://api-production.tokens.studio');

--- a/packages/tokens-studio-for-figma/src/utils/licenseApiUrl.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/licenseApiUrl.test.ts
@@ -1,0 +1,28 @@
+import {
+  LEGACY_LICENSE_API_URL,
+  LICENSE_API_HOSTS,
+  PRIMARY_LICENSE_API_URL,
+  normalizeLicenseApiUrl,
+} from './licenseApiUrl';
+
+describe('licenseApiUrl', () => {
+  it('normalizes URLs and strips trailing slashes', () => {
+    expect(normalizeLicenseApiUrl('https://api-production.tokens.studio/')).toEqual('https://api-production.tokens.studio');
+    expect(normalizeLicenseApiUrl('localhost:3100/')).toEqual('http://localhost:3100');
+    expect(normalizeLicenseApiUrl('licence.tokens.studio')).toEqual('https://licence.tokens.studio');
+  });
+
+  it('rejects empty values', () => {
+    expect(() => normalizeLicenseApiUrl('   ')).toThrow('License API URL cannot be empty');
+  });
+
+  it('tries the new production API before the legacy one', () => {
+    expect(LICENSE_API_HOSTS[0]).toEqual(PRIMARY_LICENSE_API_URL);
+    expect(PRIMARY_LICENSE_API_URL).toEqual('https://api-production.tokens.studio');
+    expect(LICENSE_API_HOSTS).toContain(LEGACY_LICENSE_API_URL);
+  });
+
+  it('never lists the same host twice', () => {
+    expect(new Set(LICENSE_API_HOSTS).size).toEqual(LICENSE_API_HOSTS.length);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/licenseApiUrl.ts
+++ b/packages/tokens-studio-for-figma/src/utils/licenseApiUrl.ts
@@ -1,0 +1,45 @@
+export function normalizeLicenseApiUrl(url: string) {
+  const trimmedUrl = url.trim();
+
+  if (!trimmedUrl) {
+    throw new Error('License API URL cannot be empty');
+  }
+
+  let withProtocol: string;
+  if (/^[a-z][a-z\d+\-.]*:\/\//i.test(trimmedUrl)) {
+    withProtocol = trimmedUrl;
+  } else if (/^(localhost|127\.0\.0\.1)(:\d+)?(\/.*)?$/i.test(trimmedUrl)) {
+    withProtocol = `http://${trimmedUrl}`;
+  } else {
+    withProtocol = `https://${trimmedUrl}`;
+  }
+
+  if (!/^https?:\/\//i.test(withProtocol)) {
+    throw new Error('License API URL must use http or https');
+  }
+
+  // Strip trailing slashes without relying on the URL constructor (unavailable in Figma sandbox)
+  return withProtocol.replace(/\/+$/, '');
+}
+
+// Every license request is tried here first.
+export const PRIMARY_LICENSE_API_URL = normalizeLicenseApiUrl('https://api-production.tokens.studio');
+
+// Kept only for the duration of the license data migration. Requests fall back
+// here when the primary cannot answer them.
+export const LEGACY_LICENSE_API_URL = normalizeLicenseApiUrl(
+  process.env.LICENSE_API_URL || 'https://licence.tokens.studio',
+);
+
+/**
+ * Hosts in the order they are tried.
+ *
+ * MIGRATION: once the `License API fallback` telemetry reports no more
+ * `migrationGap: true` events, drop LEGACY_LICENSE_API_URL from this list and
+ * delete the `isComplete` guard in licenseApi.ts along with it — with a single
+ * host there is nowhere to fall back to, and the guard would start turning
+ * entitlement-less responses into hard errors.
+ */
+export const LICENSE_API_HOSTS: string[] = PRIMARY_LICENSE_API_URL === LEGACY_LICENSE_API_URL
+  ? [PRIMARY_LICENSE_API_URL]
+  : [PRIMARY_LICENSE_API_URL, LEGACY_LICENSE_API_URL];

--- a/packages/tokens-studio-for-figma/src/utils/removeLicense.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/removeLicense.test.ts
@@ -1,0 +1,51 @@
+import { mockFetch } from '../../tests/__mocks__/fetchMock';
+import { LICENSE_API_HOSTS } from './licenseApiUrl';
+import removeLicense from './removeLicense';
+
+const [PRIMARY, LEGACY] = LICENSE_API_HOSTS;
+
+const json = (status: number, body: unknown) => Promise.resolve({ status, text: () => Promise.resolve(JSON.stringify(body)) });
+
+describe('removeLicense', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('detaches on the primary host and returns the key', async () => {
+    mockFetch.mockImplementationOnce(() => json(200, 'detached-key'));
+
+    expect(await removeLicense('a-license-key', 'jan')).toEqual({ key: 'detached-key' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(`${PRIMARY}/detach-license`, expect.objectContaining({
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ licenseKey: 'a-license-key', userId: 'jan' }),
+    }));
+  });
+
+  it('falls back to the legacy host, carrying the request through unchanged', async () => {
+    mockFetch
+      .mockImplementationOnce(() => json(500, { message: 'boom' }))
+      .mockImplementationOnce(() => json(200, 'detached-key'));
+
+    expect(await removeLicense('a-license-key', 'jan')).toEqual({ key: 'detached-key' });
+    expect(mockFetch).toHaveBeenNthCalledWith(2, `${LEGACY}/detach-license`, expect.objectContaining({
+      method: 'PUT',
+      body: JSON.stringify({ licenseKey: 'a-license-key', userId: 'jan' }),
+    }));
+  });
+
+  it('surfaces the last error message when neither host detaches', async () => {
+    mockFetch
+      .mockImplementationOnce(() => json(500, { message: 'primary is unhappy' }))
+      .mockImplementationOnce(() => json(500, { message: 'Detach error message' }));
+
+    expect(await removeLicense('a-license-key', 'jan')).toEqual({ error: 'Detach error message' });
+  });
+
+  it('falls back to a generic message when no host produced one', async () => {
+    mockFetch.mockImplementation(() => Promise.reject());
+
+    expect(await removeLicense('a-license-key', 'jan')).toEqual({ error: 'Error removing license' });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/removeLicense.ts
+++ b/packages/tokens-studio-for-figma/src/utils/removeLicense.ts
@@ -1,27 +1,23 @@
+import { fetchLicenseApi } from './licenseApi';
+
 export default async function removeLicense(
   licenseKey: string,
   userId: string | null,
 ): Promise<{ key?: string; error?: string }> {
-  try {
-    const requestOptions = {
+  // MIGRATION: detach fails over like the reads do. While both systems are
+  // live a detach the primary accepts leaves the seat attached on the legacy
+  // host, so re-run the import as a delta sync before switching it off.
+  const result = await fetchLicenseApi<string>('/detach-license', {
+    endpoint: 'detach-license',
+    figmaId: userId,
+    init: {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ licenseKey, userId }),
-    };
-    const res = await fetch(`${process.env.LICENSE_API_URL}/detach-license`, requestOptions);
-    if (res.status === 200) {
-      const key = await res.json();
-      return { key };
-    }
+    },
+  });
 
-    const { message } = await res.json();
-    return {
-      error: message,
-    };
-  } catch (e) {
-    console.log(e);
-    return {
-      error: 'Error removing license',
-    };
-  }
+  if (result.ok) return { key: result.data };
+
+  return { error: result.message ?? 'Error removing license' };
 }

--- a/packages/tokens-studio-for-figma/src/utils/validateLicense.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/validateLicense.test.ts
@@ -1,0 +1,80 @@
+import { mockFetch } from '../../tests/__mocks__/fetchMock';
+import { LICENSE_API_HOSTS } from './licenseApiUrl';
+import validateLicense from './validateLicense';
+
+const [PRIMARY, LEGACY] = LICENSE_API_HOSTS;
+
+const PRO = { plan: 'pro', entitlements: ['pro'], email: 'pro@example.test' };
+const json = (status: number, body: unknown) => Promise.resolve({ status, text: () => Promise.resolve(JSON.stringify(body)) });
+const urlOf = (call: number) => mockFetch.mock.calls[call - 1][0] as string;
+
+describe('validateLicense', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('validates against the primary host and returns the licence details', async () => {
+    mockFetch.mockImplementationOnce(() => json(200, PRO));
+
+    expect(await validateLicense('a-key', 'jan', 'Jan Six')).toEqual(PRO);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(urlOf(1)).toEqual(`${PRIMARY}/validate-license?licenseKey=a-key&userId=jan&userName=Jan Six`);
+  });
+
+  it('omits userName from the query when there is none', async () => {
+    mockFetch.mockImplementationOnce(() => json(200, PRO));
+
+    await validateLicense('a-key', 'jan');
+
+    expect(urlOf(1)).toEqual(`${PRIMARY}/validate-license?licenseKey=a-key&userId=jan`);
+  });
+
+  it('falls back to the legacy host when the primary has no record', async () => {
+    mockFetch
+      .mockImplementationOnce(() => json(404, { message: 'License not found' }))
+      .mockImplementationOnce(() => json(200, PRO));
+
+    expect(await validateLicense('a-key', 'jan')).toEqual(PRO);
+    expect(urlOf(2)).toEqual(`${LEGACY}/validate-license?licenseKey=a-key&userId=jan`);
+  });
+
+  // A partially imported record answers 200 with a valid-looking but empty
+  // payload. addLicenseKey would treat that as VERIFIED and drop a paying user
+  // to the free tier, so it has to count as a miss.
+  it.each([
+    ['no plan and no entitlements', { plan: null, entitlements: [] }],
+    ['an empty object', {}],
+    ['a null body', null],
+  ])('falls back when the primary answers 200 with %s', async (_label, incomplete) => {
+    mockFetch
+      .mockImplementationOnce(() => json(200, incomplete))
+      .mockImplementationOnce(() => json(200, PRO));
+
+    expect(await validateLicense('a-key', 'jan')).toEqual(PRO);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['a plan but no entitlements', { plan: 'pro', entitlements: [] }],
+    ['entitlements but no plan', { plan: null, entitlements: ['beta'] }],
+  ])('accepts a 200 carrying %s', async (_label, complete) => {
+    mockFetch.mockImplementationOnce(() => json(200, complete));
+
+    expect(await validateLicense('a-key', 'jan')).toEqual(complete);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the last host error message when neither host validates', async () => {
+    mockFetch
+      .mockImplementationOnce(() => json(404, { message: 'License not found' }))
+      .mockImplementationOnce(() => json(404, { message: 'No license key found' }));
+
+    expect(await validateLicense('a-key', 'jan')).toEqual({ error: 'No license key found' });
+  });
+
+  it('falls back to a generic message when no host produced one', async () => {
+    mockFetch.mockImplementation(() => Promise.reject());
+
+    expect(await validateLicense('a-key', 'jan')).toEqual({ error: 'Error validating license' });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/validateLicense.ts
+++ b/packages/tokens-studio-for-figma/src/utils/validateLicense.ts
@@ -1,31 +1,27 @@
-import * as Sentry from '@sentry/react';
 import { Entitlements } from '@/app/store/models/userState';
+import { fetchLicenseApi } from './licenseApi';
+
+type ValidateLicenseResponse = { plan?: string; entitlements?: Entitlements[]; email?: string };
 
 export default async function validateLicense(
   licenseKey: string,
   userId: string | null,
   userName?: string | null,
 ): Promise<{ plan?: string; entitlements?: Entitlements[]; email?: string; error?: string }> {
-  try {
-    const res = await fetch(
-      `${process.env.LICENSE_API_URL}/validate-license?licenseKey=${licenseKey}&userId=${userId}${
-        userName ? `&userName=${userName}` : ''
-      }`,
-    );
+  const result = await fetchLicenseApi<ValidateLicenseResponse>(
+    `/validate-license?licenseKey=${licenseKey}&userId=${userId}${userName ? `&userName=${userName}` : ''}`,
+    {
+      endpoint: 'validate-license',
+      figmaId: userId,
+      // MIGRATION: a partially imported record can answer 200 with no plan and
+      // no entitlements, which addLicenseKey would accept as a valid response
+      // and quietly drop the user to free. Treat it as a miss and let the
+      // legacy host answer instead. Remove with the legacy host.
+      isComplete: (data) => Boolean(data?.plan) || (data?.entitlements?.length ?? 0) > 0,
+    },
+  );
 
-    if (res.status === 200) {
-      return await res.json();
-    }
+  if (result.ok) return result.data;
 
-    const { message } = await res.json();
-    return {
-      error: message,
-    };
-  } catch (e) {
-    console.log(e);
-    Sentry.captureException(e);
-    return {
-      error: 'Error validating license',
-    };
-  }
+  return { error: result.message ?? 'Error validating license' };
 }


### PR DESCRIPTION
## Why

We're moving the plugin's license API from `licence.tokens.studio` to `api-production.tokens.studio`. The two run on separate datastores, and the license data hasn't been imported yet, so neither host can serve every user on its own for the duration of the migration.

This replaces the configurable license API URL this PR originally introduced. Rather than a hidden override for internal testers, every request now goes to the new API first and falls back to the old one when it can't answer — so both stay live until the import completes. The follow-up PR drops the legacy host and this becomes a single-host client again.

## What changed

- **`src/utils/licenseApiUrl.ts`** — `LICENSE_API_HOSTS`, in the order they're tried: `api-production.tokens.studio`, then `LICENSE_API_URL` (defaulting to `licence.tokens.studio`). Deduped, so pointing the env var at the primary doesn't issue every request twice. Keeps the regex normalizer from the original PR — the `URL` constructor is still unavailable in the Figma sandbox.
- **`src/utils/licenseApi.ts`** — `fetchLicenseApi()`. Falls through to the next host on a transport error, a timeout, any non-200, a body it can't read as JSON, or a payload the caller rejects. Reads the body once via `text()`; the previous helpers called `res.json()` in two branches, which throws on the second read. The last host's `message` is what surfaces, so error text is unchanged when both fail.
- **`validateLicense` / `getLicenseKey` / `removeLicense`** — rewritten on top of it.
- **`src/mocks/handlers.ts`** — msw now serves both hosts.

### A timeout, because there wasn't one

`fetch` has no default timeout, and `addLicenseFactory` awaits these calls on the startup path. An unreachable host previously hung startup indefinitely rather than failing over — precisely the case this PR exists for. Requests now abort after 8s.

### Guarding against a silent downgrade

`validate-license` also rejects a 200 that carries neither a plan nor entitlements. A partially imported record can answer exactly that way, and `addLicenseKey` treats any error-free response as `VERIFIED` — so a paying user would be quietly dropped to the free tier. Marked in the source to be deleted along with the legacy host: with one host there is nowhere to fall through to, and the guard would start turning entitlement-less responses into hard errors.

### Telemetry, because the cutover needs a gate

Each fallback emits a `License API fallback` event: `{endpoint, primaryStatus, primaryReason, fallbackStatus, resolvedBy, migrationGap, figmaId}`.

`migrationGap` is precomputed as *the primary could not answer and the legacy host could* — the literal definition of a record the import missed. Users with no license fail on both hosts and are excluded, which matters: they'd otherwise give the metric a permanent floor it could never clear, since "user not found" and "user has no license" are the same response. **`migrationGap` reaching zero is the signal that it's safe to turn the old system off** — not the import finishing. `figmaId` goes through `track()`'s existing hashing, so a gap is traceable to an account.

Sentry now reports only when *no* host responded, which is what the per-helper `captureException` was actually catching, without a not-found storm.

## Verification

287 suites / 1663 tests green. 19 new tests cover each fallback trigger, the timeout, option pass-through on the PUT, and both telemetry cases.

Also driven against the real plugin in Figma Desktop over the bridge — interceptor injected before the bundle loads, a key seeded into `clientStorage`, and the plugin relaunched so the genuine startup path ran. Responses stubbed at the network boundary; everything above it is the shipped bundle. Confirmed the running build was this branch's before trusting any of it.

```
━━━ gap ━━━  (today: the new API has no record yet)
   2061ms  GET api-production.tokens.studio  validate-license → 404 {"message":"License not found"}
   2073ms  GET licence.tokens.studio         validate-license → 200 {"plan":"pro","entitlements":["pro"]}
   2078ms  EVENT "License API fallback" primary=404/status fallback=200 migrationGap=true
  RESULT  status=verified plan="pro" entitlements=["pro"]

━━━ migrated ━━━  (after the import — the legacy stub was a 500 tripwire; it never fired)
   1558ms  GET api-production.tokens.studio  validate-license → 200 {"plan":"pro",...}
  RESULT  status=verified plan="pro" entitlements=["pro"]

━━━ downgrade ━━━  (half-imported record: 200, valid JSON, nothing in it)
   1723ms  GET api-production.tokens.studio  validate-license → 200 {"plan":null,"entitlements":[]}
   1734ms  GET licence.tokens.studio         validate-license → 200 {"plan":"pro","entitlements":["pro"]}
   1745ms  EVENT "License API fallback" primary=200/incomplete fallback=200 migrationGap=true
  RESULT  status=verified plan="pro" entitlements=["pro"]     ← the downgrade did not happen

━━━ nokey ━━━  (ordinary user with no license — not a migration gap)
    875ms  GET api-production.tokens.studio  validate-license → 404
    889ms  GET licence.tokens.studio         validate-license → 404
    891ms  EVENT "License API fallback" primary=404 fallback=404 migrationGap=false   ← excluded from the gate
  RESULT  status=error error="No license key found"

━━━ hang ━━━  (new API accepts the connection, never answers)
   8807ms  GET api-production.tokens.studio  validate-license → ABORTED after 8003ms
   8811ms  GET licence.tokens.studio         validate-license → 200 {"plan":"pro",...}
   8813ms  EVENT "License API fallback" primary=null/timeout fallback=200 migrationGap=true
  RESULT  status=verified plan="pro" entitlements=["pro"]
```

`AbortController` fired at 8003ms inside the real Figma plugin iframe, so the sandbox concern was unfounded. `detach-license` was deliberately not exercised live — it mutates real license state.

## Notes for whoever lands this

- **`detach-license` fails over like the reads do.** While both systems are live, a detach the primary accepts leaves the seat attached on the legacy host. Re-run the import as a delta sync before switching the old one off.
- **Both migration exits are commented in `licenseApiUrl.ts`**: when the legacy host is dropped from `LICENSE_API_HOSTS`, the `isComplete` guard in `validateLicense` has to go with it.
- Unstubbed, `api-production` currently answers a bogus key in **75ms** — about 7× faster than the legacy host's 533ms — but with a **500** rather than a 404, as does the legacy host. That doesn't affect this PR (any non-200 falls back), but it does mean the new API's error rate is 100% noise during the window. Being fixed separately on the API side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
