### PR TITLE
fix: normalize missing metadata on retrieve so conversion pushes rout…

### DIFF
--- a/.changeset/fifty-dancers-help.md
+++ b/.changeset/fifty-dancers-help.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix legacy↔DTCG token format conversion on GitHub silently committing only $metadata.json without rewriting any token files.

--- a/packages/tokens-studio-for-figma/src/storage/RemoteTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/RemoteTokenStorage.ts
@@ -144,6 +144,16 @@ export abstract class RemoteTokenStorage<
           };
         }
       });
+      // Normalize metadata so the diff hook's baseState always has the same shape as
+      // what useChangedState.buildMetadata produces. Repos without a $metadata.json
+      // (fresh syncs, older repos predating the file) would otherwise leave metadata
+      // undefined — isEqual(undefined, {tokenSetOrder}) is false, tripping a permanent
+      // phantom diff that routes conversion pushes through saveOptimized with zero token
+      // diffs and commits only $metadata.json (see PR #3941 for the corresponding
+      // buildMetadata normalization).
+      if (!data.metadata) {
+        data.metadata = { tokenSetOrder: Object.keys(data.tokens) } as RemoteTokenStorageMetadata & Metadata;
+      }
       return {
         status: 'success',
         ...data,

--- a/packages/tokens-studio-for-figma/src/storage/RemoteTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/RemoteTokenStorage.ts
@@ -150,9 +150,14 @@ export abstract class RemoteTokenStorage<
       // undefined — isEqual(undefined, {tokenSetOrder}) is false, tripping a permanent
       // phantom diff that routes conversion pushes through saveOptimized with zero token
       // diffs and commits only $metadata.json (see PR #3941 for the corresponding
-      // buildMetadata normalization).
+      // buildMetadata normalization). Derive tokenSetOrder directly from the retrieved
+      // token-set files so the order matches the read()-side authoritative ordering,
+      // independent of how data.tokens happened to be constructed above.
       if (!data.metadata) {
-        data.metadata = { tokenSetOrder: Object.keys(data.tokens) } as RemoteTokenStorageMetadata & Metadata;
+        const tokenSetOrder = files
+          .filter((file): file is RemoteTokenStorageSingleTokenSetFile => file.type === 'tokenSet')
+          .map((file) => file.name);
+        data.metadata = { tokenSetOrder } as RemoteTokenStorageMetadata & Metadata;
       }
       return {
         status: 'success',

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/RemoteTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/RemoteTokenStorage.test.ts
@@ -1,0 +1,113 @@
+import { RemoteTokenStorage, RemoteTokenStorageFile, RemoteTokenstorageErrorMessage } from '../RemoteTokenStorage';
+import { TokenTypes } from '@/constants/TokenTypes';
+
+class StubRemoteTokenStorage extends RemoteTokenStorage {
+  private files: RemoteTokenStorageFile[] | RemoteTokenstorageErrorMessage;
+
+  constructor(files: RemoteTokenStorageFile[] | RemoteTokenstorageErrorMessage) {
+    super();
+    this.files = files;
+  }
+
+  public async read() {
+    return this.files;
+  }
+
+  public async write() {
+    return true;
+  }
+}
+
+describe('RemoteTokenStorage.retrieve', () => {
+  // Regression: pre-#3941 the phantom `tokenSetsData` diff in useChangedState.buildMetadata
+  // was tripping the optimized-sync gate on every push and dropping token files. #3941
+  // normalized buildMetadata to `{tokenSetOrder}` for git providers, but retrieve() left
+  // `data.metadata` undefined when no `$metadata.json` was present on remote. On the next
+  // push, `isEqual(undefined, {tokenSetOrder})` is false → phantom fires again → conversion
+  // commits only `$metadata.json`. Normalize `data.metadata` on retrieve so the diff's
+  // baseState always has the same shape as buildMetadata's compareState.
+  it('normalizes missing metadata to {tokenSetOrder} matching the retrieved tokens', async () => {
+    const storage = new StubRemoteTokenStorage([
+      {
+        type: 'tokenSet',
+        name: 'global',
+        path: 'global.json',
+        data: {
+          primary: { name: 'primary', type: TokenTypes.COLOR, value: '#000' },
+        },
+      },
+      {
+        type: 'tokenSet',
+        name: 'semantic',
+        path: 'semantic.json',
+        data: {
+          background: { name: 'background', type: TokenTypes.COLOR, value: '#fff' },
+        },
+      },
+      {
+        type: 'themes',
+        path: '$themes.json',
+        data: [],
+      },
+      // no metadata file
+    ]);
+
+    const result = await storage.retrieve();
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe('success');
+    if (result?.status === 'success') {
+      expect(result.metadata).toEqual({ tokenSetOrder: ['global', 'semantic'] });
+    }
+  });
+
+  it('preserves the file contents when a $metadata.json is present', async () => {
+    const storage = new StubRemoteTokenStorage([
+      {
+        type: 'tokenSet',
+        name: 'global',
+        path: 'global.json',
+        data: {
+          primary: { name: 'primary', type: TokenTypes.COLOR, value: '#000' },
+        },
+      },
+      {
+        type: 'metadata',
+        path: '$metadata.json',
+        data: { tokenSetOrder: ['global'] },
+      },
+    ]);
+
+    const result = await storage.retrieve();
+
+    if (result?.status === 'success') {
+      expect(result.metadata).toEqual({ tokenSetOrder: ['global'] });
+    }
+  });
+
+  it('preserves an empty metadata object rather than overwriting it', async () => {
+    // Guards against the normalization mistakenly firing on `{}` — an author who wrote
+    // an empty $metadata.json should get {} back, not tokenSetOrder derived from tokens.
+    const storage = new StubRemoteTokenStorage([
+      {
+        type: 'tokenSet',
+        name: 'global',
+        path: 'global.json',
+        data: {
+          primary: { name: 'primary', type: TokenTypes.COLOR, value: '#000' },
+        },
+      },
+      {
+        type: 'metadata',
+        path: '$metadata.json',
+        data: {},
+      },
+    ]);
+
+    const result = await storage.retrieve();
+
+    if (result?.status === 'success') {
+      expect(result.metadata).toEqual({});
+    }
+  });
+});

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/RemoteTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/RemoteTokenStorage.test.ts
@@ -56,9 +56,8 @@ describe('RemoteTokenStorage.retrieve', () => {
 
     expect(result).not.toBeNull();
     expect(result?.status).toBe('success');
-    if (result?.status === 'success') {
-      expect(result.metadata).toEqual({ tokenSetOrder: ['global', 'semantic'] });
-    }
+    if (result?.status !== 'success') throw new Error('retrieve failed');
+    expect(result.metadata).toEqual({ tokenSetOrder: ['global', 'semantic'] });
   });
 
   it('preserves the file contents when a $metadata.json is present', async () => {
@@ -80,9 +79,9 @@ describe('RemoteTokenStorage.retrieve', () => {
 
     const result = await storage.retrieve();
 
-    if (result?.status === 'success') {
-      expect(result.metadata).toEqual({ tokenSetOrder: ['global'] });
-    }
+    expect(result?.status).toBe('success');
+    if (result?.status !== 'success') throw new Error('retrieve failed');
+    expect(result.metadata).toEqual({ tokenSetOrder: ['global'] });
   });
 
   it('preserves an empty metadata object rather than overwriting it', async () => {
@@ -106,8 +105,8 @@ describe('RemoteTokenStorage.retrieve', () => {
 
     const result = await storage.retrieve();
 
-    if (result?.status === 'success') {
-      expect(result.metadata).toEqual({});
-    }
+    expect(result?.status).toBe('success');
+    if (result?.status !== 'success') throw new Error('retrieve failed');
+    expect(result.metadata).toEqual({});
   });
 });


### PR DESCRIPTION
…e correctly

PR #3941 normalized useChangedState.buildMetadata to {tokenSetOrder} for git providers, fixing the phantom tokenSetsData diff that was routing every conversion push through saveOptimized with zero token diffs. But the fix only covered one side of the diff: RemoteTokenStorage.retrieve() still returned data.metadata as undefined when the remote had no $metadata.json (fresh syncs, older repos, hand- created repos). isEqual(undefined, {tokenSetOrder}) is false, so the phantom fired again on those repos and conversion commits still contained only $metadata.json.

Normalize metadata to {tokenSetOrder: Object.keys(data.tokens)} on retrieve when no $metadata.json is present, matching the shape buildMetadata produces. Both sides of the diff now agree by construction — no new signal, no plumbing, and the !!changedPushState.metadata gate in github.tsx keeps its original efficiency for legitimate metadata-only pushes (token-set reorders). An empty {} from an author-provided file is preserved as-is.

All PR #3941 guarantees remain: blue-dot fix (compareLastSyncedState + removeIdPropertyFromTokens), no phantom tokenSetsData in buildMetadata, empty-set NEW/REMOVE routing via tokenSetChanges, and empty-set pull preservation in GithubTokenStorage.read.

<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

When a user converts their tokens from legacy to W3C DTCG format (or back) with a GitHub sync configured, the resulting commit only contains the `$metadata.json` change — every token file is silently omitted, so the on-disk representation stays in the old format and the "conversion" never actually reaches the repo.

**How the last release introduced this.** The bug is a residual of [PR #3941](https://github.com/tokens-studio/figma-plugin/pull/3941) ("prevent stuck blue dot and empty commits on git sync"). That PR fixed a permanent phantom metadata diff by normalizing `useChangedState.buildMetadata` for git providers from `{tokenSetOrder, tokenSetsData}` down to `{tokenSetOrder}` — but only touched one side of the comparison. The other side, `remoteData.metadata`, is populated from `RemoteTokenStorage.retrieve()`, which still leaves it `undefined` when the remote has no `$metadata.json` file (fresh syncs, hand-created repos, older repos that predate the file). `isEqual(undefined, {tokenSetOrder})` is `false`, so the phantom fires again on those repos, `hasChanges` becomes truthy via `!!changedPushState.metadata`, and the conversion push is routed through `saveOptimized` with zero token diffs — dropping every token-set file from the commit.

The deeper root cause is that DTCG conversion is a *serialization-time* concern: it changes which key names (`value` vs `$value`, etc.) `convertTokensToObject` writes, but does not mutate any in-memory `SingleToken`. So `findDifferentState` (which diffs in-memory tokens) reports no token diffs, and the optimizer has no reason to include any token file in the changeset — unless the phantom metadata diff routes it there anyway.

### What does this pull request do?

**One production change** in [`RemoteTokenStorage.retrieve()`](packages/tokens-studio-for-figma/src/storage/RemoteTokenStorage.ts): when no `$metadata.json` is present on remote, normalize the returned metadata to `{tokenSetOrder: Object.keys(data.tokens)}` — matching the shape `useChangedState.buildMetadata` already produces. Both sides of the diff now agree by construction, so the phantom cannot fire; a pure format flip resolves to `hasChanges=false` and correctly falls through to `storage.save` (full write), which serializes every token file in the new format.

**Why this shape, not something bigger:**
- No new `tokenFormatChanged` signal is introduced anywhere. No `PushOverrides` field. No new hook return value. No push-time imperative check. `changedPushState` remains the sole trigger for the routing decision.
- The `!!changedPushState.metadata` gate in `github.tsx` — original design from the optimizer PR (#3424) — is left intact, so legitimate metadata-only pushes (e.g. a pure token-set reorder) still get the single-file efficient commit they were designed for.
- The fix is complementary to #3941: #3941 fixed the local side of the diff; this fixes the remote side by mirroring the same shape.
- An author-provided empty `{}` metadata file is preserved as-is (guarded on `!data.metadata`, so `{}` is truthy and skips normalization).

**All #3941 guarantees remain intact** (verified):
- Blue-dot fix (`compareLastSyncedState` + `removeIdPropertyFromTokens`) — untouched.
- No phantom `tokenSetsData` diff — `buildMetadata` still returns `{tokenSetOrder}` for git providers.
- Empty-set NEW/REMOVE routing via `tokenSetChanges` — untouched.
- Empty-set pull preservation in `GithubTokenStorage.read` — untouched.

### Testing this change

**Manual repro:**
1. Set up a GitHub multi-file sync (Pro) to a repo that has NO `$metadata.json` on remote (fresh repo, or delete the file manually on GitHub).
2. Open Settings → Token format → Convert to W3C DTCG.
3. Confirm the push. Inspect the resulting commit on the `w3c-dtcg-conversion` branch: every token-set file should be rewritten with `$value` / `$type` / `$description` keys (previously only `$metadata.json` was committed and token files stayed in the old format).
4. Repeat the reverse (DTCG → Legacy) — token files should be rewritten with `value` / `type` / `description` keys.
5. Repeat on a repo that already has `$metadata.json` — behavior unchanged (works both before and after).

**Regression checks for PR #3941 (all still hold):**
- Push any change, wait for success → blue dot clears. Push again with no edits → no new commit, no blue dot.
- Create an empty token set, push, reload the plugin → the empty set survives.
- Make an unrelated single-token edit and push → the commit still contains only the changed set file (optimizer efficiency preserved for real content edits).

**Automated:**
- `yarn jest src/storage/__tests__/RemoteTokenStorage.test.ts` — three new cases: `metadata` is normalized to `{tokenSetOrder}` when the file is absent; preserved as-is when the file is present; preserved as `{}` when the file exists but is empty.
- Full storage suite (`yarn jest src/storage/__tests__/`) — 110 tests pass, including every existing multi-file, empty-set, and `$metadata` case from PR #3941.
- Adjacent suites (`useChangedState`, `remoteTokens`, `findDifferentState`, `GitSyncOptimizer`, `GithubTokenStorage`) — all pass.

### Additional Notes (if any)

- The fix touches the *base class* `RemoteTokenStorage`, so it affects every provider that inherits from it (GitHub, GitLab, Bitbucket, ADO, JSONBin, URL, generic-versioned, file). The blast radius is intentional — the same "missing metadata triggers a phantom diff" trap applies to any git provider whose remote lacks `$metadata.json`. Tokens Studio OAuth uses a different retrieve path and is not affected. Every downstream consumer of `remoteData.metadata` that I traced uses optional chaining (`?.tokenSetOrder`, `?.tokenSetsData`, `?.changeSetId`) with a safe fallback, so nothing else changes shape-wise for consumers.
- Contract change worth noting for future contributors: `retrieve()` now always returns non-null `metadata` on success. A future caller that specifically checks `if (data.metadata === undefined)` to detect "no metadata file exists" would see the truthy branch instead — the comment at the normalization site documents this so the invariant is discoverable.
- One narrow edge case not fully covered: if the user restarts the plugin and pushes *before* any pull happens in the session, `remoteData.metadata` is still `null` (Redux initial state, before `retrieve` runs). In practice this window is tiny (any pull normalizes it) and other diff signals (token-content NEW entries from the empty `remoteData.tokens`) usually make the conversion push write everything correctly anyway. A follow-up initializing `tokenState.remoteData.metadata` to `{tokenSetOrder: []}` would close that gap.
- Structural follow-up worth considering (not in this PR): extract a shared `buildGitMetadata` helper used by both `retrieve()` normalization and `useChangedState.buildMetadata`. Would prevent any future field addition from re-introducing the same class of phantom.