### PR TITLE
docs(figma-bridge): document driving a plugin's own UI

### DIFF
--- a/tools/figma-bridge/AGENTS.md
+++ b/tools/figma-bridge/AGENTS.md
@@ -16,12 +16,40 @@ mutate nodes, manage variables/styles, export a node to a PNG, screenshot the ca
 - **Platform:** macOS only, for now. **Runtime:** Node 22+ (built-in `WebSocket`/`fetch` globals). **Zero npm deps.**
 - Steady state: always launch via `node cli.mjs start` (it clones/patches/signs once, then reuses).
 
+## Yes, you can drive a plugin's own UI
+
+The bridge is not limited to the raw Plugin API. **A Figma plugin's own UI is
+fully drivable** — launch the plugin, navigate its tabs, open its modals, fill its
+forms, click through its dialogs, and read its app state, all without a human.
+(Done end-to-end against the Tokens Studio plugin's React UI.) Don't conclude
+you're stuck at `figma.*`.
+
+Two facts decide whether this works for you:
+
+1. **The plugin UI is a separate execution context in the same CDP target** —
+   not a separate target. `client._contexts` lists them all; the plugin one has a
+   `data:text/html;base64,…` `location.href`, the document one has `figma`. `eval`
+   and every `cli.mjs` command talk to the *document* context only.
+2. **`Input.dispatchMouseEvent` coordinates are top-level-page coordinates**, while
+   rects measured inside the plugin iframe are iframe-relative. **Add the iframe's
+   offset** or your clicks land on the canvas and silently do nothing.
+
+Full recipes — finding the context, the offset, `realClick`/`evalIn` helpers,
+typing, launching a plugin via Cmd+P, reading `window.store.getState()` — are in
+[AGENT-GUIDE.md → Driving a plugin's UI](./docs/AGENT-GUIDE.md#driving-a-plugins-ui).
+
+**What still needs a human:** importing a plugin manifest the first time
+(*Plugins → Development → Import plugin from manifest…* opens a macOS
+`NSOpenPanel`, which CDP cannot touch) and re-pointing an existing registration at
+a different path. Everything after that registration is automatable.
+
 ## Start here
 
 1. **[README.md](./README.md)** — what it is, why it works, full command reference, setup.
 2. **[docs/BEST-PRACTICES.md](./docs/BEST-PRACTICES.md)** — how to operate it well. Read
    **the verification hierarchy** first; it's the single most important habit.
-3. **[docs/AGENT-GUIDE.md](./docs/AGENT-GUIDE.md)** — copy-paste recipes for read / create / verify.
+3. **[docs/AGENT-GUIDE.md](./docs/AGENT-GUIDE.md)** — copy-paste recipes for read / create /
+   verify, and for **driving a plugin's own UI**.
 
 ## Commands
 
@@ -40,12 +68,15 @@ last. (Full version in [BEST-PRACTICES.md](./docs/BEST-PRACTICES.md#the-verifica
 
 1. **Read the value with `eval`** (the Figma **Plugin API**, in-process over the bridge —
    _not_ the REST API). For any _"what is this?"_ — color, name, size, bound variable,
-   font, node tree — read it, never eyeball it. Structured data is assertable.
+   font, node tree — read it, never eyeball it. Structured data is assertable. This
+   extends to a **plugin's** own state: read `document.body.innerText` or the app's
+   store from the plugin context instead of screenshotting its UI.
 2. **`export <nodeId>` → PNG** to validate _a frame you drew_. `node.exportAsync` gives
    just that node's pixels, tight-cropped, full fidelity, zoom/panel-independent.
-3. **`shot` (whole-window screenshot)** _only_ for Figma's own UI (plugin iframes,
-   panels) or values the API genuinely can't expose. A full-window shot to check a
-   frame's content is almost always the wrong call.
+3. **`shot` (whole-window screenshot)** _only_ for Figma's own chrome (panels, native
+   menus/dialogs) or values nothing else can expose. A full-window shot to check a
+   frame's content — or a plugin's UI, which you can read directly — is almost always
+   the wrong call.
 
 ## Key facts & gotchas (learned building it)
 
@@ -74,6 +105,20 @@ last. (Full version in [BEST-PRACTICES.md](./docs/BEST-PRACTICES.md#the-verifica
 - **Mutations are real & cloud-synced** — `eval` edits the user's actual logged-in
   Figma; there's no sandbox. Work on a scratch file/page, prefer additive changes, write
   idempotent scripts (find-by-name before create), and never delete user content unasked.
+- **UI state does not survive between script invocations** — menus and flyouts close,
+  plugin dialogs reset. Do a whole interaction (open → navigate → click → assert) in
+  **one continuous script**, with retries/polling inside it. Splitting it across runs
+  is the biggest time sink when driving UI.
+- **Verify _which build_ of a dev plugin is running.** Figma keys development plugins
+  on the manifest **`id`** and keeps the path it was first registered from — so a
+  worktree can silently run the main repo's months-old build. Prove it's your build
+  (unique marker → rebuild → relaunch → confirm) before trusting any behaviour. Also
+  check for `Failed to load .env.` at build time: env-dependent features then fail
+  *silently at runtime*, and `.env` is gitignored so fresh worktrees lack it.
+- **The debug build crashes, especially on keyboard events.** Avoid
+  `Input.dispatchKeyEvent` **with modifiers** (Cmd+A repeatedly hard-crashed Figma).
+  After any CDP timeout, run `node cli.mjs status` — `running: false` is the tell —
+  then `node cli.mjs start` and re-run.
 - **Target a specific file** among many tabs by filtering on its **file key**:
   `connect({ targetUrl: "<key>" })` in an inline `node -e` script (the CLI itself doesn't
   expose targetUrl; it picks the first live design context). See

--- a/tools/figma-bridge/README.md
+++ b/tools/figma-bridge/README.md
@@ -6,15 +6,22 @@ and evaluates **Plugin-API** JavaScript (`figma.*`) directly in the renderer, so
 agent (or you) can read the document, mutate nodes, manage variables, export any node
 to a PNG, and screenshot the canvas entirely from the command line.
 
+The same CDP connection also reaches **a running plugin's own UI** — its iframe is a
+separate execution context in the same target, so you can launch a registered plugin,
+click through its interface, type into its forms and read its app state, all
+automated. See [Driving a plugin's UI](./docs/AGENT-GUIDE.md#driving-a-plugins-ui).
+
 > **Platform:** macOS only, for now. **Runtime:** Node 22+ (uses the built-in global
 > `WebSocket`/`fetch`; `WebSocket` is a stable global from Node 22). **Zero npm dependencies.**
 
 ## Why this exists
 
-Figma deliberately strips the `--remote-debugging-port` flag at launch, and its plugin
-sandbox can't be imported/run without a human clicking through the UI. This tool works
-around the first restriction with a one-byte patch to a **copy** of Figma.app and skips
-the plugin sandbox entirely — the agent talks to the real `figma` global over CDP.
+Figma deliberately strips the `--remote-debugging-port` flag at launch, and a plugin
+can't be *imported* without a human clicking through a native file dialog. This tool
+works around the first restriction with a one-byte patch to a **copy** of Figma.app,
+and sidesteps the second by not needing a plugin at all — the agent talks to the real
+`figma` global over CDP. (Once a plugin *has* been imported, launching it and driving
+its UI is automatable too; only that first import needs a human.)
 
 ## How it works
 
@@ -60,11 +67,12 @@ Two very different screenshots, and picking the right one matters:
   node's pixels** — tightly cropped, full fidelity, independent of zoom/viewport/panels.
   This is the right way to **validate a frame you built**. Default scale is `2` (@2x).
 - **`shot [file]`** captures the **entire Figma window** (toolbar, panels, canvas chrome)
-  at the current zoom. Reserve it for when the thing you need to see *is Figma's own UI* —
-  a plugin's iframe, the inspector/variables panels, etc.
+  at the current zoom. Reserve it for when the thing you need to see *is Figma's own
+  chrome* — the inspector/variables panels, a native menu or dialog.
 
 And when the question is *"what is this value?"* (a color, a name, a bound variable), don't
-screenshot at all — **read it with `eval`**. See
+screenshot at all — **read it with `eval`**. That holds for a plugin's UI too: its DOM and
+app state are readable directly, so it isn't a reason to reach for `shot`. See
 [docs/BEST-PRACTICES.md](./docs/BEST-PRACTICES.md#the-verification-hierarchy) for the full
 verification hierarchy.
 
@@ -93,8 +101,19 @@ verification hierarchy.
   reachable — that's where the `figma` global lives. `start` waits until a document's
   `figma` is actually evaluable before returning; restored/suspended background tabs are
   scanned and skipped automatically.
+- **Native file dialogs are off-limits to CDP.** *Plugins → Development → Import plugin
+  from manifest…* opens a macOS `NSOpenPanel`, which CDP can neither see nor click, so
+  **a human must do the one-time manifest import** (and any re-pointing of an existing
+  registration at a new path). Launching an already-registered plugin is automatable —
+  Cmd+P, type its name, Enter.
+- **Development plugins are identified by manifest `id`, not by path.** If the same `id`
+  is registered from another checkout, Figma keeps running *that* copy — easy to test a
+  stale build from a different branch for hours. Confirm which build is live before
+  drawing conclusions.
 - The debug copy is **ad-hoc signed**. That's fine for launching locally; it is not
-  distributable.
+  distributable. It is also noticeably **crash-prone** — especially around synthetic
+  keyboard events with modifiers. After a CDP timeout, check `node cli.mjs status` and
+  `start` again if it died.
 
 ## Fallback: patch the installed app (variant B)
 
@@ -143,7 +162,10 @@ This tool lives under `tools/` and is intentionally **outside** the npm workspac
   gotchas. Self-contained so it travels with the folder.
 - **[docs/BEST-PRACTICES.md](./docs/BEST-PRACTICES.md)** — how to operate the bridge well.
   Start with the verification hierarchy (read with `eval` → `export` a node → `shot` the
-  window), plus notes on idempotency, real/cloud-synced mutations, and file targeting.
+  window), plus notes on idempotency, real/cloud-synced mutations, file targeting,
+  keeping a UI interaction in one script run, and proving which build is loaded.
 - **[docs/AGENT-GUIDE.md](./docs/AGENT-GUIDE.md)** — copy-paste recipes for the
   build → run → verify loop: reading variables/styles, creating frames and text, the
-  auto-layout hug/wrap gotcha, exporting to verify, and targeting a specific file.
+  auto-layout hug/wrap gotcha, exporting to verify, targeting a specific file, and
+  **driving a plugin's own UI** (finding its context, the iframe offset, clicking,
+  typing, reading its store).

--- a/tools/figma-bridge/docs/AGENT-GUIDE.md
+++ b/tools/figma-bridge/docs/AGENT-GUIDE.md
@@ -175,13 +175,16 @@ When a built layout looks collapsed, **read the sizing modes with `eval`**
 # preferred: export just the node you care about (tight crop, full fidelity)
 node cli.mjs export "<nodeId>" /tmp/out.png 2     # 2 = @2x scale (default)
 
-# only for Figma's own UI (plugin iframes, panels): whole-window shot
+# only for Figma's own chrome (panels, menus, native dialogs): whole-window shot
 node cli.mjs shot /tmp/figma-window.png
 ```
 
 Then view the PNG. See the [verification hierarchy](./BEST-PRACTICES.md#the-verification-hierarchy)
 for when to use which — the short version is: **read values with `eval`, validate
 frames with `export`, and only `shot` the whole window for Figma's chrome.**
+
+A plugin's own UI is **not** a reason to reach for `shot`: you can read its DOM
+and its app state directly. See [Driving a plugin's UI](#driving-a-plugins-ui).
 
 ---
 
@@ -204,6 +207,272 @@ node -e '
 
 The same `connect({ targetUrl })` handle exposes `eval()`, `screenshot()` and
 `exportNode(id, { scale })` if you need to script a full targeted flow.
+
+---
+
+## Driving a plugin's UI
+
+A Figma plugin's own UI is **not out of reach**. It's an iframe whose JavaScript
+runs in a *different execution context* inside the *same* CDP target as the
+document. Once you have that context id you can read its DOM, call into its app
+state, click its buttons and type into its fields — fully automated, no human
+clicks. (This is not theory: the Tokens Studio plugin's entire React UI — tabs,
+modals, forms, the push/commit dialogs — was driven end-to-end this way.)
+
+This is one level below `cli.mjs`: you write a `.mjs` script that imports
+`connect` from `cdp.mjs` and uses three internal-but-usable escape hatches on the
+client it returns:
+
+- **`client._contexts`** — every execution context CDP has announced for the
+  target. Populated because `connect()` already calls `Runtime.enable`.
+- **`client._rawEval(expr, { contextId })`** — `Runtime.evaluate` in **one
+  specific context**. Returns the raw CDP result, so the value is at
+  `.result.value`. Unlike `client.eval()` it does **not** auto-wrap `return`/`await`.
+- **`client._send(method, params)`** — any raw CDP command:
+  `Input.dispatchMouseEvent`, `Input.insertText`, …
+
+`client.eval()` and every `cli.mjs` command always target `client.contextId` —
+the **document** context, where `figma` lives. Plugin-UI work means talking to a
+*different* contextId in the same client.
+
+### The two facts that make or break this
+
+1. **The plugin UI is a separate execution context**, not a separate target. The
+   document context has `typeof figma !== "undefined"` and a
+   `figma.com/(design|file)/` URL; the plugin UI context's `location.href` starts
+   with `data:text/html;base64,…` and its `document` is the plugin's own DOM.
+2. **Coordinates live in two different spaces.** `Input.dispatchMouseEvent`
+   coordinates are relative to the **top-level page**. Element rects you measure
+   *inside* the plugin iframe are **iframe-relative**. You must add the iframe's
+   offset. Getting this wrong makes clicks land on the canvas and *silently do
+   nothing* — this is the number one gotcha, and it looks exactly like "the click
+   didn't work".
+
+### Helper: eval in a specific context
+
+```js
+async function evalIn(client, contextId, code, timeoutMs = 5000) {
+  const expr = /\breturn\b|\bawait\b/.test(code) ? `(async () => { ${code} })()` : code;
+  const res = await client._rawEval(expr, { contextId, timeoutMs });
+  if (res?.exceptionDetails) {
+    throw new Error(res.exceptionDetails.exception?.description ?? res.exceptionDetails.text);
+  }
+  return res?.result?.value;
+}
+```
+
+Pass a short `timeoutMs` when probing contexts: `_send` defaults to **15 s**, and
+a dead context will burn all of it before rejecting — painful when you're
+iterating over a dozen of them.
+
+### Find the plugin's execution context
+
+Match on distinctive plugin text **and** a second signal that the app is actually
+alive. Text alone is not enough: `_contexts` accumulates as contexts are created
+and is not pruned when they're destroyed, so a plugin reload leaves a **stale,
+blank context** behind that can still match on a name. For a Redux app,
+`window.store.getState` is the ideal liveness probe.
+
+```js
+async function findPluginContext(client) {
+  // newest first — after a reload the live context is the most recently created
+  for (const ctx of [...client._contexts].reverse()) {
+    try {
+      const ok = await evalIn(client, ctx.id, `
+        return location.href.startsWith("data:text/html")
+          && typeof window.store !== "undefined"
+          && typeof window.store.getState === "function";
+      `);
+      if (ok) return ctx.id;
+    } catch {
+      // suspended / destroyed context — skip it
+    }
+  }
+  return null;
+}
+```
+
+If the plugin has no store to probe, fall back to a distinctive string in
+`document.body.innerText` — but expect the stale-context failure mode and
+re-check that the context still responds before trusting it.
+
+### Get the iframe offset
+
+Measure it in the **document** context (`client.contextId`), not the plugin one:
+
+```js
+const offset = await evalIn(client, client.contextId, `
+  const f = Array.from(document.querySelectorAll("iframe"))
+    .find(f => (f.title || "").includes("Plugin:") && f.getBoundingClientRect().width > 0);
+  if (!f) throw new Error("no visible plugin iframe — is the plugin running?");
+  const r = f.getBoundingClientRect();
+  return { x: r.x, y: r.y, w: r.width, h: r.height };
+`);
+```
+
+Re-measure it after anything that could move or resize the plugin window; don't
+cache it across a relaunch.
+
+### Helper: a real click
+
+Synthetic `el.click()` works for plain buttons inside the plugin's own UI, but
+**not** for Figma's native menus (hover-driven flyouts that only respond to real
+input) and **not** reliably for focusing React inputs. When in doubt, dispatch
+real mouse events:
+
+```js
+async function realClick(client, x, y) {
+  const at = { x, y };
+  await client._send("Input.dispatchMouseEvent", { ...at, type: "mouseMoved", button: "none", clickCount: 0 });
+  await client._send("Input.dispatchMouseEvent", { ...at, type: "mousePressed", button: "left", clickCount: 1 });
+  await client._send("Input.dispatchMouseEvent", { ...at, type: "mouseReleased", button: "left", clickCount: 1 });
+}
+```
+
+### Click an element in the plugin UI by its visible text
+
+Measure inside the plugin context, then **add the offset** before clicking.
+Match on **leaf nodes** so you don't also match every ancestor container:
+
+```js
+const rect = await evalIn(client, pluginCtx, `
+  const el = Array.from(document.querySelectorAll("*"))
+    .find(e => e.children.length === 0 && (e.textContent || "").trim() === "Settings");
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.x, y: r.y, w: r.width, h: r.height };
+`);
+if (!rect) throw new Error("Settings not found");
+await realClick(client, offset.x + rect.x + rect.w / 2, offset.y + rect.y + rect.h / 2);
+```
+
+For **Figma's own menus** (not the plugin's), items carry `role=menuitem`, so
+`document.querySelectorAll("[role=menuitem]")` in the *document* context is the
+better selector — and those must be clicked with `realClick`, never `el.click()`.
+
+### Type into a field
+
+Real click to focus, then `Input.insertText`. This is the reliable path:
+
+```js
+await realClick(client, offset.x + rect.x + rect.w / 2, offset.y + rect.y + rect.h / 2);
+await client._send("Input.insertText", { text: "my commit message" });
+```
+
+Two traps when the field is React-controlled:
+
+- **Setting `el.value` directly is ignored by React.** The native-setter trick
+  does register with plain React state:
+  ```js
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+  setter.call(el, "text");
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  ```
+- **…but even that did not work for a `react-hook-form` form.** The value showed
+  up in the DOM while the library's internal state never updated, and Save
+  persisted the *old* value — a silent, very convincing false positive. For
+  those forms, focus with a real click and type with `Input.insertText`.
+
+> **Avoid `Input.dispatchKeyEvent` with modifiers** (Cmd+A to select-all, etc.).
+> In this environment it repeatedly **hard-crashed Figma**. To replace a field's
+> contents, prefer the native-setter approach or clear the field some other way.
+
+### Launch a plugin without touching a native file dialog
+
+Do **not** try to drive *Plugins → Development → Import plugin from manifest…*.
+That opens a macOS `NSOpenPanel`, which CDP cannot see or touch. **A human must
+do the one-time import.** Same for re-pointing an existing registration at a
+different path.
+
+Once the plugin is registered, launching it *is* fully automatable via the
+quick-actions palette — far more reliable than the Plugins → Development flyout,
+which auto-collapses out from under you:
+
+```js
+// Cmd+P → type the plugin name → Enter
+await client._send("Input.dispatchKeyEvent", {
+  type: "rawKeyDown", key: "p", code: "KeyP", modifiers: 4,   // 4 = Meta/Cmd
+  windowsVirtualKeyCode: 80, nativeVirtualKeyCode: 80,
+});
+await client._send("Input.dispatchKeyEvent", {
+  type: "keyUp", key: "p", code: "KeyP", modifiers: 4,
+  windowsVirtualKeyCode: 80, nativeVirtualKeyCode: 80,
+});
+await client._send("Input.insertText", { text: "Tokens Studio" });
+// …poll until the palette shows a result, then:
+await client._send("Input.dispatchKeyEvent", {
+  type: "keyDown", key: "Enter", code: "Enter", text: "\r",
+  windowsVirtualKeyCode: 13, nativeVirtualKeyCode: 13,
+});
+await client._send("Input.dispatchKeyEvent", {
+  type: "keyUp", key: "Enter", code: "Enter",
+  windowsVirtualKeyCode: 13, nativeVirtualKeyCode: 13,
+});
+```
+
+This one modifier combo is the exception worth taking — but it *is* a modifier
+combo, so treat a crash as a normal outcome: check `node cli.mjs status`, and if
+it reports `running: false`, `node cli.mjs start` and re-run.
+
+### Read the plugin's state instead of screenshotting it
+
+The [verification hierarchy](./BEST-PRACTICES.md#the-verification-hierarchy)
+applies *inside* plugin UIs too — "read the value" means the plugin's state, not
+just `figma.*`. If the plugin exposes a Redux store, assert on real state:
+
+```js
+const dirty = await evalIn(client, pluginCtx, `
+  const s = window.store.getState();
+  return { tab: s.uiState.activeTab, dirty: s.tokenState.changedState };
+`);
+```
+
+That is how you compare what the plugin *thinks* is true against what actually
+got written somewhere else — evidence a screenshot can never give you.
+
+And for a fast, cheap "what is the plugin showing right now?" (which tab, which
+modal, any error banner), read text rather than pixels:
+
+```js
+await evalIn(client, pluginCtx, `return document.body.innerText`);
+```
+
+### Instrument with a global array, not console capture
+
+When you need to see inside the plugin's own code, **don't** rely on capturing
+`Runtime.consoleAPICalled`: the listener is bound to a context that gets replaced
+on every plugin iframe reload, and logs go silently missing. Push into a global
+from the instrumented source instead:
+
+```js
+((globalThis).__debug = (globalThis).__debug || []).push({ where: "push", ok, at: Date.now() });
+```
+
+Then read it back with an eval in the plugin context afterwards. It survives
+reloads and gives decisive evidence instead of an empty log.
+
+### Do the whole interaction in ONE script
+
+Figma's menus and flyouts close, and plugin modal state resets, **between
+separate `node script.mjs` invocations**. Open the menu, navigate, click, and
+assert in a *single* continuous run; put retries and polling *inside* that run
+rather than re-running the script. Splitting an interaction across invocations is
+the single biggest time sink here.
+
+```js
+import { connect } from "./cdp.mjs";
+
+const client = await connect({ timeoutMs: 20000 });
+try {
+  const pluginCtx = await findPluginContext(client);            // 1. locate
+  const offset = await evalIn(client, client.contextId, `…`);   // 2. measure
+  await realClick(client, /* offset + rect */);                 // 3. act
+  const state = await evalIn(client, pluginCtx, `…`);           // 4. assert on state
+  console.log(JSON.stringify(state, null, 2));
+} finally {
+  client.close();
+}
+```
 
 ---
 

--- a/tools/figma-bridge/docs/BEST-PRACTICES.md
+++ b/tools/figma-bridge/docs/BEST-PRACTICES.md
@@ -54,14 +54,14 @@ which panels are open**. No toolbar, no sidebars, no canvas chrome. This is the
 right tool for _"validate what's on a frame"_ and it should be your default for
 visual checks.
 
-### 3. `shot` the whole window — _only for Figma's own UI_
+### 3. `shot` the whole window — _only for Figma's own chrome_
 
 `shot` captures the **entire Figma window as pixels** — toolbar, panels, canvas
 chrome, at the current zoom. Reserve it for the few cases where the thing you need
 to see _is_ Figma itself:
 
-- a plugin's own iframe/UI while you're building or debugging a plugin
 - the state of the variables / inspector / layers panels
+- native menus and dialogs you can't reach any other way
 - something the Plugin API genuinely can't expose
 
 ```bash
@@ -72,6 +72,22 @@ node cli.mjs shot /tmp/figma-window.png
 `shot`. Answering _"what is the value"_ → don't screenshot at all, `eval` and read
 it. A full-window screenshot to check a frame's colors is almost always the wrong
 call — it's zoom-dependent, cluttered, and lower fidelity than an `export`.
+
+### The hierarchy applies inside plugin UIs too
+
+It's tempting to treat a plugin's own UI as a reason to `shot` the window. **It
+isn't one.** The plugin UI is a real DOM in a separate execution context of the
+same CDP target, so you can read it directly — which puts it right back at level 1:
+
+- _"which tab / modal is showing, is there an error banner?"_ →
+  `document.body.innerText` from the plugin context. Fast, cheap, greppable.
+- _"is the app's state actually what I think?"_ → read the store, e.g.
+  `window.store.getState()` for a Redux app, and assert on real values.
+
+Reading state is the strongest habit available when debugging a plugin: it's how
+you compare what the plugin *believes* against what actually got written
+somewhere else. Pixels can't do that. Recipes are in
+[Driving a plugin's UI](./AGENT-GUIDE.md#driving-a-plugins-ui).
 
 ---
 
@@ -108,6 +124,67 @@ if (!page) {
   page.name = "My scratch page";
 }
 ```
+
+### Do a whole UI interaction in ONE script run
+
+**UI state does not survive between invocations.** Figma's menus and flyouts
+close, and plugin dialogs close or reset, between separate `node script.mjs`
+runs. So open the menu, navigate it, click, and assert **inside one continuous
+script** — and build the retries and polling *into* that script rather than
+re-running it to get one step further.
+
+Splitting an interaction across invocations is the single biggest source of
+wasted time when driving UI over this bridge. It also produces very convincing
+wrong conclusions ("the menu item isn't there") when the real cause is that the
+menu closed when the previous process exited.
+
+### Verify _which build_ is actually loaded
+
+Figma identifies a development plugin by its manifest **`id`**, and it keeps the
+**path it was originally registered from**. If the same `id` is registered from
+another checkout — the main repo vs. a git worktree, say — Figma keeps running
+that *other* copy. You can spend hours testing a months-old build from a
+different branch while believing you're testing your working tree.
+
+Before drawing any conclusion from plugin behaviour, **prove the running plugin
+is your build**: temporarily add a unique marker to the source, rebuild,
+relaunch, and confirm the marker appears. Check the displayed version too, if the
+plugin has one. Re-pointing a registration at a different path is a **human**
+step — they must re-import the manifest.
+
+Related trap: a build that printed `Failed to load .env.` produces a bundle where
+env-dependent features fail *silently at runtime*. In one case that disabled
+license validation, which took a whole paid code path down with it and made
+pushes fail for reasons that looked like a product bug. `.env` is gitignored, so
+a **fresh worktree won't have one** — copy it from another checkout of the same
+repo before concluding a feature is broken.
+
+### Instrument with a global, not console capture
+
+Capturing `Runtime.consoleAPICalled` is unreliable across plugin iframe reloads:
+the listener is attached to a context that gets replaced, and the logs are
+silently lost. Have the instrumented source push into a global instead, and read
+it back with an eval afterwards — it survives reloads and gives decisive evidence.
+
+```js
+((globalThis).__debug = (globalThis).__debug || []).push({ where: "push", ok, at: Date.now() });
+```
+
+### Expect the debug build to crash, and make re-runs cheap
+
+The patched debug Figma is noticeably crash-prone, especially around keyboard
+events — **avoid `Input.dispatchKeyEvent` with modifiers** (Cmd+A and friends
+repeatedly hard-crashed it). After any CDP timeout, and particularly
+`CDP Input.dispatchKeyEvent timed out`, don't debug the script: check whether
+Figma is still alive.
+
+```bash
+node cli.mjs status     # running: false right after a failure is the tell
+node cli.mjs start      # relaunch and re-run
+```
+
+Write scripts so that a restart-and-rerun costs nothing — idempotent, no manual
+setup steps in between.
 
 ### Target a specific file by key when many tabs are open
 


### PR DESCRIPTION
### Why does this PR exist?

The `figma-bridge` docs implied the tool could only reach the raw Plugin API (`figma.*`). `AGENTS.md` said it "skips the plugin sandbox entirely", and `BEST-PRACTICES.md` told you to reach for a whole-window screenshot to see "a plugin's own iframe". Agents read that and concluded a plugin's UI was off-limits — and stopped there.

It isn't off-limits. A plugin's UI is an iframe running in a **separate execution context inside the same CDP target**, so it can be read and driven directly: launch the plugin, navigate its tabs, open modals, fill forms, click through dialogs, and assert on its app state — no human clicks.

This was verified end-to-end while validating #3957: the entire Tokens Studio React UI was driven over the bridge, including the GitHub sync form and the push/commit dialogs, and the resulting commits were checked against the repo.

### What does this pull request do?

Docs only. **No changes to `cdp.mjs`, `launch.mjs` or `cli.mjs`.**

- **`docs/AGENT-GUIDE.md`** — new "Driving a plugin's UI" section: finding the plugin context, the iframe coordinate offset, `evalIn`/`realClick` helpers, typing via `Input.insertText`, launching a plugin via Cmd+P, reading `window.store.getState()`, instrumenting via a global, and a one-script skeleton.
- **`docs/BEST-PRACTICES.md`** — `shot` is scoped to Figma's own chrome; the verification hierarchy now explicitly applies *inside* plugin UIs (reading a plugin's DOM/state is a level-1 read, not a reason to screenshot). Adds one-continuous-script, verify-which-build, instrument-with-a-global, and crash recovery.
- **`AGENTS.md`** — a prominent "Yes, you can drive a plugin's own UI" section placed early, so an agent hits it before giving up, plus an honest "what still needs a human".
- **`README.md`** — capability mention in the intro; the old claim that a plugin "can't be imported/run without a human" now correctly scopes to *import* only.

### The gotchas it documents

Each of these cost real time to find:

- **Coordinate spaces differ.** `Input.dispatchMouseEvent` takes top-level-page coordinates, but rects measured inside the plugin iframe are iframe-relative. Miss the offset and every click silently lands on the canvas.
- **Destroyed contexts linger.** `_contexts` is appended on `executionContextCreated` but `executionContextDestroyed` is never handled, so a stale context can be picked after a plugin reload. Probe for liveness.
- **UI state does not survive between script invocations** — menus and dialogs close. Keep one interaction in one script run.
- **Dev plugins are keyed by manifest `id`, not path.** If the same `id` is registered from another checkout, that registration wins — you can test a stale build from another branch for a long time without noticing. Prove which build is live before trusting results.
- **Modifier-key events crash this debug build** (Cmd+A reliably killed it); prefer `Input.insertText` after a real click.
- **React inputs need the native-setter trick** — and even that fails on `react-hook-form`: the DOM shows the new value while the saved value stays old, which reads as a silent false positive.
- **A missing `.env`** yields a bundle where env-dependent features fail silently at runtime.

### Testing this change

Docs only — nothing to run. The recipes were all executed against a live Figma during #3957 validation, and every internal API referenced (`connect()`, `_contexts`, `_rawEval`, `_send`) was checked against `cdp.mjs` rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)