### PR TITLE
fix(typography): match numeric weights to family styles

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/getFigmaFonts.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/getFigmaFonts.ts
@@ -1,8 +1,9 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import { listAvailableFonts } from '../listAvailableFonts';
 
 export const getFigmaFonts: AsyncMessageChannelHandlers[AsyncMessageTypes.GET_FIGMA_FONTS] = async () => {
-  const availableFonts = await figma.listAvailableFontsAsync();
+  const availableFonts = await listAvailableFonts();
   return {
     fonts: availableFonts,
   };

--- a/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.test.ts
@@ -15,6 +15,10 @@ describe('fontWeight', () => {
       output: ['Light', 'Leicht'],
     },
     {
+      input: '350',
+      output: ['SemiLight', 'Semi Light', 'DemiLight', 'Demi Light'],
+    },
+    {
       input: '400',
       output: ['Regular', 'Normal', 'Book', 'Roman', 'Buch'],
     },
@@ -24,11 +28,11 @@ describe('fontWeight', () => {
     },
     {
       input: '600',
-      output: ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold', 'Halbfett'],
+      output: ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold', 'Halbfett', 'Demi'],
     },
     {
       input: '700',
-      output: ['Bold', 'Dreiviertelfett'],
+      output: ['Bold', 'Dreiviertelfett', 'Gras'],
     },
     {
       input: '800',
@@ -37,6 +41,10 @@ describe('fontWeight', () => {
     {
       input: '900',
       output: ['Black', 'Heavy', 'Super', 'Extrafett'],
+    },
+    {
+      input: '950',
+      output: ['ExtraBlack', 'Extra Black', 'UltraBlack', 'Ultra Black'],
     },
     {
       input: '450',

--- a/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.test.ts
@@ -1,4 +1,4 @@
-import { convertFontWeightToFigma } from './fontWeight';
+import { convertFontWeightToFigma, fontWeightStyleCandidates } from './fontWeight';
 
 describe('fontWeight', () => {
   const fontWeights = [
@@ -12,40 +12,50 @@ describe('fontWeight', () => {
     },
     {
       input: '300',
-      output: ['Light'],
+      output: ['Light', 'Leicht'],
     },
     {
       input: '400',
-      output: ['Regular', 'Normal'],
+      output: ['Regular', 'Normal', 'Book', 'Roman', 'Buch'],
     },
     {
       input: '500',
-      output: ['Medium'],
+      output: ['Medium', 'Kraeftig', 'Kräftig'],
     },
     {
       input: '600',
-      output: ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold'],
+      output: ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold', 'Halbfett'],
     },
     {
       input: '700',
-      output: ['Bold'],
+      output: ['Bold', 'Dreiviertelfett'],
     },
     {
       input: '800',
-      output: ['ExtraBold', 'Extra Bold', 'UltraBold', 'Ultra Bold'],
+      output: ['ExtraBold', 'Extra Bold', 'UltraBold', 'Ultra Bold', 'Fett'],
     },
     {
       input: '900',
-      output: ['Black', 'Heavy'],
+      output: ['Black', 'Heavy', 'Super', 'Extrafett'],
     },
     {
       input: '450',
       output: ['450'],
     },
+    {
+      input: 'Book',
+      output: ['Book'],
+    },
   ];
   it('should convert numerical font weight to figma font weight', () => {
     fontWeights.forEach((fontWeight) => {
       expect(convertFontWeightToFigma(fontWeight.input)).toEqual(fontWeight.output);
+      expect(fontWeightStyleCandidates(fontWeight.input)).toEqual(fontWeight.output);
     });
+  });
+
+  it('returns the raw value when shouldOutputForVariables is true', () => {
+    expect(convertFontWeightToFigma('400', true)).toEqual(['400']);
+    expect(convertFontWeightToFigma('Book', true)).toEqual(['Book']);
   });
 });

--- a/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.ts
@@ -9,20 +9,24 @@ export function convertFontWeightToFigma(value: string, shouldOutputForVariables
     case '200':
       return ['ExtraLight', 'Extra Light', 'UltraLight', 'Ultra Light'];
     case '300':
-      return ['Light'];
+      return ['Light', 'Leicht'];
     case '400':
-      return ['Regular', 'Normal'];
+      return ['Regular', 'Normal', 'Book', 'Roman', 'Buch'];
     case '500':
-      return ['Medium'];
+      return ['Medium', 'Kraeftig', 'Kräftig'];
     case '600':
-      return ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold'];
+      return ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold', 'Halbfett'];
     case '700':
-      return ['Bold'];
+      return ['Bold', 'Dreiviertelfett'];
     case '800':
-      return ['ExtraBold', 'Extra Bold', 'UltraBold', 'Ultra Bold'];
+      return ['ExtraBold', 'Extra Bold', 'UltraBold', 'Ultra Bold', 'Fett'];
     case '900':
-      return ['Black', 'Heavy'];
+      return ['Black', 'Heavy', 'Super', 'Extrafett'];
     default:
       return [value];
   }
+}
+
+export function fontWeightStyleCandidates(value: string): string[] {
+  return convertFontWeightToFigma(value, false);
 }

--- a/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figmaTransforms/fontWeight.ts
@@ -10,18 +10,22 @@ export function convertFontWeightToFigma(value: string, shouldOutputForVariables
       return ['ExtraLight', 'Extra Light', 'UltraLight', 'Ultra Light'];
     case '300':
       return ['Light', 'Leicht'];
+    case '350':
+      return ['SemiLight', 'Semi Light', 'DemiLight', 'Demi Light'];
     case '400':
       return ['Regular', 'Normal', 'Book', 'Roman', 'Buch'];
     case '500':
       return ['Medium', 'Kraeftig', 'Kräftig'];
     case '600':
-      return ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold', 'Halbfett'];
+      return ['SemiBold', 'Semibold', 'Semi Bold', 'DemiBold', 'Demi Bold', 'Halbfett', 'Demi'];
     case '700':
-      return ['Bold', 'Dreiviertelfett'];
+      return ['Bold', 'Dreiviertelfett', 'Gras'];
     case '800':
       return ['ExtraBold', 'Extra Bold', 'UltraBold', 'Ultra Bold', 'Fett'];
     case '900':
       return ['Black', 'Heavy', 'Super', 'Extrafett'];
+    case '950':
+      return ['ExtraBlack', 'Extra Black', 'UltraBlack', 'Ultra Black'];
     default:
       return [value];
   }

--- a/packages/tokens-studio-for-figma/src/plugin/listAvailableFonts.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/listAvailableFonts.test.ts
@@ -1,0 +1,39 @@
+import { listAvailableFonts, resetListAvailableFontsCache } from './listAvailableFonts';
+
+describe('listAvailableFonts', () => {
+  const fonts = [{ fontName: { family: 'Inter', style: 'Regular' } }];
+
+  beforeEach(() => {
+    resetListAvailableFontsCache();
+    (figma.listAvailableFontsAsync as jest.Mock).mockReset();
+  });
+
+  it('invokes listAvailableFontsAsync once for parallel calls', async () => {
+    (figma.listAvailableFontsAsync as jest.Mock).mockResolvedValue(fonts);
+
+    const [first, second] = await Promise.all([listAvailableFonts(), listAvailableFonts()]);
+
+    expect(first).toEqual(fonts);
+    expect(second).toEqual(fonts);
+    expect(figma.listAvailableFontsAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the resolved list for a sequential second call', async () => {
+    (figma.listAvailableFontsAsync as jest.Mock).mockResolvedValue(fonts);
+
+    await listAvailableFonts();
+    await listAvailableFonts();
+
+    expect(figma.listAvailableFontsAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a rejection', async () => {
+    (figma.listAvailableFontsAsync as jest.Mock)
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockResolvedValueOnce(fonts);
+
+    await expect(listAvailableFonts()).rejects.toThrow('unavailable');
+    await expect(listAvailableFonts()).resolves.toEqual(fonts);
+    expect(figma.listAvailableFontsAsync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/listAvailableFonts.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/listAvailableFonts.ts
@@ -1,0 +1,16 @@
+let fontsPromise: Promise<Font[]> | null = null;
+
+export function listAvailableFonts(): Promise<Font[]> {
+  if (!fontsPromise) {
+    fontsPromise = figma.listAvailableFontsAsync().then((fonts) => fonts || []).catch((error) => {
+      // Do not cache a rejected promise. The next call retries.
+      fontsPromise = null;
+      throw error;
+    });
+  }
+  return fontsPromise;
+}
+
+export function resetListAvailableFontsCache(): void {
+  fontsPromise = null;
+}

--- a/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.test.ts
@@ -1,0 +1,76 @@
+import { mockLoadFontAsync, mockNotify } from '../../tests/__mocks__/figmaMock';
+import { setFontStyleOnTarget } from './setFontStyleOnTarget';
+
+function mockAvailableFonts(family: string, styles: string[]) {
+  (figma.listAvailableFontsAsync as jest.Mock).mockResolvedValue(
+    styles.map((style) => ({ fontName: { family, style } })),
+  );
+  mockLoadFontAsync.mockImplementation(async (fontName: FontName) => {
+    const exists = fontName.family === family && styles.includes(fontName.style);
+    if (!exists) {
+      throw new Error('Font not available');
+    }
+  });
+}
+
+describe('setFontStyleOnTarget', () => {
+  let target: { fontName: FontName };
+
+  beforeEach(() => {
+    target = {
+      fontName: { family: 'Inter', style: 'Regular' },
+    };
+  });
+
+  it('applies Gotham SSm Book for numeric 400', async () => {
+    mockAvailableFonts('Gotham SSm', ['Book', 'Medium', 'Bold']);
+
+    await setFontStyleOnTarget({
+      target: target as unknown as TextNode,
+      value: { fontFamily: 'Gotham SSm', fontWeight: '400' },
+      baseFontSize: '16',
+    });
+
+    expect(target.fontName).toEqual({ family: 'Gotham SSm', style: 'Book' });
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('applies Inter Regular for numeric 400', async () => {
+    mockAvailableFonts('Inter', ['Regular', 'Medium', 'Bold']);
+
+    await setFontStyleOnTarget({
+      target: target as unknown as TextNode,
+      value: { fontFamily: 'Inter', fontWeight: '400' },
+      baseFontSize: '16',
+    });
+
+    expect(target.fontName).toEqual({ family: 'Inter', style: 'Regular' });
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('applies Book when the token weight is already Book', async () => {
+    mockAvailableFonts('Gotham SSm', ['Book', 'Medium', 'Bold']);
+
+    await setFontStyleOnTarget({
+      target: target as unknown as TextNode,
+      value: { fontFamily: 'Gotham SSm', fontWeight: 'Book' },
+      baseFontSize: '16',
+    });
+
+    expect(target.fontName).toEqual({ family: 'Gotham SSm', style: 'Book' });
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('toasts when no family/weight combination can be loaded', async () => {
+    mockAvailableFonts('Gotham SSm', ['Medium']);
+
+    await setFontStyleOnTarget({
+      target: target as unknown as TextNode,
+      value: { fontFamily: 'Gotham SSm', fontWeight: '400' },
+      baseFontSize: '16',
+    });
+
+    expect(target.fontName).toEqual({ family: 'Inter', style: 'Regular' });
+    expect(mockNotify).toHaveBeenCalledWith('Error setting font family/weight combination for Gotham SSm/400', undefined);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.test.ts
@@ -1,5 +1,6 @@
 import { mockLoadFontAsync, mockNotify } from '../../tests/__mocks__/figmaMock';
 import { setFontStyleOnTarget } from './setFontStyleOnTarget';
+import { resetListAvailableFontsCache } from './listAvailableFonts';
 
 function mockAvailableFonts(family: string, styles: string[]) {
   (figma.listAvailableFontsAsync as jest.Mock).mockResolvedValue(
@@ -17,6 +18,7 @@ describe('setFontStyleOnTarget', () => {
   let target: { fontName: FontName };
 
   beforeEach(() => {
+    resetListAvailableFontsCache();
     target = {
       fontName: { family: 'Inter', style: 'Regular' },
     };

--- a/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.ts
@@ -1,8 +1,8 @@
-import { transformValue } from './helpers';
 import { notifyUI } from './notifiers';
 import { ResolvedTypographyObject } from './ResolvedTypographyObject';
+import { fontWeightStyleCandidates } from './figmaTransforms/fontWeight';
 
-export async function setFontStyleOnTarget({ target, value, baseFontSize }: { target: BaseNode | TextStyle; value: Pick<ResolvedTypographyObject, 'fontFamily' | 'fontWeight'>; baseFontSize: string }) {
+export async function setFontStyleOnTarget({ target, value }: { target: BaseNode | TextStyle; value: Pick<ResolvedTypographyObject, 'fontFamily' | 'fontWeight'>; baseFontSize: string }) {
   if (!('fontName' in target)) return;
   const {
     fontFamily, fontWeight,
@@ -19,52 +19,51 @@ export async function setFontStyleOnTarget({ target, value, baseFontSize }: { ta
         style,
       };
     }
-  } catch (e) {
-    const splitFontFamily = family.split(',');
-    const candidateStyles = transformValue(style, 'fontWeights', baseFontSize);
-    const candidateFonts: { family: string; style: string; }[] = [];
-    splitFontFamily?.forEach((candidateFontFamily) => {
-      const normalizedFontFamily = candidateFontFamily?.replace(/['"]/g, '').trim();
-      if (candidateStyles.length > 0) {
-        candidateStyles.forEach((candidateStyle) => {
-          candidateFonts.push({
-            family: normalizedFontFamily,
-            style: candidateStyle,
-          });
-        });
-      } else {
-        candidateFonts.push({
-          family: normalizedFontFamily,
-          style,
-        });
-      }
+  } catch {
+    const families = family.split(',')
+      .map((candidateFontFamily) => candidateFontFamily.replace(/['"]/g, '').trim())
+      .filter(Boolean);
+    const weightCandidates = fontWeightStyleCandidates(style);
+    const available = await figma.listAvailableFontsAsync() || [];
+
+    const fontsToTry: { family: string; style: string; }[] = [];
+    families.forEach((candidateFamily) => {
+      const familyStyles = available
+        .filter((font) => font.fontName.family === candidateFamily)
+        .map((font) => font.fontName.style);
+      // Keep Figma's canonical style string; match aliases case-insensitively.
+      weightCandidates.forEach((candidate) => {
+        const match = familyStyles.find((familyStyle) => familyStyle.toLowerCase() === candidate.toLowerCase());
+        if (match) {
+          fontsToTry.push({ family: candidateFamily, style: match });
+        }
+      });
     });
 
-    let hasErrored = false;
-
-    for (let i = 0; i < candidateFonts.length; i += 1) {
-      let isApplied = false; // if font is applied then skip other font families
-      await figma
-        .loadFontAsync({ family: candidateFonts[i].family, style: candidateFonts[i].style })
-        .then(() => {
-          if (candidateFonts[i]) {
-            target.fontName = {
-              family: candidateFonts[i].family,
-              style: candidateFonts[i].style,
-            };
-            isApplied = true;
-          }
-        })
-        // eslint-disable-next-line @typescript-eslint/no-loop-func
-        .catch(() => {
-          hasErrored = true;
+    // Installed styles first; candidate loads cover a stale font list.
+    if (fontsToTry.length === 0) {
+      families.forEach((candidateFamily) => {
+        weightCandidates.forEach((candidateStyle) => {
+          fontsToTry.push({ family: candidateFamily, style: candidateStyle });
         });
-      if (isApplied) {
-        hasErrored = false;
+      });
+    }
+
+    let applied = false;
+    for (let i = 0; i < fontsToTry.length; i += 1) {
+      try {
+        await figma.loadFontAsync({ family: fontsToTry[i].family, style: fontsToTry[i].style });
+        target.fontName = {
+          family: fontsToTry[i].family,
+          style: fontsToTry[i].style,
+        };
+        applied = true;
         break;
+      } catch {
+        // Try the next family/style pair.
       }
     }
-    if (hasErrored) {
+    if (!applied) {
       notifyUI(`Error setting font family/weight combination for ${family}/${style}`);
     }
   }

--- a/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setFontStyleOnTarget.ts
@@ -1,6 +1,7 @@
 import { notifyUI } from './notifiers';
 import { ResolvedTypographyObject } from './ResolvedTypographyObject';
 import { fontWeightStyleCandidates } from './figmaTransforms/fontWeight';
+import { listAvailableFonts } from './listAvailableFonts';
 
 export async function setFontStyleOnTarget({ target, value }: { target: BaseNode | TextStyle; value: Pick<ResolvedTypographyObject, 'fontFamily' | 'fontWeight'>; baseFontSize: string }) {
   if (!('fontName' in target)) return;
@@ -24,7 +25,7 @@ export async function setFontStyleOnTarget({ target, value }: { target: BaseNode
       .map((candidateFontFamily) => candidateFontFamily.replace(/['"]/g, '').trim())
       .filter(Boolean);
     const weightCandidates = fontWeightStyleCandidates(style);
-    const available = await figma.listAvailableFontsAsync() || [];
+    const available = await listAvailableFonts();
 
     const fontsToTry: { family: string; style: string; }[] = [];
     families.forEach((candidateFamily) => {

--- a/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
@@ -6,6 +6,7 @@ import { transformTypographyKeyToFigmaVariable } from './transformTypographyKeyT
 import { normalizeTypographyPropertyValue } from './normalizeTypographyPropertyValue';
 import { SingleTypographyToken } from '@/types/tokens';
 import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
+import { listAvailableFonts } from './listAvailableFonts';
 
 // Cache to track font loading promises to prevent race conditions in Promise.all
 const fontLoadingPromises = new Map<string, Promise<void>>();
@@ -49,7 +50,7 @@ export async function tryApplyTypographyCompositeVariable({
             if (!loadingPromise) {
               // Create and cache the loading promise
               loadingPromise = (async () => {
-                const fontsMatching = (await figma.listAvailableFontsAsync() || []).filter((font) => font.fontName.family === firstVariableValue);
+                const fontsMatching = (await listAvailableFonts()).filter((font) => font.fontName.family === firstVariableValue);
                 for (const font of fontsMatching) {
                   await figma.loadFontAsync(font.fontName);
                 }


### PR DESCRIPTION
## Summary

Numeric font-weight `400` was applied as `Regular`/`Normal` only. Families like Gotham SSm have **Book** instead, so apply failed with `Error setting font family/weight combination for GothamSSm/400`.

- Invert the sd-transforms weight map (plus Roman/Buch) into Figma style candidates.
- On apply, `listAvailableFontsAsync()` ∩ those candidates (case-insensitive, keep Figma’s canonical style string).
- Fallback: try candidates via `loadFontAsync` if the font list has no hit.

Companion Platform PR: https://github.com/The-Phoenix-Will-Fly/studio-on-rails/pull/4867

## Test plan

- [x] `jest src/plugin/figmaTransforms/fontWeight.test.ts src/plugin/setFontStyleOnTarget.test.ts`
- [ ] Apply typography with Gotham SSm + weight 400 → Book, no toast
- [ ] Apply Inter + 400 → Regular
- [ ] Weight token `Book` still applies