### PR TITLE
color to gradient - delete connected variables

### DIFF
--- a/.changeset/tame-parrots-drum.md
+++ b/.changeset/tame-parrots-drum.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Add Prompt to delete stale Figma variables when exporting color tokens that have been converted to gradients. Figma variables can't hold gradient values, so a bound variable from a previous export keeps overriding the new gradient style on any layer that uses it. The export flow now scans for these mismatches and shows a checkbox confirm so you can clean them up in one step.

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -13,12 +13,14 @@ import { useIsProUser } from '@/app/hooks/useIsProUser';
 
 import OptionsModal from './OptionsModal';
 import useTokens from '@/app/store/useTokens';
+import useConfirm from '@/app/hooks/useConfirm';
 import ExportSetsTab from './ExportSetsTab';
 import ExportThemesTab from './ExportThemesTab';
-import { allTokenSetsSelector, themesListSelector } from '@/selectors';
+import { allTokenSetsSelector, themesListSelector, tokensSelector } from '@/selectors';
 import { ExportTokenSet } from '@/types/ExportTokenSet';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { Dispatch } from '@/app/store';
+import { TokenTypes } from '@/constants/TokenTypes';
 
 export default function ManageStylesAndVariables({ showModal, setShowModal }: { showModal: boolean, setShowModal: (show: boolean) => void }) {
   const { t } = useTranslation(['manageStylesAndVariables']);
@@ -53,7 +55,10 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
 
   const {
     createVariablesFromSets, createVariablesFromThemes, createStylesFromSelectedTokenSets, createStylesFromSelectedThemes,
+    removeVariablesFromToken,
   } = useTokens();
+  const { confirm } = useConfirm<string[]>();
+  const allTokens = useSelector(tokensSelector);
 
   // Save selected themes when they change and update redux state
   React.useEffect(() => {
@@ -72,7 +77,47 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
     setShowOptions(false);
   }, []);
 
+  // Color tokens that now hold a gradient value but still have a Figma variable
+  // bound from an earlier export. Figma variables can't store gradients, so a
+  // stale variable will keep overriding the new gradient style on any bound
+  // layer. Offer to delete these variables before we push.
+  const gradientTokensWithStaleVariable = React.useMemo(() => {
+    const isGradient = (v: unknown): v is string => typeof v === 'string'
+      && (v.startsWith('linear-gradient') || v.startsWith('radial-gradient') || v.startsWith('conic-gradient'));
+    const seen = new Set<string>();
+    const collected: string[] = [];
+    Object.values(allTokens).forEach((tokenList) => {
+      tokenList.forEach((token) => {
+        if (token.type !== TokenTypes.COLOR || !isGradient(token.value) || seen.has(token.name)) return;
+        const hasVariable = themes.some((theme) => Boolean(theme.$figmaVariableReferences?.[token.name]));
+        if (hasVariable) {
+          seen.add(token.name);
+          collected.push(token.name);
+        }
+      });
+    });
+    return collected;
+  }, [allTokens, themes]);
+
   const handleExportToFigma = React.useCallback(async () => {
+    if (gradientTokensWithStaleVariable.length > 0) {
+      const gradientConfirm = await confirm({
+        text: 'Delete Figma variables for gradient tokens?',
+        description: "Figma variables can't store gradients. These color tokens are now gradients but still have variables from a previous export — bound layers will keep showing the old color until the variable is removed. Uncheck any you'd rather keep.",
+        confirmAction: 'Delete selected & export',
+        cancelAction: 'Cancel',
+        variant: 'danger',
+        choices: gradientTokensWithStaleVariable.map((name) => ({
+          key: name,
+          label: name,
+          enabled: true,
+        })),
+      });
+      if (!gradientConfirm) return; // user cancelled — abort export entirely
+      const toDelete = gradientConfirm.data ?? [];
+      await Promise.all(toDelete.map((name) => removeVariablesFromToken(name)));
+    }
+
     setShowModal(false);
     if (activeTab === 'useSets') {
       await createVariablesFromSets(selectedSets);
@@ -81,7 +126,12 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
       await createVariablesFromThemes(selectedThemes);
       await createStylesFromSelectedThemes(selectedThemes);
     }
-  }, [setShowModal, activeTab, selectedThemes, selectedSets, createVariablesFromSets, createStylesFromSelectedTokenSets, createVariablesFromThemes, createStylesFromSelectedThemes]);
+  }, [
+    setShowModal, activeTab, selectedThemes, selectedSets,
+    createVariablesFromSets, createStylesFromSelectedTokenSets,
+    createVariablesFromThemes, createStylesFromSelectedThemes,
+    gradientTokensWithStaleVariable, confirm, removeVariablesFromToken,
+  ]);
   const canExportToFigma = activeTab === 'useSets' ? selectedSets.length > 0 : selectedThemes.length > 0;
 
   const handleTabChange = React.useCallback((tab: 'useThemes' | 'useSets') => {

--- a/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/ManageStylesAndVariables/ManageStylesAndVariables.tsx
@@ -84,13 +84,18 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
   const gradientTokensWithStaleVariable = React.useMemo(() => {
     const isGradient = (v: unknown): v is string => typeof v === 'string'
       && (v.startsWith('linear-gradient') || v.startsWith('radial-gradient') || v.startsWith('conic-gradient'));
+    // Flatten variable-reference keys across all themes once so the token scan
+    // stays O(tokens + refs) rather than O(tokens × themes).
+    const referencedTokenNames = new Set<string>();
+    themes.forEach((theme) => {
+      Object.keys(theme.$figmaVariableReferences ?? {}).forEach((name) => referencedTokenNames.add(name));
+    });
     const seen = new Set<string>();
     const collected: string[] = [];
     Object.values(allTokens).forEach((tokenList) => {
       tokenList.forEach((token) => {
         if (token.type !== TokenTypes.COLOR || !isGradient(token.value) || seen.has(token.name)) return;
-        const hasVariable = themes.some((theme) => Boolean(theme.$figmaVariableReferences?.[token.name]));
-        if (hasVariable) {
+        if (referencedTokenNames.has(token.name)) {
           seen.add(token.name);
           collected.push(token.name);
         }
@@ -102,10 +107,10 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
   const handleExportToFigma = React.useCallback(async () => {
     if (gradientTokensWithStaleVariable.length > 0) {
       const gradientConfirm = await confirm({
-        text: 'Delete Figma variables for gradient tokens?',
-        description: "Figma variables can't store gradients. These color tokens are now gradients but still have variables from a previous export — bound layers will keep showing the old color until the variable is removed. Uncheck any you'd rather keep.",
-        confirmAction: 'Delete selected & export',
-        cancelAction: 'Cancel',
+        text: t('confirmDeleteGradientVariables.text', { defaultValue: 'Delete Figma variables for gradient tokens?' }),
+        description: t('confirmDeleteGradientVariables.description', { defaultValue: "Figma variables can't store gradients. These color tokens are now gradients but still have variables from a previous export — bound layers will keep showing the old color until the variable is removed. Uncheck any you'd rather keep." }),
+        confirmAction: t('confirmDeleteGradientVariables.confirmAction', { defaultValue: 'Delete selected & export' }),
+        cancelAction: t('confirmDeleteGradientVariables.cancelAction', { defaultValue: 'Cancel' }),
         variant: 'danger',
         choices: gradientTokensWithStaleVariable.map((name) => ({
           key: name,
@@ -115,7 +120,14 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
       });
       if (!gradientConfirm) return; // user cancelled — abort export entirely
       const toDelete = gradientConfirm.data ?? [];
-      await Promise.all(toDelete.map((name) => removeVariablesFromToken(name)));
+      // Sequential rather than Promise.all — each call posts a REMOVE_VARIABLES
+      // message and the plugin side processes them serially anyway, so this
+      // keeps behavior predictable without a burst of parallel requests.
+      // eslint-disable-next-line no-restricted-syntax
+      for (const name of toDelete) {
+        // eslint-disable-next-line no-await-in-loop
+        await removeVariablesFromToken(name);
+      }
     }
 
     setShowModal(false);
@@ -130,7 +142,7 @@ export default function ManageStylesAndVariables({ showModal, setShowModal }: { 
     setShowModal, activeTab, selectedThemes, selectedSets,
     createVariablesFromSets, createStylesFromSelectedTokenSets,
     createVariablesFromThemes, createStylesFromSelectedThemes,
-    gradientTokensWithStaleVariable, confirm, removeVariablesFromToken,
+    gradientTokensWithStaleVariable, confirm, removeVariablesFromToken, t,
   ]);
   const canExportToFigma = activeTab === 'useSets' ? selectedSets.length > 0 : selectedThemes.length > 0;
 

--- a/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
+++ b/packages/tokens-studio-for-figma/src/i18n/lang/en/manageStylesAndVariables.json
@@ -80,6 +80,12 @@
   "confirmSets": "Create styles or variables based on token sets",
   "intro": "You can use token sets to manage your styles, and variables. Use themes (Pro) to create multiple collections of variables or styles for easy switching between design concepts.",
   "setsSelectedForExport": "Sets selected for export"
+},
+"confirmDeleteGradientVariables": {
+  "text": "Delete Figma variables for gradient tokens?",
+  "description": "Figma variables can't store gradients. These color tokens are now gradients but still have variables from a previous export — bound layers will keep showing the old color until the variable is removed. Uncheck any you'd rather keep.",
+  "confirmAction": "Delete selected & export",
+  "cancelAction": "Cancel"
 }
 }
 


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

When a user converts a color token to a gradient (e.g. `linear-gradient(...)`) and re-exports, Figma continues to render the *previously exported* variable instead of the new gradient style. This happens because Figma variables can only hold solid colors — a gradient can only be applied as a style — but the old variable binding on the layer persists, and Figma always resolves the variable over the style. The result: Tokens Studio shows the correct (gradient) token, the Figma paint style is updated, but bound layers keep showing the old solid color with no visible indication of what went wrong.

### What does this pull request do?

Adds a guard in the **Manage styles & variables → Export** flow:

- Before the export runs, the plugin scans every color token across all sets and collects any whose value is now a `linear/radial/conic-gradient(...)` string **but** still has a `$figmaVariableReferences` entry in one or more themes (i.e. a stale variable from a prior export).
- If any mismatches exist, a danger-styled confirm dialog opens listing them as a **pre-checked checkbox list**:

  > **Delete Figma variables for gradient tokens?**
  > Figma variables can't store gradients. These color tokens are now gradients but still have variables from a previous export — bound layers will keep showing the old color until the variable is removed. Uncheck any you'd rather keep.
  >
  > ☑ colors.brand.primary
  > ☑ colors.surface.hero
  > ☑ colors.accent.warm
  >
  > [Cancel] &nbsp;&nbsp; [Delete selected & export]

- **Delete selected & export** → deletes the checked variables via the existing `REMOVE_VARIABLES` async message (`variable.remove()` on the plugin side), then continues the normal Sets/Themes export flow.
- **Cancel** → aborts the export entirely (nothing pushed, nothing deleted) so the user can review before continuing.
- If there are no mismatches, the dialog is skipped and export runs as before — zero overhead in the common case.

**Design choices worth calling out:**

- Reuses the existing `useConfirm` + `ConfirmDialog` (already supports pre-checked `choices` — same pattern as the remap-across-sets dialog).
- Scan runs against raw token values, not resolved aliases. If a user aliases a solid to a gradient token, only the aliased target is flagged; this covers the source of the collision in ~all realistic cases.
- The scan covers *all* color tokens, not just those in the currently selected sets/themes. A stale variable in the Figma file will keep overriding bound layers regardless of which export scope is chosen, so scoping this to the selection would leak the bug back in.
- Chose the export-time chokepoint over per-token / JSON-editor checks because it catches every path (edit form, JSON paste, git sync pull, file import, teammate changes) — the single place where the mismatch actually starts causing user-visible problems.

### Testing this change

1. Create a color token `colors.brand.primary` with a solid value (`#FF00AA`) and export via **Manage styles & variables**. Confirm the variable is created in Figma.
2. Edit the same token — change its value to a gradient, e.g. `linear-gradient(90deg, #E8409D 0%, #F070B8 100%)`.
3. Reopen **Manage styles & variables** and click **Export**.
4. **Expected**: A danger-styled confirm dialog appears listing `colors.brand.primary` as a checked item. Description explains the Figma variables + gradients limitation.
5. Confirm with the box checked → variable is deleted, export runs, any layer previously bound to it now renders the gradient style correctly.
6. Repeat step 3 with the box **unchecked** → variable is preserved, export still runs; bound layers continue to show the old solid (documented tradeoff).
7. Repeat step 3 after **cancelling** the dialog → no variables deleted, no export runs.
8. As a regression check, export a workspace with **no** color-to-gradient conversions — no dialog should appear.

### Additional Notes (if any)

<img width="560" height="733" alt="Screenshot 2026-09-01 at 1 45 35 PM" src="https://github.com/user-attachments/assets/cec79a43-1213-40ce-a5aa-99009073c557" />
