### PR TITLE
fix: use `type` for shadow layers in the default preset

### DIFF
--- a/.changeset/box-shadow-layer-type.md
+++ b/.changeset/box-shadow-layer-type.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix the default preset's box shadow token using `$type` instead of `type` for the shadow type of its individual layers, a leftover from the DTCG migration. The layer type was unreadable, so every layer was applied as a drop shadow instead of one drop and one inner shadow.

--- a/packages/tokens-studio-for-figma/src/config/default.json
+++ b/packages/tokens-studio-for-figma/src/config/default.json
@@ -721,7 +721,7 @@
             "spread": 3,
             "color": "rgba({shadows.default}, 0.15)",
             "blur": 5,
-            "$type": "dropShadow"
+            "type": "dropShadow"
           },
           {
             "x": 4,
@@ -729,7 +729,7 @@
             "spread": 6,
             "color": "#00000033",
             "blur": 5,
-            "$type": "innerShadow"
+            "type": "innerShadow"
           }
         ],
         "$type": "boxShadow"


### PR DESCRIPTION
### Why does this PR exist?

The default preset's `boxShadow.default` token creates its two layers, but both end up as **Drop shadow** instead of one drop and one inner shadow.

The DTCG migration (#2449) blanket-renamed `type` → `$type` throughout `default.json`, including *inside* the individual shadow layer objects. Only a token's own type key gets the `$` prefix in DTCG — a shadow layer's type is always `type` (see [`TokenBoxshadowValue`](https://github.com/tokens-studio/figma-plugin/blob/main/packages/tokens-studio-for-figma/src/types/values/TokenBoxShadowValue.ts)). With the layer type stored under `$type`, `value.type` is `undefined` and `convertBoxShadowTypeToFigma` hits its `default:` branch, returning `DROP_SHADOW` for every layer.

`git log -L 715,737:src/config/default.json` shows the rename landing on those lines.

### What does this pull request do?

Changes `$type` back to `type` on the two shadow layers of the preset's `boxShadow.default` token. The token's own `"$type": "boxShadow"` is correct and stays as is.

Data-only fix — no parsing changes. The parser is behaving correctly; the preset was simply asking for something it didn't mean.

### Testing this change

1. Open the plugin in an empty file and load the default preset ("Load example tokens" / new file flow).
2. Apply `boxShadow.default` to a frame.
3. The frame should have two effects: a **Drop shadow** (5/5, blur 5, spread 3) and an **Inner shadow** (4/4, blur 5, spread 6). Before this change both were drop shadows.

The layer types are also visible in the token's edit form, so the inner/outer dropdowns on the second layer show the difference without applying to a node.

### Additional Notes (if any)

Anyone who already loaded the preset has `$type` on those layers persisted in their document and synced repo. `convertTokenToFormat` only rewrites top-level keys, so the bad key survives round-trips and their existing `boxShadow.default` will stay two drop shadows until the layer types are corrected by hand. Worth knowing if this comes up in support.

I initially also normalized layer-level `$type` → `type` on import so existing files would self-heal, but dropped it — the parser isn't wrong, and silently rewriting user token values is a bigger decision than this bug warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)